### PR TITLE
Add bounded workers for scan concurrency

### DIFF
--- a/cmd/flan-go-scan/main.go
+++ b/cmd/flan-go-scan/main.go
@@ -113,6 +113,7 @@ func main() {
 	checkpoint := scanner.NewCheckpoint(cfg.Checkpoint.File)
 	reportWriter := output.NewReportWriter(cfg.Output.Directory)
 
+	pool := scanner.NewWorkerPool(cfg.Scan.Workers)
 	var wg sync.WaitGroup
 	var mu sync.Mutex
 	var results []scanner.ScanResult
@@ -129,9 +130,11 @@ func main() {
 				if checkpoint.ShouldSkip(ipStr, port) {
 					continue
 				}
+				pool.Acquire()
 				wg.Add(1)
 				go func(ip string, port int) {
 					defer wg.Done()
+					defer pool.Release()
 					limiter.Wait()
 					// Use DetectProtocol with a goroutine and channel
 					resultsChan := make(chan string, 1)

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -2,6 +2,7 @@ scan:
   timeout: 3s
   ports: "1-10000"
   rate_limit: 200
+  workers: 100
 dns:
   ttl: 10m
 output:

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -11,6 +11,7 @@ type Config struct {
 		Timeout   time.Duration `mapstructure:"timeout"`
 		Ports     string        `mapstructure:"ports"`
 		RateLimit int           `mapstructure:"rate_limit"`
+		Workers   int           `mapstructure:"workers"`
 	} `mapstructure:"scan"`
 	DNS struct {
 		TTL time.Duration `mapstructure:"ttl"`

--- a/internal/scanner/pool.go
+++ b/internal/scanner/pool.go
@@ -1,0 +1,20 @@
+package scanner
+
+type WorkerPool struct {
+	sem chan struct{}
+}
+
+func NewWorkerPool(size int) *WorkerPool {
+	if size <= 0 {
+		size = 100
+	}
+	return &WorkerPool{sem: make(chan struct{}, size)}
+}
+
+func (p *WorkerPool) Acquire() {
+	p.sem <- struct{}{}
+}
+
+func (p *WorkerPool) Release() {
+	<-p.sem
+}

--- a/internal/scanner/pool_test.go
+++ b/internal/scanner/pool_test.go
@@ -1,0 +1,44 @@
+package scanner
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+)
+
+func TestWorkerPoolBoundsConcurrency(t *testing.T) {
+	pool := NewWorkerPool(5)
+	var peak int64
+	var current int64
+	var wg sync.WaitGroup
+
+	for i := 0; i < 50; i++ {
+		pool.Acquire()
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			defer pool.Release()
+			val := atomic.AddInt64(&current, 1)
+			for {
+				old := atomic.LoadInt64(&peak)
+				if val <= old || atomic.CompareAndSwapInt64(&peak, old, val) {
+					break
+				}
+			}
+			atomic.AddInt64(&current, -1)
+		}()
+	}
+
+	wg.Wait()
+
+	if peak > 5 {
+		t.Errorf("peak concurrency %d exceeded pool size 5", peak)
+	}
+}
+
+func TestWorkerPoolDefaultSize(t *testing.T) {
+	pool := NewWorkerPool(0)
+	if cap(pool.sem) != 100 {
+		t.Errorf("expected default size 100, got %d", cap(pool.sem))
+	}
+}


### PR DESCRIPTION
Replaced unbounded goroutine spawning with a worker pool.
Added scan.workers config field (default 100) to cap concurrent scan go-routines.