### PR TITLE
Add cidr input parsing and stdin support

### DIFF
--- a/cmd/flan-go-scan/main.go
+++ b/cmd/flan-go-scan/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"bufio"
 	"flag"
 	"fmt"
 	"os"
@@ -34,20 +33,18 @@ func parsePorts(portStr string) []int {
 }
 
 func readHosts(filename string) ([]string, error) {
-	file, err := os.Open(filename)
-	if err != nil {
-		return nil, err
-	}
-	defer file.Close()
-	var hosts []string
-	scanner := bufio.NewScanner(file)
-	for scanner.Scan() {
-		line := strings.TrimSpace(scanner.Text())
-		if line != "" {
-			hosts = append(hosts, line)
+	var r *os.File
+	if filename == "-" {
+		r = os.Stdin
+	} else {
+		f, err := os.Open(filename)
+		if err != nil {
+			return nil, err
 		}
+		defer f.Close()
+		r = f
 	}
-	return hosts, scanner.Err()
+	return scanner.ParseTargets(r)
 }
 
 func main() {

--- a/internal/scanner/targets.go
+++ b/internal/scanner/targets.go
@@ -1,0 +1,81 @@
+package scanner
+
+import (
+	"bufio"
+	"encoding/binary"
+	"fmt"
+	"io"
+	"net"
+	"strings"
+)
+
+func ParseTargets(r io.Reader) ([]string, error) {
+	var targets []string
+	seen := make(map[string]bool)
+	s := bufio.NewScanner(r)
+
+	for s.Scan() {
+		line := strings.TrimSpace(s.Text())
+		if line == "" {
+			continue
+		}
+
+		expanded, err := expandTarget(line)
+		if err != nil {
+			return nil, fmt.Errorf("invalid target %q: %w", line, err)
+		}
+
+		for _, t := range expanded {
+			if !seen[t] {
+				seen[t] = true
+				targets = append(targets, t)
+			}
+		}
+	}
+
+	return targets, s.Err()
+}
+
+func expandTarget(target string) ([]string, error) {
+	if !strings.Contains(target, "/") {
+		return []string{target}, nil
+	}
+
+	ip, ipNet, err := net.ParseCIDR(target)
+	if err != nil {
+		return nil, err
+	}
+
+	ones, bits := ipNet.Mask.Size()
+	if bits == 0 {
+		return nil, fmt.Errorf("unsupported CIDR: %s", target)
+	}
+
+	if ones == bits {
+		return []string{ip.String()}, nil
+	}
+
+	count := 1 << uint(bits-ones)
+	if count > 1<<20 {
+		return nil, fmt.Errorf("CIDR range too large: %s (%d hosts)", target, count)
+	}
+
+	var results []string
+	startIP := ipToUint32(ipNet.IP.To4())
+
+	for i := 0; i < count; i++ {
+		results = append(results, uint32ToIP(startIP+uint32(i)).String())
+	}
+
+	return results, nil
+}
+
+func ipToUint32(ip net.IP) uint32 {
+	return binary.BigEndian.Uint32(ip)
+}
+
+func uint32ToIP(n uint32) net.IP {
+	ip := make(net.IP, 4)
+	binary.BigEndian.PutUint32(ip, n)
+	return ip
+}

--- a/internal/scanner/targets_test.go
+++ b/internal/scanner/targets_test.go
@@ -1,0 +1,73 @@
+package scanner
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParseTargets(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    int
+		wantErr bool
+	}{
+		{
+			name:  "plain IPs",
+			input: "192.168.1.1\n10.0.0.1\n",
+			want:  2,
+		},
+		{
+			name:  "hostname",
+			input: "example.com\n",
+			want:  1,
+		},
+		{
+			name:  "cidr /24",
+			input: "10.0.0.0/24\n",
+			want:  256,
+		},
+		{
+			name:  "cidr /32",
+			input: "10.0.0.5/32\n",
+			want:  1,
+		},
+		{
+			name:  "mixed",
+			input: "192.168.1.1\nexample.com\n10.0.0.0/30\n",
+			want:  6,
+		},
+		{
+			name:  "dedup",
+			input: "10.0.0.1\n10.0.0.1\n",
+			want:  1,
+		},
+		{
+			name:  "empty lines",
+			input: "\n\n192.168.1.1\n\n",
+			want:  1,
+		},
+		{
+			name:    "invalid cidr",
+			input:   "not-a-cidr/24\n",
+			wantErr: true,
+		},
+		{
+			name:    "cidr too large",
+			input:   "10.0.0.0/8\n",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParseTargets(strings.NewReader(tt.input))
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("err = %v, wantErr = %v", err, tt.wantErr)
+			}
+			if !tt.wantErr && len(got) != tt.want {
+				t.Fatalf("got %d targets, want %d", len(got), tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION

- Replace readHosts with ParseTargets supporting CIDR notation expansion, deduplication, and stdin input via -ips -. 
- Fix DNS compile errors for Go 1.24 (LookupIPAddr, LookupCNAME signatures).