### PR TITLE
Add service version extraction from banners

### DIFF
--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -11,7 +11,8 @@ type ScanResult struct {
 	Port            int        `json:"port"`
 	Protocol        string     `json:"protocol"`
 	Service         string     `json:"service"`
-	Banner          string     `json:"banner"`
+	Version         string     `json:"version,omitempty"`
+	Banner          string     `json:"banner,omitempty"`
 	TLS             *TLSResult `json:"tls,omitempty"`
 	Vulnerabilities []string   `json:"vulnerabilities,omitempty"`
 }

--- a/internal/scanner/service_detection.go
+++ b/internal/scanner/service_detection.go
@@ -4,207 +4,244 @@ import (
 	"bufio"
 	"fmt"
 	"net"
+	"regexp"
 	"strings"
-	"sync"
 	"time"
 )
 
-// DetectProtocol tries to identify the service running on a port using protocol handshakes.
-func DetectProtocol(host string, port int, timeout time.Duration, results chan<- string, wg *sync.WaitGroup) {
-	defer wg.Done()
-	address := fmt.Sprintf("%s:%d", host, port)
-	conn, err := net.DialTimeout("tcp", address, timeout)
+type ServiceResult struct {
+	Name    string `json:"name"`
+	Version string `json:"version,omitempty"`
+	Banner  string `json:"banner,omitempty"`
+}
+
+func DetectService(host string, port int, timeout time.Duration) ServiceResult {
+	addr := net.JoinHostPort(host, fmt.Sprintf("%d", port))
+	conn, err := net.DialTimeout("tcp", addr, timeout)
 	if err != nil {
-		results <- "closed"
-		return
+		return ServiceResult{Name: "closed"}
 	}
 	defer conn.Close()
 
-	var service string
 	switch port {
 	case 21:
-		service = detectFTP(conn, timeout)
+		return detectFTP(conn, timeout)
 	case 22:
-		service = "ssh"
+		return detectSSH(conn, timeout)
 	case 23:
-		service = detectTelnet(conn, timeout)
+		return detectTelnet(conn, timeout)
 	case 25, 465, 587:
-		service = detectSMTP(conn, timeout)
+		return detectSMTP(conn, timeout)
 	case 53:
-		service = detectDNS(conn, timeout)
-	case 80, 8080:
-		service = detectHTTP(conn, timeout)
+		return detectDNS(conn, timeout)
+	case 80, 443, 8080, 8443:
+		return detectHTTP(conn, timeout)
 	case 110:
-		service = detectPOP3(conn, timeout)
+		return detectPOP3(conn, timeout)
 	case 143, 993:
-		service = detectIMAP(conn, timeout)
+		return detectIMAP(conn, timeout)
 	case 3306:
-		service = detectMySQL(conn, timeout)
+		return detectMySQL(conn, timeout)
 	case 5432:
-		service = detectPostgres(conn, timeout)
+		return detectPostgres(conn, timeout)
 	case 6379:
-		service = detectRedis(conn, timeout)
+		return detectRedis(conn, timeout)
 	case 3389:
-		service = detectRDP(conn, timeout)
+		return detectRDP(conn, timeout)
 	default:
-		service = detectByBanner(conn, timeout)
+		return detectByBanner(conn, timeout)
 	}
-	results <- service
 }
 
-// --- Protocol-specific detection functions ---
-
-func detectFTP(conn net.Conn, timeout time.Duration) string {
+func readBanner(conn net.Conn, timeout time.Duration) string {
 	conn.SetReadDeadline(time.Now().Add(timeout))
 	buf := make([]byte, 1024)
-	n, err := conn.Read(buf)
-	if err == nil && strings.HasPrefix(string(buf[:n]), "220") {
-		return "ftp"
-	}
-	return "unknown"
+	n, _ := conn.Read(buf)
+	return string(buf[:n])
 }
 
-func detectTelnet(conn net.Conn, timeout time.Duration) string {
+var sshVersionRe = regexp.MustCompile(`SSH-[\d.]+-(\S+)`)
+var smtpVersionRe = regexp.MustCompile(`220\s+\S+\s+(?:ESMTP\s+)?(\S+)`)
+var ftpVersionRe = regexp.MustCompile(`220.*?(\S+\s+\d+\.\d+\S*)`)
+
+func detectFTP(conn net.Conn, timeout time.Duration) ServiceResult {
+	banner := readBanner(conn, timeout)
+	if !strings.HasPrefix(banner, "220") {
+		return ServiceResult{Name: "unknown", Banner: banner}
+	}
+	version := ""
+	if m := ftpVersionRe.FindStringSubmatch(banner); len(m) > 1 {
+		version = m[1]
+	}
+	return ServiceResult{Name: "ftp", Version: version, Banner: banner}
+}
+
+func detectSSH(conn net.Conn, timeout time.Duration) ServiceResult {
+	banner := readBanner(conn, timeout)
+	version := ""
+	if m := sshVersionRe.FindStringSubmatch(banner); len(m) > 1 {
+		version = m[1]
+	}
+	return ServiceResult{Name: "ssh", Version: version, Banner: strings.TrimSpace(banner)}
+}
+
+func detectTelnet(conn net.Conn, timeout time.Duration) ServiceResult {
 	conn.SetReadDeadline(time.Now().Add(timeout))
 	buf := make([]byte, 1024)
 	n, err := conn.Read(buf)
 	if err == nil && n > 0 && buf[0] == 0xFF {
-		return "telnet"
+		return ServiceResult{Name: "telnet"}
 	}
-	return "unknown"
+	return ServiceResult{Name: "unknown"}
 }
 
-func detectSMTP(conn net.Conn, timeout time.Duration) string {
-	conn.SetReadDeadline(time.Now().Add(timeout))
-	buf := make([]byte, 1024)
-	n, err := conn.Read(buf)
-	if err == nil && strings.HasPrefix(string(buf[:n]), "220") {
-		return "smtp"
+func detectSMTP(conn net.Conn, timeout time.Duration) ServiceResult {
+	banner := readBanner(conn, timeout)
+	if !strings.HasPrefix(banner, "220") {
+		return ServiceResult{Name: "unknown", Banner: banner}
 	}
-	return "unknown"
+	version := ""
+	if m := smtpVersionRe.FindStringSubmatch(banner); len(m) > 1 {
+		version = m[1]
+	}
+	return ServiceResult{Name: "smtp", Version: version, Banner: banner}
 }
 
-func detectDNS(conn net.Conn, timeout time.Duration) string {
-	// TCP DNS detection: send a standard DNS query
+func detectDNS(conn net.Conn, timeout time.Duration) ServiceResult {
 	query := []byte{
-		0x00, 0x1c, // Length
-		0x12, 0x34, // ID
-		0x01, 0x00, // Standard query
-		0x00, 0x01, // QDCOUNT
-		0x00, 0x00, // ANCOUNT
-		0x00, 0x00, // NSCOUNT
-		0x00, 0x00, // ARCOUNT
+		0x00, 0x1c,
+		0x12, 0x34,
+		0x01, 0x00,
+		0x00, 0x01,
+		0x00, 0x00,
+		0x00, 0x00,
+		0x00, 0x00,
 		0x03, 'w', 'w', 'w',
 		0x06, 'g', 'o', 'o', 'g', 'l', 'e',
 		0x03, 'c', 'o', 'm',
-		0x00,       // null terminator
-		0x00, 0x01, // Type A
-		0x00, 0x01, // Class IN
+		0x00,
+		0x00, 0x01,
+		0x00, 0x01,
 	}
 	conn.Write(query)
 	conn.SetReadDeadline(time.Now().Add(timeout))
 	buf := make([]byte, 1024)
 	n, err := conn.Read(buf)
-	if err == nil && n > 0 && buf[2] == 0x12 && buf[3] == 0x34 {
-		return "dns"
+	if err == nil && n > 3 && buf[2] == 0x12 && buf[3] == 0x34 {
+		return ServiceResult{Name: "dns"}
 	}
-	return "unknown"
+	return ServiceResult{Name: "unknown"}
 }
 
-func detectHTTP(conn net.Conn, timeout time.Duration) string {
-	fmt.Fprintf(conn, "HEAD / HTTP/1.0\r\n\r\n")
+func detectHTTP(conn net.Conn, timeout time.Duration) ServiceResult {
+	fmt.Fprintf(conn, "HEAD / HTTP/1.0\r\nHost: %s\r\n\r\n", conn.RemoteAddr().String())
 	conn.SetReadDeadline(time.Now().Add(timeout))
-	scanner := bufio.NewScanner(conn)
-	for scanner.Scan() {
-		line := scanner.Text()
-		if strings.HasPrefix(line, "HTTP/") {
-			return "http"
+	s := bufio.NewScanner(conn)
+	var serverVersion string
+	for s.Scan() {
+		line := s.Text()
+		lower := strings.ToLower(line)
+		if strings.HasPrefix(lower, "server:") {
+			serverVersion = strings.TrimSpace(line[7:])
 		}
 	}
-	return "unknown"
+	return ServiceResult{Name: "http", Version: serverVersion}
 }
 
-func detectPOP3(conn net.Conn, timeout time.Duration) string {
+func detectPOP3(conn net.Conn, timeout time.Duration) ServiceResult {
+	banner := readBanner(conn, timeout)
+	if strings.HasPrefix(banner, "+OK") {
+		return ServiceResult{Name: "pop3", Banner: banner}
+	}
+	return ServiceResult{Name: "unknown", Banner: banner}
+}
+
+func detectIMAP(conn net.Conn, timeout time.Duration) ServiceResult {
+	banner := readBanner(conn, timeout)
+	if strings.Contains(banner, "* OK") {
+		return ServiceResult{Name: "imap", Banner: banner}
+	}
+	return ServiceResult{Name: "unknown", Banner: banner}
+}
+
+func detectMySQL(conn net.Conn, timeout time.Duration) ServiceResult {
 	conn.SetReadDeadline(time.Now().Add(timeout))
 	buf := make([]byte, 1024)
 	n, err := conn.Read(buf)
-	if err == nil && strings.HasPrefix(string(buf[:n]), "+OK") {
-		return "pop3"
+	if err != nil || n == 0 || buf[0] != 0x0a {
+		return ServiceResult{Name: "unknown"}
 	}
-	return "unknown"
+	version := ""
+	if n > 1 {
+		end := 1
+		for end < n && buf[end] != 0x00 {
+			end++
+		}
+		version = string(buf[1:end])
+	}
+	return ServiceResult{Name: "mysql", Version: version}
 }
 
-func detectIMAP(conn net.Conn, timeout time.Duration) string {
-	conn.SetReadDeadline(time.Now().Add(timeout))
-	buf := make([]byte, 1024)
-	n, err := conn.Read(buf)
-	if err == nil && strings.Contains(string(buf[:n]), "* OK") {
-		return "imap"
+func detectPostgres(conn net.Conn, timeout time.Duration) ServiceResult {
+	banner := readBanner(conn, timeout)
+	if strings.Contains(banner, "PostgreSQL") {
+		return ServiceResult{Name: "postgresql", Banner: banner}
 	}
-	return "unknown"
+	return ServiceResult{Name: "unknown", Banner: banner}
 }
 
-func detectMySQL(conn net.Conn, timeout time.Duration) string {
-	conn.SetReadDeadline(time.Now().Add(timeout))
-	buf := make([]byte, 1024)
-	n, err := conn.Read(buf)
-	if err == nil && n > 0 && buf[0] == 0x0a {
-		return "mysql"
-	}
-	return "unknown"
-}
-
-func detectPostgres(conn net.Conn, timeout time.Duration) string {
-	conn.SetReadDeadline(time.Now().Add(timeout))
-	buf := make([]byte, 1024)
-	n, err := conn.Read(buf)
-	if err == nil && strings.Contains(string(buf[:n]), "PostgreSQL") {
-		return "postgresql"
-	}
-	return "unknown"
-}
-
-func detectRedis(conn net.Conn, timeout time.Duration) string {
+func detectRedis(conn net.Conn, timeout time.Duration) ServiceResult {
 	conn.SetDeadline(time.Now().Add(timeout))
-	conn.Write([]byte("PING\r\n"))
-	buf := make([]byte, 1024)
-	n, err := conn.Read(buf)
-	if err == nil && strings.HasPrefix(string(buf[:n]), "+PONG") {
-		return "redis"
+	conn.Write([]byte("INFO server\r\n"))
+	banner := readBanner(conn, timeout)
+	if strings.Contains(banner, "redis") {
+		version := ""
+		for _, line := range strings.Split(banner, "\n") {
+			if strings.HasPrefix(line, "redis_version:") {
+				version = strings.TrimSpace(strings.TrimPrefix(line, "redis_version:"))
+			}
+		}
+		return ServiceResult{Name: "redis", Version: version}
 	}
-	return "unknown"
+	conn.Write([]byte("PING\r\n"))
+	banner = readBanner(conn, timeout)
+	if strings.HasPrefix(banner, "+PONG") {
+		return ServiceResult{Name: "redis"}
+	}
+	return ServiceResult{Name: "unknown"}
 }
 
-func detectRDP(conn net.Conn, timeout time.Duration) string {
+func detectRDP(conn net.Conn, timeout time.Duration) ServiceResult {
 	conn.SetDeadline(time.Now().Add(timeout))
 	rdpNegReq := []byte{0x03, 0x00, 0x00, 0x13, 0x0e, 0xe0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x08, 0x00, 0x03, 0x00, 0x00, 0x00}
 	conn.Write(rdpNegReq)
-	buf := make([]byte, 1024)
-	n, err := conn.Read(buf)
-	if err == nil && n > 0 && buf[0] == 0x03 {
-		return "rdp"
-	}
-	return "unknown"
-}
-
-func detectByBanner(conn net.Conn, timeout time.Duration) string {
 	conn.SetReadDeadline(time.Now().Add(timeout))
 	buf := make([]byte, 1024)
 	n, err := conn.Read(buf)
-	banner := string(buf[:n])
-	if err == nil {
-		if strings.Contains(strings.ToLower(banner), "ftp") {
-			return "ftp"
-		}
-		if strings.Contains(strings.ToLower(banner), "ssh") {
-			return "ssh"
-		}
-		if strings.Contains(strings.ToLower(banner), "smtp") {
-			return "smtp"
-		}
-		if strings.Contains(strings.ToLower(banner), "http") {
-			return "http"
-		}
+	if err == nil && n > 0 && buf[0] == 0x03 {
+		return ServiceResult{Name: "rdp"}
 	}
-	return "unknown"
+	return ServiceResult{Name: "unknown"}
+}
+
+func detectByBanner(conn net.Conn, timeout time.Duration) ServiceResult {
+	banner := readBanner(conn, timeout)
+	lower := strings.ToLower(banner)
+
+	switch {
+	case strings.Contains(lower, "ssh"):
+		version := ""
+		if m := sshVersionRe.FindStringSubmatch(banner); len(m) > 1 {
+			version = m[1]
+		}
+		return ServiceResult{Name: "ssh", Version: version, Banner: banner}
+	case strings.Contains(lower, "ftp"):
+		return ServiceResult{Name: "ftp", Banner: banner}
+	case strings.Contains(lower, "smtp"):
+		return ServiceResult{Name: "smtp", Banner: banner}
+	case strings.Contains(lower, "http"):
+		return ServiceResult{Name: "http", Banner: banner}
+	}
+
+	return ServiceResult{Name: "unknown", Banner: banner}
 }

--- a/internal/scanner/service_detection_test.go
+++ b/internal/scanner/service_detection_test.go
@@ -1,0 +1,69 @@
+package scanner
+
+import (
+	"testing"
+	"time"
+)
+
+func TestSSHVersionParsing(t *testing.T) {
+	tests := []struct {
+		banner  string
+		version string
+	}{
+		{
+			banner:  "SSH-2.0-OpenSSH_8.9p1 Ubuntu-3ubuntu0.1\r\n",
+			version: "OpenSSH_8.9p1",
+		},
+		{
+			banner:  "SSH-2.0-dropbear_2022.83\r\n",
+			version: "dropbear_2022.83",
+		},
+		{
+			banner:  "SSH-2.0-\r\n",
+			version: "",
+		},
+	}
+	for _, tt := range tests {
+		m := sshVersionRe.FindStringSubmatch(tt.banner)
+		got := ""
+		if len(m) > 1 {
+			got = m[1]
+		}
+		if got != tt.version {
+			t.Errorf("banner %q: got %q, want %q", tt.banner, got, tt.version)
+		}
+	}
+}
+
+func TestSMTPVersionParsing(t *testing.T) {
+	tests := []struct {
+		banner  string
+		version string
+	}{
+		{
+			banner:  "220 mail.example.com ESMTP Postfix\r\n",
+			version: "Postfix",
+		},
+		{
+			banner:  "220 smtp.example.com Sendmail\r\n",
+			version: "Sendmail",
+		},
+	}
+	for _, tt := range tests {
+		m := smtpVersionRe.FindStringSubmatch(tt.banner)
+		got := ""
+		if len(m) > 1 {
+			got = m[1]
+		}
+		if got != tt.version {
+			t.Errorf("banner %q: got %q, want %q", tt.banner, got, tt.version)
+		}
+	}
+}
+
+func TestDetectServiceClosedPort(t *testing.T) {
+	result := DetectService("127.0.0.1", 1, 100*time.Millisecond)
+	if result.Name != "closed" {
+		t.Errorf("expected closed, got %s", result.Name)
+	}
+}

--- a/internal/scanner/tls_detection.go
+++ b/internal/scanner/tls_detection.go
@@ -24,14 +24,14 @@ func InspectTLS(host string, port int, timeout time.Duration) *TLSResult {
 	addr := net.JoinHostPort(host, fmt.Sprintf("%d", port))
 	conn, err := net.DialTimeout("tcp", addr, timeout)
 	if err != nil {
-		return &TLSResult{Enabled: false}
+		return nil
 	}
 	defer conn.Close()
 
 	tlsConn := tls.Client(conn, &tls.Config{InsecureSkipVerify: true})
 	tlsConn.SetDeadline(time.Now().Add(timeout))
 	if err := tlsConn.Handshake(); err != nil {
-		return &TLSResult{Enabled: false}
+		return nil
 	}
 
 	state := tlsConn.ConnectionState()

--- a/internal/scanner/tls_detection_test.go
+++ b/internal/scanner/tls_detection_test.go
@@ -42,7 +42,7 @@ func TestTLSVersionString(t *testing.T) {
 
 func TestInspectTLSClosedPort(t *testing.T) {
 	result := InspectTLS("127.0.0.1", 1, 100*time.Millisecond)
-	if result.Enabled {
-		t.Error("expected TLS disabled for closed port")
+	if result != nil {
+		t.Error("expected nil for closed port")
 	}
 }

--- a/ips.txt
+++ b/ips.txt
@@ -1,2 +1,3 @@
 scanme.nmap.org
-
+healthybyte.net
+randomsecurity.dev


### PR DESCRIPTION

- Replace DetectProtocol with DetectService returning ServiceResult with name, version, and banner. Consolidate triple-connect into single connection per port. 
- Remove fake CVE match. 
- Return nil from InspectTLS for non-TLS ports. 
- Parse versions from SSH, SMTP, FTP, MySQL, Redis, and HTTP Server headers.