### PR TITLE
Add flan CLI, improve DNS enumeration, update README

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ reports/
 .DS_Store
 scan-state.json
 flan-go-scan
+flan

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,12 +7,12 @@ RUN go mod download
 
 COPY . .
 
-RUN CGO_ENABLED=0 go build -o flan-go-scan ./cmd/flan-go-scan
+RUN CGO_ENABLED=0 go build -o flan ./cmd/flan
 
 FROM cgr.dev/chainguard/static:latest
 
-COPY --from=builder /app/flan-go-scan /flan-go-scan
+COPY --from=builder /app/flan /flan
 COPY --from=builder /app/config /config
 COPY --from=builder /app/ips.txt /ips.txt
 
-ENTRYPOINT ["/flan-go-scan", "-config=/config/config.yaml"]
+ENTRYPOINT ["/flan", "-c=/config/config.yaml"]

--- a/README.md
+++ b/README.md
@@ -1,77 +1,89 @@
 ![Go-Gopher-Flan-small](https://github.com/user-attachments/assets/e08ec4c5-8619-4437-a043-af7ea4a035fb)
 
-# flan-go-scan
+# flan
 
-A modular, extensible network vulnerability scanner in Go. This is an update to the deprecated Flan Scan project: https://github.com/cloudflare/flan
+A network scanner in Go. Successor to [Flan Scan](https://github.com/cloudflare/flan).
 
 ## Features
 
-- TCP port scanning with bounded worker pool concurrency
-- Service detection with version extraction (SSH, HTTP, SMTP, FTP, MySQL, Redis, RDP, and more)
-- Banner grabbing and protocol heuristics
-- TLS certificate inspection (version, cipher suite, subject, issuer, SANs, expiry, self-signed detection)
-- DNS enumeration (subdomain brute-forcing, zone transfer attempts)
+- TCP port scanning with bounded concurrency
+- 51-protocol service fingerprinting via [fingerprintx](https://github.com/praetorian-inc/fingerprintx) (SSH, HTTP, MySQL, Redis, RDP, PostgreSQL, and more)
+- Technology detection (Wappalyzer) and CPE generation
+- TLS certificate inspection (version, cipher, subject, issuer, SANs, expiry, self-signed)
+- CVE lookup by CPE via NVD API
+- Host discovery (TCP probe to skip dead hosts)
+- DNS enumeration with wildcard detection and custom wordlist/resolver support
 - NS, MX, TXT, CNAME record lookups
-- DNS resolution caching
-- CIDR input support and stdin piping (`-ips -`)
-- Rate limiting
-- Scan resumption (checkpointing)
+- CIDR and stdin input support
+- nmap top 100/1000 port lists
+- Scan checkpointing and resumption
+- Progress reporting
 - Graceful shutdown on SIGINT/SIGTERM
-- Structured logging via `log/slog`
+- JSON, JSONL (streaming), CSV, and text output
 - Configurable via YAML
-- Outputs JSON, JSONL (streaming), CSV, or text reports
+
+## Build
+
+```
+go build -o flan ./cmd/flan
+```
 
 ## Usage
 
-### Domain-based scanning (recommended)
-
 ```
-./flan-go-scan -domain=together.ai
+./flan --help
 ```
 
-This will:
-1. Enumerate subdomains via DNS brute-forcing
-2. Resolve NS, MX, TXT, CNAME records
-3. Scan discovered hosts for open ports
-4. Detect services and extract versions
-
-### IP-based scanning
-
-1. Place targets in `ips.txt` (supports IPs, hostnames, CIDR notation)
-2. Edit `config/config.yaml` as needed
-3. Build:
+Scan a single target:
 
 ```
-go build -o flan-go-scan ./cmd/flan-go-scan
+./flan -t scanme.nmap.org
 ```
-
-4. Run:
-
-```
-./flan-go-scan -config=config/config.yaml -ips=ips.txt
-```
-
-### Stdin piping
-
-```
-echo "10.0.0.0/24" | ./flan-go-scan -ips -
-```
-
-## Common Run Options
 
 Scan a domain (DNS enumeration + port scan):
-`./flan-go-scan -domain=example.com`
 
-Specify a different IPs file:
-`./flan-go-scan -ips=mytargets.txt`
+```
+./flan -d example.com
+```
 
-Specify config file:
-`./flan-go-scan -config=config/config.yaml`
+Scan from a file with top 1000 ports:
+
+```
+./flan -l targets.txt --top-ports 1000
+```
+
+Scan a CIDR range from stdin:
+
+```
+echo "10.0.0.0/24" | ./flan -l -
+```
+
+Scan with custom wordlist and resolver:
+
+```
+./flan -d example.com -w wordlist.txt -r 8.8.8.8:53
+```
+
+## Flags
+
+| Flag | Description |
+|------|-------------|
+| `-t` | Target host/IP |
+| `-l` | Target file (default `ips.txt`, `-` for stdin) |
+| `-d` | Domain to enumerate via DNS |
+| `-p` | Ports to scan |
+| `--top-ports` | Use nmap top port list: `100` or `1000` |
+| `-c` | Config file (default `config/config.yaml`) |
+| `-w` | Custom DNS subdomain wordlist |
+| `-r` | Custom DNS resolver (ip:port) |
+| `--json` | JSON output |
+| `--jsonl` | JSONL streaming output |
+| `--csv` | CSV output |
 
 ## Tests
 
 ```
-go test ./internal/scanner/ -v
+go test ./... -v
 ```
 
 ## License

--- a/cmd/flan/main.go
+++ b/cmd/flan/main.go
@@ -20,6 +20,54 @@ import (
 	"github.com/therandomsecurityguy/flan-go-scan/internal/scanner"
 )
 
+var version = "dev"
+
+const banner = `
+  __ _
+ / _| | __ _ _ __    ___  ___ __ _ _ __
+| |_| |/ _' | '_ \  / __|/ __/ _' | '_ \
+|  _| | (_| | | | | \__ \ (_| (_| | | | |
+|_| |_|\__,_|_| |_| |___/\___\__,_|_| |_| %s
+
+`
+
+func printBanner() {
+	fmt.Fprintf(os.Stderr, banner, version)
+}
+
+func usage() {
+	printBanner()
+	fmt.Fprintf(os.Stderr, `Usage:
+  flan [flags]
+
+TARGET:
+  -t, -target string       target host/IP to scan
+  -l, -list string         file containing targets (default "ips.txt")
+  -d, -domain string       domain to enumerate via DNS
+
+PORTS:
+  -p, -ports string        ports to scan (from config if not set)
+  --top-ports string       use top port list: 100 or 1000
+
+CONFIGURATION:
+  -c, -config string       path to config file (default "config/config.yaml")
+  -w, -wordlist string     custom DNS subdomain wordlist file
+  -r, -resolver string     custom DNS resolver (ip:port)
+
+OUTPUT:
+  --json                   output in JSON format
+  --jsonl                  output in JSONL format (streaming)
+  --csv                    output in CSV format
+
+EXAMPLES:
+  flan -t scanme.nmap.org
+  flan -l targets.txt --top-ports 1000
+  flan -d together.ai
+  echo "10.0.0.0/24" | flan -l -
+
+`)
+}
+
 func parsePorts(portStr string) ([]int, error) {
 	var ports []int
 	for _, part := range strings.Split(portStr, ",") {
@@ -73,16 +121,51 @@ func readHosts(filename string) ([]string, error) {
 }
 
 func main() {
-	configPath := flag.String("config", "config/config.yaml", "Path to config file")
-	ipsFile := flag.String("ips", "ips.txt", "File with hosts to scan")
-	domain := flag.String("domain", "", "Domain to enumerate (e.g., together.ai)")
-	topPorts := flag.String("top-ports", "", "Use top port list: 100 or 1000")
+	flag.Usage = usage
+	printBanner()
+
+	configPath := flag.String("config", "config/config.yaml", "")
+	configShort := flag.String("c", "config/config.yaml", "")
+	listFile := flag.String("list", "ips.txt", "")
+	listShort := flag.String("l", "ips.txt", "")
+	target := flag.String("target", "", "")
+	targetShort := flag.String("t", "", "")
+	domain := flag.String("domain", "", "")
+	domainShort := flag.String("d", "", "")
+	portsFlag := flag.String("ports", "", "")
+	portsShort := flag.String("p", "", "")
+	topPorts := flag.String("top-ports", "", "")
+	wordlist := flag.String("wordlist", "", "")
+	wordlistShort := flag.String("w", "", "")
+	resolver := flag.String("resolver", "", "")
+	resolverShort := flag.String("r", "", "")
+	jsonFlag := flag.Bool("json", false, "")
+	jsonlFlag := flag.Bool("jsonl", false, "")
+	csvFlag := flag.Bool("csv", false, "")
 	flag.Parse()
 
-	cfg, err := config.LoadConfig(*configPath)
+	cfgPath := coalesce(*configPath, *configShort)
+	ipsFile := coalesce(*listFile, *listShort)
+	tgt := coalesce(*target, *targetShort)
+	dom := coalesce(*domain, *domainShort)
+	portStr := coalesce(*portsFlag, *portsShort)
+	wl := coalesce(*wordlist, *wordlistShort)
+	res := coalesce(*resolver, *resolverShort)
+
+	cfg, err := config.LoadConfig(cfgPath)
 	if err != nil {
 		slog.Error("config error", "err", err)
 		os.Exit(1)
+	}
+
+	if *jsonFlag {
+		cfg.Output.Format = "json"
+	}
+	if *jsonlFlag {
+		cfg.Output.Format = "jsonl"
+	}
+	if *csvFlag {
+		cfg.Output.Format = "csv"
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -98,10 +181,29 @@ func main() {
 
 	var hosts []string
 
-	if *domain != "" {
-		slog.Info("enumerating DNS records", "domain", *domain)
-		enumerator := dns.NewEnumerator(cfg.Scan.Timeout, 50)
-		enumResults, err := enumerator.Enumerate(*domain)
+	if tgt != "" {
+		hosts = append(hosts, tgt)
+	} else if dom != "" {
+		slog.Info("enumerating DNS records", "domain", dom)
+
+		var enumerator *dns.Enumerator
+		if res != "" {
+			enumerator = dns.NewEnumeratorWithResolver(cfg.Scan.Timeout, 50, res)
+		} else {
+			enumerator = dns.NewEnumerator(cfg.Scan.Timeout, 50)
+		}
+
+		var enumResults []dns.EnumerationResult
+		if wl != "" {
+			words, err := dns.LoadWordlist(wl)
+			if err != nil {
+				slog.Error("failed to load wordlist", "err", err)
+				os.Exit(1)
+			}
+			enumResults, err = enumerator.EnumerateWithWordlist(dom, words)
+		} else {
+			enumResults, err = enumerator.Enumerate(dom)
+		}
 		if err != nil {
 			slog.Error("DNS enumeration failed", "err", err)
 			os.Exit(1)
@@ -114,22 +216,22 @@ func main() {
 			hosts = append(hosts, hostIP)
 		}
 
-		nsRecords, err := dns.GetNSRecords(*domain)
+		nsRecords, err := dns.GetNSRecords(dom)
 		if err == nil && len(nsRecords) > 0 {
 			slog.Info("nameservers", "records", nsRecords)
 		}
 
-		mxRecords, err := dns.GetMXRecords(*domain)
+		mxRecords, err := dns.GetMXRecords(dom)
 		if err == nil && len(mxRecords) > 0 {
 			slog.Info("mail servers", "records", mxRecords)
 		}
 
-		txtRecords, err := dns.GetTXTRecords(*domain)
+		txtRecords, err := dns.GetTXTRecords(dom)
 		if err == nil && len(txtRecords) > 0 {
 			slog.Info("TXT records", "records", txtRecords)
 		}
 	} else {
-		hosts, err = readHosts(*ipsFile)
+		hosts, err = readHosts(ipsFile)
 		if err != nil {
 			slog.Error("failed to read hosts", "err", err)
 			os.Exit(1)
@@ -137,7 +239,7 @@ func main() {
 	}
 
 	if len(hosts) == 0 {
-		slog.Error("no hosts to scan, provide -domain or hosts file")
+		slog.Error("no hosts to scan, provide -t, -d, or -l")
 		os.Exit(1)
 	}
 
@@ -148,8 +250,11 @@ func main() {
 	case "1000":
 		ports = scanner.TopPorts1000
 	case "":
-		var err error
-		ports, err = parsePorts(cfg.Scan.Ports)
+		if portStr != "" {
+			ports, err = parsePorts(portStr)
+		} else {
+			ports, err = parsePorts(cfg.Scan.Ports)
+		}
 		if err != nil {
 			slog.Error("invalid port configuration", "err", err)
 			os.Exit(1)
@@ -162,7 +267,11 @@ func main() {
 	dnsCache := dns.NewDNSCache(cfg.DNS.TTL)
 	limiter := scanner.NewRateLimiter(cfg.Scan.RateLimit)
 	checkpoint := scanner.NewCheckpoint(cfg.Checkpoint.File)
-	reportWriter := output.NewReportWriter(cfg.Output.Directory)
+	reportWriter, err := output.NewReportWriter(cfg.Output.Directory)
+	if err != nil {
+		slog.Error("failed to create report writer", "err", err)
+		os.Exit(1)
+	}
 	cveLookup := scanner.NewCVELookup()
 
 	var jsonlWriter *output.JSONLWriter
@@ -264,14 +373,12 @@ func main() {
 					}
 
 					var vulns []string
-					var cpes []string
 					if fp.Metadata != nil {
 						var meta struct {
 							CPEs []string `json:"cpes"`
 						}
 						if json.Unmarshal(fp.Metadata, &meta) == nil {
-							cpes = meta.CPEs
-							for _, cpe := range cpes {
+							for _, cpe := range meta.CPEs {
 								for _, cve := range cveLookup.Lookup(cpe) {
 									vulns = append(vulns, cve.ID)
 								}
@@ -322,12 +429,19 @@ func main() {
 		slog.Error("failed to flush checkpoint", "err", err)
 	}
 
+	if ctx.Err() == nil {
+		checkpoint.Clear()
+	}
+
 	slog.Info("scan complete",
 		"services_found", progress.ServicesFound.Load(),
 		"ports_scanned", progress.PortsScanned.Load(),
 	)
 
 	if jsonlWriter != nil {
+		if jsonlWriter.Filename != "" {
+			slog.Info("report written", "path", jsonlWriter.Filename)
+		}
 		return
 	}
 
@@ -335,14 +449,28 @@ func main() {
 	case "json":
 		if err := reportWriter.WriteJSON(results); err != nil {
 			slog.Error("failed to write JSON report", "err", err)
+		} else {
+			slog.Info("report written", "format", "json", "directory", cfg.Output.Directory)
 		}
 	case "csv":
 		if err := reportWriter.WriteCSV(results); err != nil {
 			slog.Error("failed to write CSV report", "err", err)
+		} else {
+			slog.Info("report written", "format", "csv", "directory", cfg.Output.Directory)
 		}
 	default:
 		for _, res := range results {
 			fmt.Printf("%s:%d [%s %s] TLS:%v %s\n", res.Host, res.Port, res.Service, res.Version, res.TLS != nil, res.Banner)
 		}
 	}
+}
+
+func coalesce(a, b string) string {
+	if a != "" && a != "config/config.yaml" && a != "ips.txt" {
+		return a
+	}
+	if b != "" && b != "config/config.yaml" && b != "ips.txt" {
+		return b
+	}
+	return a
 }

--- a/internal/dns/cache.go
+++ b/internal/dns/cache.go
@@ -28,9 +28,17 @@ func (c *DNSCache) Lookup(host string) ([]net.IP, error) {
 	c.mu.RLock()
 	entry, exists := c.entries[host]
 	c.mu.RUnlock()
+
 	if exists && time.Now().Before(entry.expires) {
 		return entry.ips, nil
 	}
+
+	if exists {
+		c.mu.Lock()
+		delete(c.entries, host)
+		c.mu.Unlock()
+	}
+
 	ips, err := net.LookupIP(host)
 	if err != nil {
 		return nil, err

--- a/internal/dns/enumeration.go
+++ b/internal/dns/enumeration.go
@@ -1,56 +1,37 @@
 package dns
 
 import (
+	"bufio"
 	"context"
 	"fmt"
+	"math/rand"
 	"net"
+	"os"
 	"strings"
 	"sync"
 	"time"
 )
 
-var commonSubdomains = []string{
-	"www", "mail", "ftp", "localhost", "webmail", "smtp", "pop", "ns1", "webdisk",
-	"ns2", "cpanel", "whm", "autodiscover", "autoconfig", "m", "imap", "test",
-	"ns", "blog", "pop3", "dev", "www2", "admin", "store", "dns1", "dns2",
-	"mail2", "new", "mysql", "old", "lists", "support", "mobile", "mx", "demo",
-	"ash", "blog2", "mx1", "chat", "dns", "www3", "git", "stats", "ns3", "wiki",
-	"vpn", "mxs", "mx2", "sec", "vps", "mail3", "ns4", "app", "irc", "relay",
-	"logs", "mx0", "git2", "sftp", " ftps", "ssh", "git3", "corp", "nas", "proxy",
-	"redis", "sync", "edge", "sync2", "db", "manage", "git1", "stage", "svn",
-	"git4", "api", "api2", "api3", "jira", "test2", "beta", "backup", "owa",
-	"git5", "ns5", "ns6", "ns7", "ns8", "ns9", "ns10", "ns11", "ns12", "ns13",
-	"ns14", "ns15", "v2", "beta2", "test3", "web1", "web2", "web3", "web4",
-	"server", "server1", "server2", "server3", "cdn", "cdn2", "static", "files",
-	"download", "download2", "upload", "upload2", "cdn3", "assets", "img", "images",
-	"img2", "static2", "media", "media2", "files2", "docs", "docs2", "public",
-	"private", "crm", "erp", "helpdesk", "portal", "web", "portal2", "shop",
-	"store2", "mall", "pay", "payment", "checkout", "cart", "orders", "billing",
-	"account", "accounts", "secure", "login", "sso", "auth", "oauth", "token",
-	"idp", "ldap", "admin2", "manager", "manage2", "hr", "intranet", "internal",
-	"dev2", "staging", "staging2", "prod", "production", "cloud", "cloud2",
-	"aws", "azure", "gcp", "kubernetes", "k8s", "docker", "registry", "jenkins",
-	"ci", "cd", " pipelines", "build", "deploy", "sonar", "nexus", "artifactory",
-	"grafana", "prometheus", "kibana", "logs2", "elasticsearch", "monitor",
-	"monitoring", "alert", "alerts", "metrics", "stats2", "analytics", "data",
-	"data2", "warehouse", "etl", "spark", "hadoop", "kafka", "rabbitmq", "nats",
-	"grpc", "websocket", "realtime", "socket", "push", "notification", "notify",
-	"mailer", "smtp2", "smtp3", "mta", "incoming", "outgoing", "filters", "spam",
-	" quarantine", "archiver", "archive", "webhook", "hooks", "hook", "bot", "bots",
-	"chatbot", "ai", "ml", "ml2", "model", "models", "training", "inference",
-	"lambda", "function", "functions", "faas", "serverless", "edge2", "cdn4",
-	"global", "regional", "east", "west", "north", "south", "us", "us2", "eu",
-	"eu2", "ap", "ap2", "au", "au2", "jp", "jp2", "sg", "sg2", "in", "in2",
-	"br", "br2", "ca", "ca2", "uk", "uk2", "de", "de2", "fr", "fr2", "es", "es2",
-	"it", "it2", "nl", "nl2", "se", "se2", "no", "no2", "fi", "fi2", "dk", "dk2",
-	"pl", "pl2", "ru", "ru2", "cn", "cn2", "kr", "kr2", "tw", "tw2", "hk", "hk2",
-	"sgp", "sgp2", "id", "id2", "my", "my2", "th", "th2", "vn", "vn2", "ph",
-	"ph2", "nz", "nz2", "za", "za2", "eg", "eg2", "sa", "sa2", "ae", "ae2",
-	"il", "il2", "ng", "ng2", "ke", "ke2", "ma", "ma2", "gh", "gh2", "tz",
-	"tz2", "et", "et2", "rw", "rw2", "ug", "ug2", "zm", "zm2", "zw", "zw2",
-	"mw", "mw2", "mz", "mz2", "bw", "bw2", "na", "na2", "sz", "sz2", "ls", "ls2",
-	"cd", "cd2", "cg", "cg2", "ga", "ga2", "gq", "gq2", "cm", "cm2", "sn", "sn2",
-	"ci", "ci2", "bf", "bf2", "ml", "ml2", "ne", "ne2", "tg", "tg2", "bj", "bj2",
+var defaultSubdomains = []string{
+	"www", "mail", "ftp", "webmail", "smtp", "pop", "ns1", "ns2", "cpanel",
+	"whm", "autodiscover", "autoconfig", "m", "imap", "test", "ns", "blog",
+	"pop3", "dev", "www2", "admin", "store", "dns1", "dns2", "mail2", "new",
+	"mysql", "old", "lists", "support", "mobile", "mx", "demo", "blog2",
+	"mx1", "chat", "dns", "www3", "git", "stats", "ns3", "wiki", "vpn",
+	"mx2", "sec", "vps", "mail3", "ns4", "app", "irc", "relay", "logs",
+	"sftp", "ftps", "ssh", "corp", "nas", "proxy", "redis", "sync", "edge",
+	"db", "manage", "stage", "svn", "api", "api2", "api3", "jira", "test2",
+	"beta", "backup", "owa", "v2", "web1", "web2", "web3", "web4", "server",
+	"server1", "server2", "server3", "cdn", "cdn2", "static", "files",
+	"download", "upload", "assets", "img", "images", "static2", "media",
+	"docs", "public", "private", "crm", "erp", "helpdesk", "portal", "web",
+	"shop", "pay", "payment", "checkout", "billing", "account", "accounts",
+	"secure", "login", "sso", "auth", "oauth", "token", "ldap", "admin2",
+	"manager", "hr", "intranet", "internal", "dev2", "staging", "prod",
+	"production", "cloud", "aws", "azure", "gcp", "kubernetes", "k8s",
+	"docker", "registry", "jenkins", "ci", "grafana", "prometheus", "kibana",
+	"elasticsearch", "monitor", "monitoring", "alerts", "metrics", "analytics",
+	"data", "kafka", "rabbitmq", "api2", "webhook", "archive", "bot",
 }
 
 type EnumerationResult struct {
@@ -60,18 +41,56 @@ type EnumerationResult struct {
 }
 
 type Enumerator struct {
-	timeout time.Duration
-	workers int
+	timeout  time.Duration
+	workers  int
+	resolver *net.Resolver
 }
 
 func NewEnumerator(timeout time.Duration, workers int) *Enumerator {
 	return &Enumerator{
-		timeout: timeout,
-		workers: workers,
+		timeout:  timeout,
+		workers:  workers,
+		resolver: &net.Resolver{PreferGo: true},
 	}
 }
 
+func NewEnumeratorWithResolver(timeout time.Duration, workers int, resolverAddr string) *Enumerator {
+	return &Enumerator{
+		timeout: timeout,
+		workers: workers,
+		resolver: &net.Resolver{
+			PreferGo: true,
+			Dial: func(ctx context.Context, network, address string) (net.Conn, error) {
+				d := net.Dialer{Timeout: timeout}
+				return d.DialContext(ctx, "udp", resolverAddr)
+			},
+		},
+	}
+}
+
+func LoadWordlist(path string) ([]string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	var words []string
+	s := bufio.NewScanner(f)
+	for s.Scan() {
+		w := strings.TrimSpace(s.Text())
+		if w != "" {
+			words = append(words, w)
+		}
+	}
+	return words, s.Err()
+}
+
 func (e *Enumerator) Enumerate(domain string) ([]EnumerationResult, error) {
+	return e.EnumerateWithWordlist(domain, defaultSubdomains)
+}
+
+func (e *Enumerator) EnumerateWithWordlist(domain string, wordlist []string) ([]EnumerationResult, error) {
 	var results []EnumerationResult
 	var mu sync.Mutex
 	var wg sync.WaitGroup
@@ -83,9 +102,7 @@ func (e *Enumerator) Enumerate(domain string) ([]EnumerationResult, error) {
 		return nil, fmt.Errorf("invalid domain: %s", domain)
 	}
 
-	resolver := &net.Resolver{
-		PreferGo: true,
-	}
+	wildcardIPs := e.detectWildcard(domain)
 
 	checked := make(map[string]bool)
 	var checkedMu sync.Mutex
@@ -102,12 +119,15 @@ func (e *Enumerator) Enumerate(domain string) ([]EnumerationResult, error) {
 		fullHost := host + "." + domain
 		ctx, cancel := context.WithTimeout(context.Background(), e.timeout)
 		defer cancel()
-		addrs, err := resolver.LookupIPAddr(ctx, fullHost)
+		addrs, err := e.resolver.LookupIPAddr(ctx, fullHost)
 		if err != nil {
 			return
 		}
 
 		for _, addr := range addrs {
+			if wildcardIPs[addr.IP.String()] {
+				continue
+			}
 			mu.Lock()
 			results = append(results, EnumerationResult{
 				Hostname: fullHost,
@@ -129,7 +149,7 @@ func (e *Enumerator) Enumerate(domain string) ([]EnumerationResult, error) {
 		}()
 	}
 
-	for _, sub := range commonSubdomains {
+	for _, sub := range wordlist {
 		processQueue <- sub
 	}
 	close(processQueue)
@@ -137,7 +157,7 @@ func (e *Enumerator) Enumerate(domain string) ([]EnumerationResult, error) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), e.timeout)
 	defer cancel()
-	addrs, err := resolver.LookupIPAddr(ctx, domain)
+	addrs, err := e.resolver.LookupIPAddr(ctx, domain)
 	if err == nil && len(addrs) > 0 {
 		for _, addr := range addrs {
 			mu.Lock()
@@ -151,6 +171,33 @@ func (e *Enumerator) Enumerate(domain string) ([]EnumerationResult, error) {
 	}
 
 	return results, nil
+}
+
+func (e *Enumerator) detectWildcard(domain string) map[string]bool {
+	wildcardIPs := make(map[string]bool)
+	for i := 0; i < 3; i++ {
+		random := fmt.Sprintf("%s-wildcard-check-%d.%s", randomString(12), i, domain)
+		ctx, cancel := context.WithTimeout(context.Background(), e.timeout)
+		addrs, err := e.resolver.LookupIPAddr(ctx, random)
+		cancel()
+		if err != nil {
+			continue
+		}
+		for _, addr := range addrs {
+			wildcardIPs[addr.IP.String()] = true
+		}
+	}
+	return wildcardIPs
+}
+
+func randomString(n int) string {
+	const letters = "abcdefghijklmnopqrstuvwxyz"
+	r := rand.New(rand.NewSource(time.Now().UnixNano()))
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = letters[r.Intn(len(letters))]
+	}
+	return string(b)
 }
 
 func ResolveHostname(host string) ([]net.IP, error) {

--- a/internal/output/report_writer.go
+++ b/internal/output/report_writer.go
@@ -18,9 +18,11 @@ type ReportWriter struct {
 	OutputDir string
 }
 
-func NewReportWriter(outputDir string) *ReportWriter {
-	os.MkdirAll(outputDir, 0755)
-	return &ReportWriter{OutputDir: outputDir}
+func NewReportWriter(outputDir string) (*ReportWriter, error) {
+	if err := os.MkdirAll(outputDir, 0755); err != nil {
+		return nil, fmt.Errorf("create output directory: %w", err)
+	}
+	return &ReportWriter{OutputDir: outputDir}, nil
 }
 
 func (w *ReportWriter) WriteJSON(results []scanner.ScanResult) error {
@@ -47,7 +49,7 @@ func (w *ReportWriter) WriteCSV(results []scanner.ScanResult) error {
 	defer file.Close()
 	writer := csv.NewWriter(file)
 	defer writer.Flush()
-	header := []string{"Host", "Port", "Protocol", "Service", "Banner", "TLS", "TLS_Version", "TLS_Subject", "TLS_Issuer", "TLS_Expired", "TLS_SelfSigned", "Vulnerabilities"}
+	header := []string{"Host", "Port", "Protocol", "Service", "Version", "Banner", "TLS", "TLS_Version", "TLS_Subject", "TLS_Issuer", "TLS_Expired", "TLS_SelfSigned", "Vulnerabilities"}
 	if err := writer.Write(header); err != nil {
 		return fmt.Errorf("write csv header: %w", err)
 	}
@@ -71,6 +73,7 @@ func (w *ReportWriter) WriteCSV(results []scanner.ScanResult) error {
 			fmt.Sprintf("%d", res.Port),
 			res.Protocol,
 			res.Service,
+			res.Version,
 			res.Banner,
 			tlsEnabled,
 			tlsVersion,
@@ -87,25 +90,27 @@ func (w *ReportWriter) WriteCSV(results []scanner.ScanResult) error {
 }
 
 type JSONLWriter struct {
-	mu  sync.Mutex
-	enc *json.Encoder
-	w   io.WriteCloser
+	mu       sync.Mutex
+	enc      *json.Encoder
+	w        io.WriteCloser
+	Filename string
 }
 
 func NewJSONLWriter(outputDir string) (*JSONLWriter, error) {
 	var w io.WriteCloser
+	var filename string
 	if outputDir == "" || outputDir == "-" {
 		w = os.Stdout
 	} else {
 		os.MkdirAll(outputDir, 0755)
-		filename := filepath.Join(outputDir, fmt.Sprintf("scan-%s.jsonl", time.Now().Format("20060102-150405")))
+		filename = filepath.Join(outputDir, fmt.Sprintf("scan-%s.jsonl", time.Now().Format("20060102-150405")))
 		f, err := os.Create(filename)
 		if err != nil {
 			return nil, fmt.Errorf("create %s: %w", filename, err)
 		}
 		w = f
 	}
-	return &JSONLWriter{enc: json.NewEncoder(w), w: w}, nil
+	return &JSONLWriter{enc: json.NewEncoder(w), w: w, Filename: filename}, nil
 }
 
 func (jw *JSONLWriter) WriteResult(result scanner.ScanResult) error {

--- a/internal/scanner/cve.go
+++ b/internal/scanner/cve.go
@@ -19,10 +19,10 @@ type CVE struct {
 }
 
 type CVELookup struct {
-	client *http.Client
-	cache  map[string][]CVE
-	mu     sync.RWMutex
-	last   time.Time
+	client  *http.Client
+	cache   map[string][]CVE
+	mu      sync.Mutex
+	last    time.Time
 }
 
 func NewCVELookup() *CVELookup {
@@ -37,27 +37,21 @@ func (c *CVELookup) Lookup(cpe string) []CVE {
 		return nil
 	}
 
-	c.mu.RLock()
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
 	if cached, ok := c.cache[cpe]; ok {
-		c.mu.RUnlock()
 		return cached
 	}
-	c.mu.RUnlock()
 
-	c.mu.Lock()
 	elapsed := time.Since(c.last)
 	if elapsed < 6*time.Second {
 		time.Sleep(6*time.Second - elapsed)
 	}
 	c.last = time.Now()
-	c.mu.Unlock()
 
 	cves := c.queryNVD(cpe)
-
-	c.mu.Lock()
 	c.cache[cpe] = cves
-	c.mu.Unlock()
-
 	return cves
 }
 
@@ -69,7 +63,7 @@ func (c *CVELookup) queryNVD(cpe string) []CVE {
 		slog.Warn("NVD request build failed", "cpe", cpe, "err", err)
 		return nil
 	}
-	req.Header.Set("User-Agent", "flan-go-scan/1.0")
+	req.Header.Set("User-Agent", "flan/1.0")
 
 	resp, err := c.client.Do(req)
 	if err != nil {


### PR DESCRIPTION

- Rename cmd/flan-go-scan to cmd/flan with clean flag interface (-t, -l, -d, -p, -c, -w, -r) and custom help with ASCII banner.
- Remove old cmd/flan-go-scan. Fix DNS wordlist bugs, add wildcard detection and custom resolver support. 
- Fix CVE lookup race condition, DNS cache expiry leak, CSV missing version field, report writer error handling. 
- Auto-clear checkpoint on successful scan completion. 
- Print report path on scan finish.