### PR TITLE
Fix CVE mutex contention, parallelize host discovery, harden tests

### DIFF
--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -1,0 +1,37 @@
+name: Auto Tag
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: write
+
+jobs:
+  tag:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Get latest tag
+        id: latest
+        run: |
+          tag=$(git tag -l 'v*' --sort=-v:refname | head -1)
+          echo "tag=${tag:-v0.0.0}" >> "$GITHUB_OUTPUT"
+
+      - name: Bump patch version
+        id: bump
+        run: |
+          current="${{ steps.latest.outputs.tag }}"
+          major=$(echo "$current" | cut -d. -f1)
+          minor=$(echo "$current" | cut -d. -f2)
+          patch=$(echo "$current" | cut -d. -f3)
+          new="${major}.${minor}.$((patch + 1))"
+          echo "tag=${new}" >> "$GITHUB_OUTPUT"
+
+      - name: Create tag
+        run: |
+          git tag "${{ steps.bump.outputs.tag }}"
+          git push origin "${{ steps.bump.outputs.tag }}"

--- a/cmd/flan/main.go
+++ b/cmd/flan/main.go
@@ -147,18 +147,25 @@ func main() {
 	csvFlag := flag.Bool("csv", false, "")
 	flag.Parse()
 
-	cfgPath := coalesce(*configPath, *configShort)
-	ipsFile := coalesce(*listFile, *listShort)
-	tgt := coalesce(*target, *targetShort)
-	dom := coalesce(*domain, *domainShort)
-	portStr := coalesce(*portsFlag, *portsShort)
-	wl := coalesce(*wordlist, *wordlistShort)
-	res := coalesce(*resolver, *resolverShort)
+	set := make(map[string]bool)
+	flag.Visit(func(f *flag.Flag) { set[f.Name] = true })
+
+	cfgPath := pick(set, "config", configPath, "c", configShort, "config/config.yaml")
+	ipsFile := pick(set, "list", listFile, "l", listShort, "ips.txt")
+	tgt := pick(set, "target", target, "t", targetShort, "")
+	dom := pick(set, "domain", domain, "d", domainShort, "")
+	portStr := pick(set, "ports", portsFlag, "p", portsShort, "")
+	wl := pick(set, "wordlist", wordlist, "w", wordlistShort, "")
+	res := pick(set, "resolver", resolver, "r", resolverShort, "")
 
 	cfg, err := config.LoadConfig(cfgPath)
 	if err != nil {
 		slog.Error("config error", "err", err)
 		os.Exit(1)
+	}
+
+	if *passiveOnly && dom == "" {
+		slog.Warn("--passive-only has no effect without -d")
 	}
 
 	if *jsonFlag {
@@ -324,10 +331,28 @@ func main() {
 
 	if cfg.Scan.Discovery {
 		slog.Info("running host discovery", "targets", len(allIPs))
-		var alive []string
+		type aliveResult struct {
+			ip    string
+			alive bool
+		}
+		results := make(chan aliveResult, len(allIPs))
+		discoveryPool := scanner.NewWorkerPool(cfg.Scan.Workers)
+		var discoveryWg sync.WaitGroup
 		for _, ip := range allIPs {
-			if scanner.IsHostAlive(ip, cfg.Scan.Timeout) {
-				alive = append(alive, ip)
+			discoveryPool.Acquire()
+			discoveryWg.Add(1)
+			go func(ip string) {
+				defer discoveryWg.Done()
+				defer discoveryPool.Release()
+				results <- aliveResult{ip: ip, alive: scanner.IsHostAlive(ip, cfg.Scan.Timeout)}
+			}(ip)
+		}
+		discoveryWg.Wait()
+		close(results)
+		var alive []string
+		for r := range results {
+			if r.alive {
+				alive = append(alive, r.ip)
 			}
 		}
 		slog.Info("host discovery complete", "alive", len(alive), "filtered", len(allIPs)-len(alive))
@@ -507,12 +532,12 @@ func main() {
 	}
 }
 
-func coalesce(a, b string) string {
-	if a != "" && a != "config/config.yaml" && a != "ips.txt" {
-		return a
+func pick(set map[string]bool, long string, longVal *string, short string, shortVal *string, def string) string {
+	if set[long] {
+		return *longVal
 	}
-	if b != "" && b != "config/config.yaml" && b != "ips.txt" {
-		return b
+	if set[short] {
+		return *shortVal
 	}
-	return a
+	return def
 }

--- a/internal/scanner/cdn_test.go
+++ b/internal/scanner/cdn_test.go
@@ -5,22 +5,28 @@ import (
 	"testing"
 )
 
+func newTestDetector() *CDNDetector {
+	d := &CDNDetector{networks: make(map[string][]*net.IPNet)}
+	d.load("cloudflare", cloudflareCIDRsFallback)
+	return d
+}
+
 func TestCDNDetectorCloudflareIP(t *testing.T) {
-	d := NewCDNDetector()
+	d := newTestDetector()
 	if got := d.Detect("104.16.0.1"); got != "cloudflare" {
 		t.Fatalf("expected cloudflare, got %q", got)
 	}
 }
 
 func TestCDNDetectorNonCDNIP(t *testing.T) {
-	d := NewCDNDetector()
+	d := newTestDetector()
 	if got := d.Detect("8.8.8.8"); got != "" {
 		t.Fatalf("expected empty, got %q", got)
 	}
 }
 
 func TestCDNDetectorInvalidIP(t *testing.T) {
-	d := NewCDNDetector()
+	d := newTestDetector()
 	if got := d.Detect("not-an-ip"); got != "" {
 		t.Fatalf("expected empty for invalid input, got %q", got)
 	}
@@ -37,15 +43,8 @@ func TestCDNDetectorLoadAndDetect(t *testing.T) {
 	}
 }
 
-func TestFetchCloudflareCIDRsFallback(t *testing.T) {
+func TestFallbackCIDRsNotEmpty(t *testing.T) {
 	if len(cloudflareCIDRsFallback) == 0 {
 		t.Fatal("fallback list must not be empty")
-	}
-}
-
-func TestFetchCloudflareCIDRsLive(t *testing.T) {
-	cidrs := fetchCloudflareCIDRs()
-	if len(cidrs) == 0 {
-		t.Fatal("expected CIDRs from live fetch or fallback, got none")
 	}
 }

--- a/internal/scanner/cve.go
+++ b/internal/scanner/cve.go
@@ -21,7 +21,8 @@ type CVE struct {
 type CVELookup struct {
 	client  *http.Client
 	cache   map[string][]CVE
-	mu      sync.Mutex
+	mu      sync.RWMutex
+	rateMu  sync.Mutex
 	last    time.Time
 }
 
@@ -37,21 +38,27 @@ func (c *CVELookup) Lookup(cpe string) []CVE {
 		return nil
 	}
 
-	c.mu.Lock()
-	defer c.mu.Unlock()
-
+	c.mu.RLock()
 	if cached, ok := c.cache[cpe]; ok {
+		c.mu.RUnlock()
 		return cached
 	}
+	c.mu.RUnlock()
 
+	c.rateMu.Lock()
 	elapsed := time.Since(c.last)
 	if elapsed < 6*time.Second {
 		time.Sleep(6*time.Second - elapsed)
 	}
 	c.last = time.Now()
+	c.rateMu.Unlock()
 
 	cves := c.queryNVD(cpe)
+
+	c.mu.Lock()
 	c.cache[cpe] = cves
+	c.mu.Unlock()
+
 	return cves
 }
 


### PR DESCRIPTION

- Split CVE lookup into RWMutex for cache reads and separate rateMu for rate limiting so HTTP calls don't block all goroutines. 
- Parallelize host discovery using worker pool. 
- CDN tests use fallback CIDRs instead of live HTTP fetch. 
- Replace coalesce with flag.Visit-based pick. Warn when --passive-only used without -d. 
- Add auto-tag workflow on merge.