### PR TITLE
Add AI-powered scan analysis via Together API go library

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ A network scanner in Go. Successor to [Flan Scan](https://github.com/cloudflare/
 - Scan checkpointing and resumption
 - Progress reporting
 - Graceful shutdown on SIGINT/SIGTERM
+- AI-powered security analysis via [Together API](https://together.ai) (DeepSeek V3.1)
 - JSON, JSONL (streaming), CSV, and text output
 - Configurable via YAML
 
@@ -99,6 +100,12 @@ Scan all ports on CDN hosts (default is 80/443 only):
 flan -d example.com --scan-cdn
 ```
 
+Scan with AI-powered analysis (requires `TOGETHER_API_KEY`):
+
+```
+flan -t scanme.nmap.org --analyze
+```
+
 ## Flags
 
 | Flag | Description |
@@ -113,6 +120,7 @@ flan -d example.com --scan-cdn
 | `-r` | Custom DNS resolver (ip:port) |
 | `--passive-only` | Skip brute-force, use passive sources only |
 | `--scan-cdn` | Scan all ports on CDN hosts (default: 80/443 only) |
+| `--analyze` | AI security analysis via Together API (requires `TOGETHER_API_KEY`) |
 | `--json` | JSON output |
 | `--jsonl` | JSONL streaming output |
 | `--csv` | CSV output |

--- a/cmd/flan/main.go
+++ b/cmd/flan/main.go
@@ -32,7 +32,7 @@ const banner = `
 `
 
 func printBanner() {
-	fmt.Fprintf(os.Stderr, banner, version)
+	fmt.Fprintf(os.Stderr, "\033[36m"+banner+"\033[0m", version)
 }
 
 func usage() {
@@ -54,6 +54,7 @@ CONFIGURATION:
   -r, -resolver string     custom DNS resolver (ip:port)
   --passive-only           skip brute-force, use passive sources only
   --scan-cdn               scan all ports on CDN hosts (default: 80,443 only)
+  --analyze                AI-powered analysis via Together API (requires TOGETHER_API_KEY)
 
 OUTPUT:
   --json                   output in JSON format
@@ -142,6 +143,7 @@ func main() {
 	resolverShort := flag.String("r", "", "")
 	passiveOnly := flag.Bool("passive-only", false, "")
 	scanCDN := flag.Bool("scan-cdn", false, "")
+	analyze := flag.Bool("analyze", false, "")
 	jsonFlag := flag.Bool("json", false, "")
 	jsonlFlag := flag.Bool("jsonl", false, "")
 	csvFlag := flag.Bool("csv", false, "")
@@ -380,7 +382,8 @@ func main() {
 	if cfg.Scan.StatsInterval > 0 {
 		statsInterval = cfg.Scan.StatsInterval
 	}
-	go progress.Run(ctx, time.Duration(statsInterval)*time.Second)
+	progressCtx, stopProgress := context.WithCancel(ctx)
+	go progress.Run(progressCtx, time.Duration(statsInterval)*time.Second)
 
 	resultsCh := make(chan scanner.ScanResult, 100)
 	var collectWg sync.WaitGroup
@@ -394,7 +397,8 @@ func main() {
 				if err := jsonlWriter.WriteResult(res); err != nil {
 					slog.Error("failed to write JSONL result", "err", err)
 				}
-			} else {
+			}
+			if jsonlWriter == nil || *analyze {
 				results = append(results, res)
 			}
 		}
@@ -500,10 +504,24 @@ func main() {
 		checkpoint.Clear()
 	}
 
+	stopProgress()
+
 	slog.Info("scan complete",
 		"services_found", progress.ServicesFound.Load(),
 		"ports_scanned", progress.PortsScanned.Load(),
 	)
+
+	if *analyze && len(results) > 0 {
+		analysis, err := scanner.Analyze(ctx, results, cfg.Output.Directory)
+		if err != nil {
+			slog.Error("analysis failed", "err", err)
+		} else {
+			fmt.Println()
+			printAnalysis(analysis.Analysis)
+			fmt.Println("\033[2m  Powered by Together AI (deepseek-ai/DeepSeek-V3.1)\033[0m")
+			fmt.Println()
+		}
+	}
 
 	if jsonlWriter != nil {
 		if jsonlWriter.Filename != "" {
@@ -528,6 +546,47 @@ func main() {
 	default:
 		for _, res := range results {
 			fmt.Printf("%s:%d [%s %s] TLS:%v %s\n", res.Host, res.Port, res.Service, res.Version, res.TLS != nil, res.Banner)
+		}
+	}
+}
+
+func printAnalysis(text string) {
+	const (
+		red    = "\033[31m"
+		yellow = "\033[33m"
+		green  = "\033[32m"
+		cyan   = "\033[36m"
+		bold   = "\033[1m"
+		dim    = "\033[2m"
+		reset  = "\033[0m"
+	)
+
+	for _, line := range strings.Split(text, "\n") {
+		clean := strings.ReplaceAll(line, "**", "")
+		clean = strings.TrimLeft(clean, "# ")
+		clean = strings.TrimSpace(clean)
+		if clean == "" {
+			fmt.Println()
+			continue
+		}
+
+		switch {
+		case strings.Contains(clean, "CRITICAL"):
+			fmt.Println(bold + red + clean + reset)
+		case strings.Contains(clean, "HIGH"):
+			fmt.Println(red + clean + reset)
+		case strings.Contains(clean, "MEDIUM"):
+			fmt.Println(yellow + clean + reset)
+		case strings.Contains(clean, "LOW"):
+			fmt.Println(green + clean + reset)
+		case strings.Contains(clean, "INFO"):
+			fmt.Println(green + clean + reset)
+		case strings.HasPrefix(line, "---"):
+			fmt.Println(dim + "─────────────────────────────────────────" + reset)
+		case strings.HasPrefix(clean, "- "):
+			fmt.Println(dim + "  " + clean + reset)
+		default:
+			fmt.Println(clean)
 		}
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/praetorian-inc/fingerprintx v1.1.19
 	github.com/projectdiscovery/subfinder/v2 v2.12.0
 	github.com/spf13/viper v1.17.0
+	github.com/togethercomputer/together-go v0.6.0
 	golang.org/x/time v0.11.0
 )
 
@@ -114,6 +115,7 @@ require (
 	github.com/tidwall/match v1.1.1 // indirect
 	github.com/tidwall/pretty v1.2.1 // indirect
 	github.com/tidwall/rtred v0.1.2 // indirect
+	github.com/tidwall/sjson v1.2.5 // indirect
 	github.com/tidwall/tinyqueue v0.1.1 // indirect
 	github.com/tklauser/go-sysconf v0.3.12 // indirect
 	github.com/tklauser/numcpus v0.6.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -461,6 +461,7 @@ github.com/tidwall/btree v1.6.0/go.mod h1:twD9XRA5jj9VUQGELzDO4HPQTNJsoWWfYEL+EU
 github.com/tidwall/buntdb v1.3.0 h1:gdhWO+/YwoB2qZMeAU9JcWWsHSYU3OvcieYgFRS0zwA=
 github.com/tidwall/buntdb v1.3.0/go.mod h1:lZZrZUWzlyDJKlLQ6DKAy53LnG7m5kHyrEHvvcDmBpU=
 github.com/tidwall/gjson v1.12.1/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
+github.com/tidwall/gjson v1.14.2/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
 github.com/tidwall/gjson v1.18.0 h1:FIDeeyB800efLX89e5a8Y0BNH+LOngJyGrIWxG2FKQY=
 github.com/tidwall/gjson v1.18.0/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
 github.com/tidwall/grect v0.1.4 h1:dA3oIgNgWdSspFzn1kS4S/RDpZFLrIxAZOdJKjYapOg=
@@ -474,6 +475,8 @@ github.com/tidwall/pretty v1.2.1 h1:qjsOFOWWQl+N3RsoF5/ssm1pHmJJwhjlSbZ51I6wMl4=
 github.com/tidwall/pretty v1.2.1/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhsoaGGjNU=
 github.com/tidwall/rtred v0.1.2 h1:exmoQtOLvDoO8ud++6LwVsAMTu0KPzLTUrMln8u1yu8=
 github.com/tidwall/rtred v0.1.2/go.mod h1:hd69WNXQ5RP9vHd7dqekAz+RIdtfBogmglkZSRxCHFQ=
+github.com/tidwall/sjson v1.2.5 h1:kLy8mja+1c9jlljvWTlSazM7cKDRfJuR/bOJhcY5NcY=
+github.com/tidwall/sjson v1.2.5/go.mod h1:Fvgq9kS/6ociJEDnK0Fk1cpYF4FIW6ZF7LAe+6jwd28=
 github.com/tidwall/tinyqueue v0.1.1 h1:SpNEvEggbpyN5DIReaJ2/1ndroY8iyEGxPYxoSaymYE=
 github.com/tidwall/tinyqueue v0.1.1/go.mod h1:O/QNHwrnjqr6IHItYrzoHAKYhBkLI67Q096fQP5zMYw=
 github.com/tklauser/go-sysconf v0.3.11/go.mod h1:GqXfhXY3kiPa0nAXPDIQIWzJbMCB7AmcWpGR8lSZfqI=
@@ -482,6 +485,8 @@ github.com/tklauser/go-sysconf v0.3.12/go.mod h1:Ho14jnntGE1fpdOqQEEaiKRpvIavV0h
 github.com/tklauser/numcpus v0.6.0/go.mod h1:FEZLMke0lhOUG6w2JadTzp0a+Nl8PF/GFkQ5UVIcaL4=
 github.com/tklauser/numcpus v0.6.1 h1:ng9scYS7az0Bk4OZLvrNXNSAO2Pxr1XXRAPyjhIx+Fk=
 github.com/tklauser/numcpus v0.6.1/go.mod h1:1XfjsgE2zo8GVw7POkMbHENHzVg3GzmoZ9fESEdAacY=
+github.com/togethercomputer/together-go v0.6.0 h1:HmPaV73/+hNhfWyvVzjibmlRNsf5FgVeB6F57uAqWyY=
+github.com/togethercomputer/together-go v0.6.0/go.mod h1:ODvTTxqfKEhhx3T7KKFLcsV08shT77KeK8siOJ614k4=
 github.com/tomnomnom/linkheader v0.0.0-20180905144013-02ca5825eb80 h1:nrZ3ySNYwJbSpD6ce9duiP+QkD3JuLCcWkdaehUS/3Y=
 github.com/tomnomnom/linkheader v0.0.0-20180905144013-02ca5825eb80/go.mod h1:iFyPdL66DjUD96XmzVL3ZntbzcflLnznH0fr99w5VqE=
 github.com/ulikunitz/xz v0.5.8/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=

--- a/internal/scanner/analyze.go
+++ b/internal/scanner/analyze.go
@@ -1,0 +1,165 @@
+package scanner
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/togethercomputer/together-go"
+	"github.com/togethercomputer/together-go/option"
+)
+
+type AnalysisResult struct {
+	Timestamp string          `json:"timestamp"`
+	Model     string          `json:"model"`
+	Analysis  string          `json:"analysis"`
+	Usage     *AnalysisUsage  `json:"usage,omitempty"`
+}
+
+type AnalysisUsage struct {
+	PromptTokens     int64 `json:"prompt_tokens"`
+	CompletionTokens int64 `json:"completion_tokens"`
+	TotalTokens      int64 `json:"total_tokens"`
+}
+
+const systemPrompt = `You are a security expert analyzing network scan results. For each finding, provide:
+
+1. Severity (CRITICAL/HIGH/MEDIUM/LOW/INFO)
+2. What was found and why it matters
+3. Specific remediation steps
+
+Prioritize findings by risk. Be concise and actionable. Focus on:
+- Outdated software versions with known CVEs
+- Weak TLS configurations (deprecated versions, weak ciphers)
+- Exposed services that shouldn't be public
+- Missing security headers
+- Password authentication enabled on SSH
+- Default credentials risk
+
+Do not repeat raw scan data. Summarize and analyze.`
+
+func Analyze(ctx context.Context, results []ScanResult, outputDir string) (*AnalysisResult, error) {
+	apiKey := os.Getenv("TOGETHER_API_KEY")
+	if apiKey == "" {
+		return nil, fmt.Errorf("TOGETHER_API_KEY not set")
+	}
+
+	client := together.NewClient(option.WithAPIKey(apiKey))
+
+	summary := buildSummary(results)
+	slog.Info("sending scan results to Together AI for analysis", "services", len(results))
+
+	resp, err := client.Chat.Completions.New(ctx, together.ChatCompletionNewParams{
+		Model: "deepseek-ai/DeepSeek-V3.1",
+		Messages: []together.ChatCompletionNewParamsMessageUnion{
+			{
+				OfChatCompletionNewsMessageChatCompletionSystemMessageParam: &together.ChatCompletionNewParamsMessageChatCompletionSystemMessageParam{
+					Role:    "system",
+					Content: systemPrompt,
+				},
+			},
+			{
+				OfChatCompletionNewsMessageChatCompletionUserMessageParam: &together.ChatCompletionNewParamsMessageChatCompletionUserMessageParam{
+					Role: "user",
+					Content: together.ChatCompletionNewParamsMessageChatCompletionUserMessageParamContentUnion{
+						OfString: together.String(fmt.Sprintf("Analyze these network scan results:\n\n%s", summary)),
+					},
+				},
+			},
+		},
+		MaxTokens:   together.Int(2000),
+		Temperature: together.Float(0.3),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("together API call failed: %w", err)
+	}
+
+	if len(resp.Choices) == 0 {
+		return nil, fmt.Errorf("no response from model")
+	}
+
+	analysis := &AnalysisResult{
+		Timestamp: time.Now().Format(time.RFC3339),
+		Model:     "deepseek-ai/DeepSeek-V3.1",
+		Analysis:  resp.Choices[0].Message.Content,
+	}
+
+	if resp.Usage.TotalTokens > 0 {
+		analysis.Usage = &AnalysisUsage{
+			PromptTokens:     resp.Usage.PromptTokens,
+			CompletionTokens: resp.Usage.CompletionTokens,
+			TotalTokens:      resp.Usage.TotalTokens,
+		}
+	}
+
+	if outputDir != "" && outputDir != "-" {
+		filename := filepath.Join(outputDir, fmt.Sprintf("analysis-%s.json", time.Now().Format("20060102-150405")))
+		data, _ := json.MarshalIndent(analysis, "", "  ")
+		if err := os.WriteFile(filename, data, 0600); err != nil {
+			slog.Warn("failed to save analysis", "err", err)
+		} else {
+			slog.Info("analysis saved", "path", filename)
+		}
+	}
+
+	return analysis, nil
+}
+
+func buildSummary(results []ScanResult) string {
+	var b strings.Builder
+
+	hosts := make(map[string]bool)
+	for _, r := range results {
+		hosts[r.Host] = true
+	}
+	fmt.Fprintf(&b, "Scan summary: %d services found across %d hosts\n\n", len(results), len(hosts))
+
+	for _, r := range results {
+		fmt.Fprintf(&b, "Host: %s Port: %d Service: %s", r.Host, r.Port, r.Service)
+		if r.Version != "" {
+			fmt.Fprintf(&b, " Version: %s", r.Version)
+		}
+		if r.CDN != "" {
+			fmt.Fprintf(&b, " CDN: %s", r.CDN)
+		}
+		b.WriteString("\n")
+
+		if r.TLS != nil {
+			fmt.Fprintf(&b, "  TLS: %s %s", r.TLS.Version, r.TLS.CipherSuite)
+			if r.TLS.Expired {
+				b.WriteString(" [EXPIRED]")
+			}
+			if r.TLS.SelfSigned {
+				b.WriteString(" [SELF-SIGNED]")
+			}
+			fmt.Fprintf(&b, " Issuer: %s", r.TLS.Issuer)
+			b.WriteString("\n")
+		}
+
+		if len(r.Vulnerabilities) > 0 {
+			fmt.Fprintf(&b, "  CVEs: %s\n", strings.Join(r.Vulnerabilities, ", "))
+		}
+
+		if r.Metadata != nil {
+			var meta map[string]interface{}
+			if json.Unmarshal(r.Metadata, &meta) == nil {
+				if techs, ok := meta["technologies"]; ok {
+					fmt.Fprintf(&b, "  Technologies: %v\n", techs)
+				}
+				if algo, ok := meta["algo"]; ok {
+					fmt.Fprintf(&b, "  SSH Algorithms: %v\n", algo)
+				}
+				if pwAuth, ok := meta["passwordAuthEnabled"]; ok {
+					fmt.Fprintf(&b, "  Password Auth: %v\n", pwAuth)
+				}
+			}
+		}
+	}
+
+	return b.String()
+}


### PR DESCRIPTION

- Import together-go SDK. 
- Add --analyze flag that sends scan results to DeepSeek V3.1 via Together API for security analysis with prioritized findings, severity ratings, and remediation steps. 
- Color-coded terminal output with ANSI (CRITICAL=bold red, HIGH=red, MEDIUM=yellow, LOW=green).
- Saves analysis to reports directory. Requires TOGETHER_API_KEY env var.
- Cyan banner, progress ticker stops before analysis.