### PR TITLE
Add context propagation and UDP scanning

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ A network scanner in Go. Successor to [Flan Scan](https://github.com/cloudflare/
 - nmap top 100/1000 port lists
 - Scan checkpointing and resumption
 - Progress reporting
+- UDP service detection (DNS, NTP, SNMP, IPSEC) via `--udp`
+- Context-aware rate limiting and TLS inspection — clean shutdown on Ctrl+C
 - Graceful shutdown on SIGINT/SIGTERM
 - AI-powered security analysis via [Together API](https://together.ai) (DeepSeek V3.1)
 - JSON, JSONL (streaming), CSV, and text output
@@ -100,6 +102,12 @@ Scan all ports on CDN hosts (default is 80/443 only):
 flan -d example.com --scan-cdn
 ```
 
+Enable UDP scanning:
+
+```
+flan -t scanme.nmap.org --udp
+```
+
 Scan with AI-powered analysis (requires `TOGETHER_API_KEY`):
 
 ```
@@ -120,6 +128,7 @@ flan -t scanme.nmap.org --analyze
 | `-r` | Custom DNS resolver (ip:port) |
 | `--passive-only` | Skip brute-force, use passive sources only |
 | `--scan-cdn` | Scan all ports on CDN hosts (default: 80/443 only) |
+| `--udp` | Enable UDP scanning (ports 53, 123, 161, 500 by default) |
 | `--analyze` | AI security analysis via Together API (requires `TOGETHER_API_KEY`) |
 | `--json` | JSON output |
 | `--jsonl` | JSONL streaming output |

--- a/cmd/flan/main.go
+++ b/cmd/flan/main.go
@@ -54,6 +54,7 @@ CONFIGURATION:
   -r, -resolver string     custom DNS resolver (ip:port)
   --passive-only           skip brute-force, use passive sources only
   --scan-cdn               scan all ports on CDN hosts (default: 80,443 only)
+  --udp                    enable UDP scanning (ports 53,123,161,500 by default)
   --analyze                AI-powered analysis via Together API (requires TOGETHER_API_KEY)
 
 OUTPUT:
@@ -143,6 +144,7 @@ func main() {
 	resolverShort := flag.String("r", "", "")
 	passiveOnly := flag.Bool("passive-only", false, "")
 	scanCDN := flag.Bool("scan-cdn", false, "")
+	udpFlag := flag.Bool("udp", false, "")
 	analyze := flag.Bool("analyze", false, "")
 	jsonFlag := flag.Bool("json", false, "")
 	jsonlFlag := flag.Bool("jsonl", false, "")
@@ -430,7 +432,9 @@ func main() {
 				if ctx.Err() != nil {
 					return
 				}
-				limiter.Wait()
+				if err := limiter.Wait(ctx); err != nil {
+					return
+				}
 				progress.PortsScanned.Add(1)
 
 				fp := scanner.Fingerprint(ip, port, cfg.Scan.Timeout)
@@ -438,7 +442,7 @@ func main() {
 					progress.ServicesFound.Add(1)
 					var tlsResult *scanner.TLSResult
 					if fp.TLS {
-						tlsResult = scanner.InspectTLS(ip, port, cfg.Scan.Timeout)
+						tlsResult = scanner.InspectTLS(ctx, ip, port, cfg.Scan.Timeout)
 					}
 
 					var vulns []string
@@ -476,7 +480,7 @@ func main() {
 				}
 
 				progress.ServicesFound.Add(1)
-				tlsResult := scanner.InspectTLS(ip, port, cfg.Scan.Timeout)
+				tlsResult := scanner.InspectTLS(ctx, ip, port, cfg.Scan.Timeout)
 				resultsCh <- scanner.ScanResult{
 					Host:     ip,
 					Port:     port,
@@ -493,6 +497,54 @@ func main() {
 		progress.HostsDone.Add(1)
 	}
 	wg.Wait()
+
+	udpEnabled := *udpFlag || cfg.Scan.UDP
+	if udpEnabled {
+		udpPortStr := cfg.Scan.UDPPorts
+		udpPorts, err := parsePorts(udpPortStr)
+		if err != nil {
+			slog.Error("invalid UDP port configuration", "err", err)
+			os.Exit(1)
+		}
+		var udpWg sync.WaitGroup
+		for _, ip := range allIPs {
+			if ctx.Err() != nil {
+				break
+			}
+			for _, port := range udpPorts {
+				if ctx.Err() != nil {
+					break
+				}
+				pool.Acquire()
+				udpWg.Add(1)
+				go func(ip string, port int) {
+					defer udpWg.Done()
+					defer pool.Release()
+					if ctx.Err() != nil {
+						return
+					}
+					if err := limiter.Wait(ctx); err != nil {
+						return
+					}
+					fp := scanner.FingerprintUDP(ip, port, cfg.Scan.Timeout)
+					if fp == nil {
+						return
+					}
+					progress.ServicesFound.Add(1)
+					resultsCh <- scanner.ScanResult{
+						Host:     ip,
+						Port:     port,
+						Protocol: "udp",
+						Service:  fp.Service,
+						Version:  fp.Version,
+						Metadata: fp.Metadata,
+					}
+				}(ip, port)
+			}
+		}
+		udpWg.Wait()
+	}
+
 	close(resultsCh)
 	collectWg.Wait()
 

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -5,6 +5,8 @@ scan:
   workers: 100
   discovery: true
   stats_interval: 5
+  udp: false
+  udp_ports: "53,123,161,500"
 dns:
   ttl: 10m
 output:

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -14,6 +14,8 @@ type Config struct {
 		Workers       int           `mapstructure:"workers"`
 		Discovery     bool          `mapstructure:"discovery"`
 		StatsInterval int           `mapstructure:"stats_interval"`
+		UDP           bool          `mapstructure:"udp"`
+		UDPPorts      string        `mapstructure:"udp_ports"`
 	} `mapstructure:"scan"`
 	DNS struct {
 		TTL time.Duration `mapstructure:"ttl"`

--- a/internal/scanner/fingerprint.go
+++ b/internal/scanner/fingerprint.go
@@ -19,6 +19,14 @@ type FingerprintResult struct {
 }
 
 func Fingerprint(host string, port int, timeout time.Duration) *FingerprintResult {
+	return fingerprint(host, port, timeout, false)
+}
+
+func FingerprintUDP(host string, port int, timeout time.Duration) *FingerprintResult {
+	return fingerprint(host, port, timeout, true)
+}
+
+func fingerprint(host string, port int, timeout time.Duration, udp bool) *FingerprintResult {
 	addr, err := netip.ParseAddrPort(fmt.Sprintf("%s:%d", host, port))
 	if err != nil {
 		return nil
@@ -33,6 +41,7 @@ func Fingerprint(host string, port int, timeout time.Duration) *FingerprintResul
 		DefaultTimeout: timeout,
 		FastMode:       false,
 		Verbose:        false,
+		UDP:            udp,
 	}
 
 	result, err := cfg.SimpleScanTarget(target)

--- a/internal/scanner/rate_limiter.go
+++ b/internal/scanner/rate_limiter.go
@@ -16,6 +16,6 @@ func NewRateLimiter(rps int) *RateLimiter {
 	}
 }
 
-func (rl *RateLimiter) Wait() {
-	rl.limiter.Wait(context.Background())
+func (rl *RateLimiter) Wait(ctx context.Context) error {
+	return rl.limiter.Wait(ctx)
 }

--- a/internal/scanner/tls_detection.go
+++ b/internal/scanner/tls_detection.go
@@ -1,6 +1,7 @@
 package scanner
 
 import (
+	"context"
 	"crypto/tls"
 	"fmt"
 	"net"
@@ -20,9 +21,10 @@ type TLSResult struct {
 	SelfSigned  bool      `json:"self_signed,omitempty"`
 }
 
-func InspectTLS(host string, port int, timeout time.Duration) *TLSResult {
+func InspectTLS(ctx context.Context, host string, port int, timeout time.Duration) *TLSResult {
 	addr := net.JoinHostPort(host, fmt.Sprintf("%d", port))
-	conn, err := net.DialTimeout("tcp", addr, timeout)
+	d := net.Dialer{Timeout: timeout}
+	conn, err := d.DialContext(ctx, "tcp", addr)
 	if err != nil {
 		return nil
 	}

--- a/internal/scanner/tls_detection_test.go
+++ b/internal/scanner/tls_detection_test.go
@@ -1,6 +1,7 @@
 package scanner
 
 import (
+	"context"
 	"testing"
 	"time"
 )
@@ -41,7 +42,7 @@ func TestTLSVersionString(t *testing.T) {
 }
 
 func TestInspectTLSClosedPort(t *testing.T) {
-	result := InspectTLS("127.0.0.1", 1, 100*time.Millisecond)
+	result := InspectTLS(context.Background(), "127.0.0.1", 1, 100*time.Millisecond)
 	if result != nil {
 		t.Error("expected nil for closed port")
 	}


### PR DESCRIPTION

- RateLimiter.Wait() and InspectTLS() now accept context — clean shutdown on Ctrl+C                                
- UDP scanning via --udp flag using fingerprintx's UDP mode
- Default UDP ports: 53, 123, 161, 500                                                                             
- UDP results go through the same pipeline as TCP 