### PR TITLE
Add web crawler, app fingerprinting, and pretty CLI output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ reports/
 scan-state.json
 flan-go-scan
 flan
+PLAN.md

--- a/README.md
+++ b/README.md
@@ -21,9 +21,11 @@ A network scanner in Go. Successor to [Flan Scan](https://github.com/cloudflare/
 - Scan checkpointing and resumption
 - Progress reporting
 - UDP service detection (DNS, NTP, SNMP, IPSEC) via `--udp`
+- Web crawler with app fingerprinting via `--crawl` (path, header, and cookie-based detection for 60+ CMSes, frameworks, and admin tools)
 - Context-aware rate limiting and TLS inspection — clean shutdown on Ctrl+C
 - Graceful shutdown on SIGINT/SIGTERM
-- AI-powered security analysis via [Together API](https://together.ai) (DeepSeek V3.1)
+- AI-powered security analysis via [Together API](https://together.ai) (DeepSeek V3.1) — brief summary on every scan, detailed report with `--analyze`
+- Pretty streaming CLI output with TTY detection (JSONL when piping)
 - JSON, JSONL (streaming), CSV, and text output
 - Configurable via YAML
 
@@ -108,7 +110,19 @@ Enable UDP scanning:
 flan -t scanme.nmap.org --udp
 ```
 
-Scan with AI-powered analysis (requires `TOGETHER_API_KEY`):
+Crawl HTTP/HTTPS services for endpoints, sensitive paths, and app fingerprinting:
+
+```
+flan -t example.com --crawl
+```
+
+Crawl with custom depth:
+
+```
+flan -t example.com --crawl --crawl-depth 3
+```
+
+Scan with detailed AI-powered analysis (requires `TOGETHER_API_KEY`):
 
 ```
 flan -t scanme.nmap.org --analyze
@@ -129,7 +143,9 @@ flan -t scanme.nmap.org --analyze
 | `--passive-only` | Skip brute-force, use passive sources only |
 | `--scan-cdn` | Scan all ports on CDN hosts (default: 80/443 only) |
 | `--udp` | Enable UDP scanning (ports 53, 123, 161, 500 by default) |
-| `--analyze` | AI security analysis via Together API (requires `TOGETHER_API_KEY`) |
+| `--crawl` | Crawl HTTP/HTTPS services for endpoints, sensitive paths, and app fingerprinting |
+| `--crawl-depth` | Max crawl depth (default: 2) |
+| `--analyze` | Detailed AI security analysis via Together API (requires `TOGETHER_API_KEY`) |
 | `--json` | JSON output |
 | `--jsonl` | JSONL streaming output |
 | `--csv` | CSV output |

--- a/cmd/flan/main.go
+++ b/cmd/flan/main.go
@@ -55,6 +55,8 @@ CONFIGURATION:
   --passive-only           skip brute-force, use passive sources only
   --scan-cdn               scan all ports on CDN hosts (default: 80,443 only)
   --udp                    enable UDP scanning (ports 53,123,161,500 by default)
+  --crawl                  crawl HTTP/HTTPS services for endpoints and sensitive paths
+  --crawl-depth int        max crawl depth (default: 2)
   --analyze                AI-powered analysis via Together API (requires TOGETHER_API_KEY)
 
 OUTPUT:
@@ -145,6 +147,8 @@ func main() {
 	passiveOnly := flag.Bool("passive-only", false, "")
 	scanCDN := flag.Bool("scan-cdn", false, "")
 	udpFlag := flag.Bool("udp", false, "")
+	crawlFlag := flag.Bool("crawl", false, "")
+	crawlDepth := flag.Int("crawl-depth", 0, "")
 	analyze := flag.Bool("analyze", false, "")
 	jsonFlag := flag.Bool("json", false, "")
 	jsonlFlag := flag.Bool("jsonl", false, "")
@@ -168,6 +172,10 @@ func main() {
 		os.Exit(1)
 	}
 
+	if set["crawl-depth"] && *crawlDepth > 0 {
+		cfg.Scan.CrawlDepth = *crawlDepth
+	}
+
 	if *passiveOnly && dom == "" {
 		slog.Warn("--passive-only has no effect without -d")
 	}
@@ -180,6 +188,16 @@ func main() {
 	}
 	if *csvFlag {
 		cfg.Output.Format = "csv"
+	}
+
+	fi, _ := os.Stdout.Stat()
+	isTTY := (fi.Mode() & os.ModeCharDevice) != 0
+	prettyMode := isTTY && !*jsonFlag && !*jsonlFlag && !*csvFlag
+	if prettyMode {
+		if cfg.Output.Directory == "-" {
+			cfg.Output.Directory = "reports"
+		}
+		cfg.Output.Format = "jsonl"
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -384,7 +402,9 @@ func main() {
 		statsInterval = cfg.Scan.StatsInterval
 	}
 	progressCtx, stopProgress := context.WithCancel(ctx)
-	go progress.Run(progressCtx, time.Duration(statsInterval)*time.Second)
+	if !prettyMode {
+		go progress.Run(progressCtx, time.Duration(statsInterval)*time.Second)
+	}
 
 	resultsCh := make(chan scanner.ScanResult, 100)
 	var collectWg sync.WaitGroup
@@ -399,7 +419,10 @@ func main() {
 					slog.Error("failed to write JSONL result", "err", err)
 				}
 			}
-			if jsonlWriter == nil || *analyze {
+			if prettyMode {
+				printResult(res)
+			}
+			if jsonlWriter == nil || *analyze || prettyMode {
 				results = append(results, res)
 			}
 		}
@@ -458,6 +481,12 @@ func main() {
 						}
 					}
 
+					var endpoints []scanner.CrawlResult
+					var appFP *scanner.AppFingerprint
+					if *crawlFlag && scanner.IsHTTPService(fp.Service, port, fp.TLS) {
+						endpoints, appFP = scanner.Crawl(ctx, scanner.HTTPScheme(fp.TLS), ip, port, cfg.Scan.CrawlDepth, cfg.Scan.Timeout, 100*time.Millisecond)
+					}
+
 					resultsCh <- scanner.ScanResult{
 						Host:            ip,
 						Port:            port,
@@ -468,6 +497,8 @@ func main() {
 						TLS:             tlsResult,
 						Metadata:        fp.Metadata,
 						Vulnerabilities: vulns,
+						Endpoints:       endpoints,
+						App:             appFP,
 					}
 					checkpoint.Save(ip, port)
 					return
@@ -480,15 +511,25 @@ func main() {
 
 				progress.ServicesFound.Add(1)
 				tlsResult := scanner.InspectTLS(ctx, ip, port, cfg.Scan.Timeout)
+
+				var endpoints []scanner.CrawlResult
+				var appFP *scanner.AppFingerprint
+				if *crawlFlag && scanner.IsHTTPService(svc.Name, port, tlsResult != nil) {
+					hasTLS := tlsResult != nil || port == 443 || port == 8443 || port == 4443
+					endpoints, appFP = scanner.Crawl(ctx, scanner.HTTPScheme(hasTLS), ip, port, cfg.Scan.CrawlDepth, cfg.Scan.Timeout, 100*time.Millisecond)
+				}
+
 				resultsCh <- scanner.ScanResult{
-					Host:     ip,
-					Port:     port,
-					Protocol: "tcp",
-					Service:  svc.Name,
-					Version:  svc.Version,
-					Banner:   svc.Banner,
-					CDN:      cdn,
-					TLS:      tlsResult,
+					Host:      ip,
+					Port:      port,
+					Protocol:  "tcp",
+					Service:   svc.Name,
+					Version:   svc.Version,
+					Banner:    svc.Banner,
+					CDN:       cdn,
+					TLS:       tlsResult,
+					Endpoints: endpoints,
+					App:       appFP,
 				}
 				checkpoint.Save(ip, port)
 			}(ip, port)
@@ -562,6 +603,18 @@ func main() {
 		"ports_scanned", progress.PortsScanned.Load(),
 	)
 
+	if prettyMode && !*analyze && os.Getenv("TOGETHER_API_KEY") != "" && len(results) > 0 {
+		fmt.Print("\033[2m  Analyzing...\033[0m\r")
+		brief, err := scanner.AnalyzeBrief(ctx, results)
+		fmt.Print("                \r")
+		if err == nil {
+			fmt.Println()
+			printAnalysis(brief)
+			fmt.Println("\033[2m  Powered by Together AI (deepseek-ai/DeepSeek-V3.1)\033[0m")
+			fmt.Println()
+		}
+	}
+
 	if *analyze && len(results) > 0 {
 		analysis, err := scanner.Analyze(ctx, results, cfg.Output.Directory)
 		if err != nil {
@@ -606,6 +659,77 @@ func main() {
 			fmt.Printf("%s:%d [%s %s] TLS:%v %s\n", res.Host, res.Port, res.Service, res.Version, res.TLS != nil, res.Banner)
 		}
 	}
+}
+
+func printResult(res scanner.ScanResult) {
+	const (
+		bold   = "\033[1m"
+		dim    = "\033[2m"
+		red    = "\033[31m"
+		yellow = "\033[33m"
+		green  = "\033[32m"
+		cyan   = "\033[36m"
+		reset  = "\033[0m"
+	)
+
+	tls := ""
+	if res.TLS != nil {
+		tls = dim + "  " + res.TLS.Version + reset
+		if res.TLS.Expired {
+			tls += red + " (expired)" + reset
+		}
+	}
+
+	version := ""
+	if res.Version != "" {
+		version = "  " + res.Version
+	}
+
+	fmt.Printf("%s%-21s%s  %s%-10s%s%s%s\n",
+		bold+cyan, fmt.Sprintf("%s:%d", res.Host, res.Port), reset,
+		cyan, res.Service, reset,
+		version, tls,
+	)
+
+	if res.App != nil {
+		var parts []string
+		if res.App.Server != "" {
+			parts = append(parts, res.App.Server)
+		}
+		if res.App.PoweredBy != "" {
+			parts = append(parts, res.App.PoweredBy)
+		}
+		if res.App.Generator != "" {
+			parts = append(parts, res.App.Generator)
+		}
+		if len(res.App.Apps) > 0 {
+			parts = append(parts, strings.Join(res.App.Apps, ", "))
+		}
+		if len(parts) > 0 {
+			fmt.Printf("  %sapp%s  %s\n", cyan, reset, strings.Join(parts, "  ·  "))
+		}
+	}
+
+	for _, cve := range res.Vulnerabilities {
+		fmt.Printf("  %s⚠  %s%s\n", red, cve, reset)
+	}
+
+	for _, ep := range res.Endpoints {
+		if ep.StatusCode == 404 {
+			continue
+		}
+		statusColor := green
+		if ep.StatusCode >= 300 {
+			statusColor = yellow
+		}
+		title := ""
+		if ep.Title != "" {
+			title = dim + "  \"" + ep.Title + "\"" + reset
+		}
+		fmt.Printf("  %s%d%s  %-32s%s\n", statusColor, ep.StatusCode, reset, ep.Path, title)
+	}
+
+	fmt.Println()
 }
 
 func printAnalysis(text string) {

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -7,6 +7,7 @@ scan:
   stats_interval: 5
   udp: false
   udp_ports: "53,123,161,500"
+  crawl_depth: 2
 dns:
   ttl: 10m
 output:

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,8 @@ require (
 	github.com/projectdiscovery/subfinder/v2 v2.12.0
 	github.com/spf13/viper v1.17.0
 	github.com/togethercomputer/together-go v0.6.0
+	golang.org/x/net v0.47.0
+	golang.org/x/sync v0.18.0
 	golang.org/x/time v0.11.0
 )
 
@@ -134,9 +136,7 @@ require (
 	golang.org/x/crypto v0.45.0 // indirect
 	golang.org/x/exp v0.0.0-20250106191152-7588d65b2ba8 // indirect
 	golang.org/x/mod v0.29.0 // indirect
-	golang.org/x/net v0.47.0 // indirect
 	golang.org/x/oauth2 v0.27.0 // indirect
-	golang.org/x/sync v0.18.0 // indirect
 	golang.org/x/sys v0.38.0 // indirect
 	golang.org/x/term v0.37.0 // indirect
 	golang.org/x/text v0.31.0 // indirect

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -17,6 +17,7 @@ type Config struct {
 		StatsInterval int           `mapstructure:"stats_interval"`
 		UDP           bool          `mapstructure:"udp"`
 		UDPPorts      string        `mapstructure:"udp_ports"`
+		CrawlDepth    int           `mapstructure:"crawl_depth"`
 	} `mapstructure:"scan"`
 	DNS struct {
 		TTL time.Duration `mapstructure:"ttl"`
@@ -40,6 +41,7 @@ func defaults() *Config {
 	cfg.Scan.StatsInterval = 5
 	cfg.Scan.UDP = false
 	cfg.Scan.UDPPorts = "53,123,161,500"
+	cfg.Scan.CrawlDepth = 2
 	cfg.DNS.TTL = 10 * time.Minute
 	cfg.Output.Format = "jsonl"
 	cfg.Output.Directory = "-"

--- a/internal/scanner/analyze.go
+++ b/internal/scanner/analyze.go
@@ -15,10 +15,10 @@ import (
 )
 
 type AnalysisResult struct {
-	Timestamp string          `json:"timestamp"`
-	Model     string          `json:"model"`
-	Analysis  string          `json:"analysis"`
-	Usage     *AnalysisUsage  `json:"usage,omitempty"`
+	Timestamp string         `json:"timestamp"`
+	Model     string         `json:"model"`
+	Analysis  string         `json:"analysis"`
+	Usage     *AnalysisUsage `json:"usage,omitempty"`
 }
 
 type AnalysisUsage struct {
@@ -26,6 +26,11 @@ type AnalysisUsage struct {
 	CompletionTokens int64 `json:"completion_tokens"`
 	TotalTokens      int64 `json:"total_tokens"`
 }
+
+const briefSystemPrompt = `You are a security expert. Summarize the scan results in 3-5 bullet points.
+Focus only on the most critical/high severity issues and quick wins.
+For unknown or unidentified services, analyze the port number itself -- ports have well-known security associations (e.g., 31337 = Back Orifice/elite malware, 4444 = Metasploit default, 9929 = nping-echo, 1337, 6666, etc.). Flag any suspicious or non-standard ports explicitly.
+Be terse and actionable. No preamble or closing remarks.`
 
 const systemPrompt = `You are a security expert analyzing network scan results. For each finding, provide:
 
@@ -40,6 +45,7 @@ Prioritize findings by risk. Be concise and actionable. Focus on:
 - Missing security headers
 - Password authentication enabled on SSH
 - Default credentials risk
+- Unknown or unidentified services: analyze the port number itself for well-known associations (e.g., 31337 = Back Orifice/elite malware, 4444 = Metasploit, 9929 = nping-echo, 6666 = IRC/malware, 1337, etc.) and flag suspicious ports explicitly
 
 Do not repeat raw scan data. Summarize and analyze.`
 
@@ -110,6 +116,47 @@ func Analyze(ctx context.Context, results []ScanResult, outputDir string) (*Anal
 	return analysis, nil
 }
 
+func AnalyzeBrief(ctx context.Context, results []ScanResult) (string, error) {
+	apiKey := os.Getenv("TOGETHER_API_KEY")
+	if apiKey == "" {
+		return "", fmt.Errorf("TOGETHER_API_KEY not set")
+	}
+
+	client := together.NewClient(option.WithAPIKey(apiKey))
+	summary := buildSummary(results)
+
+	resp, err := client.Chat.Completions.New(ctx, together.ChatCompletionNewParams{
+		Model: "deepseek-ai/DeepSeek-V3.1",
+		Messages: []together.ChatCompletionNewParamsMessageUnion{
+			{
+				OfChatCompletionNewsMessageChatCompletionSystemMessageParam: &together.ChatCompletionNewParamsMessageChatCompletionSystemMessageParam{
+					Role:    "system",
+					Content: briefSystemPrompt,
+				},
+			},
+			{
+				OfChatCompletionNewsMessageChatCompletionUserMessageParam: &together.ChatCompletionNewParamsMessageChatCompletionUserMessageParam{
+					Role: "user",
+					Content: together.ChatCompletionNewParamsMessageChatCompletionUserMessageParamContentUnion{
+						OfString: together.String(fmt.Sprintf("Summarize:\n\n%s", summary)),
+					},
+				},
+			},
+		},
+		MaxTokens:   together.Int(400),
+		Temperature: together.Float(0.2),
+	})
+	if err != nil {
+		return "", fmt.Errorf("together API call failed: %w", err)
+	}
+
+	if len(resp.Choices) == 0 {
+		return "", fmt.Errorf("no response from model")
+	}
+
+	return resp.Choices[0].Message.Content, nil
+}
+
 func buildSummary(results []ScanResult) string {
 	var b strings.Builder
 
@@ -143,6 +190,35 @@ func buildSummary(results []ScanResult) string {
 
 		if len(r.Vulnerabilities) > 0 {
 			fmt.Fprintf(&b, "  CVEs: %s\n", strings.Join(r.Vulnerabilities, ", "))
+		}
+
+		if r.App != nil {
+			if r.App.Server != "" {
+				fmt.Fprintf(&b, "  Server: %s\n", r.App.Server)
+			}
+			if r.App.PoweredBy != "" {
+				fmt.Fprintf(&b, "  Powered-By: %s\n", r.App.PoweredBy)
+			}
+			if r.App.Generator != "" {
+				fmt.Fprintf(&b, "  Generator: %s\n", r.App.Generator)
+			}
+			if len(r.App.Apps) > 0 {
+				fmt.Fprintf(&b, "  Detected apps: %s\n", strings.Join(r.App.Apps, ", "))
+			}
+		}
+
+		if len(r.Endpoints) > 0 {
+			fmt.Fprintf(&b, "  Endpoints:\n")
+			for _, ep := range r.Endpoints {
+				fmt.Fprintf(&b, "    %d %s", ep.StatusCode, ep.Path)
+				if ep.Title != "" {
+					fmt.Fprintf(&b, " [%s]", ep.Title)
+				}
+				if ep.RedirectTo != "" {
+					fmt.Fprintf(&b, " -> %s", ep.RedirectTo)
+				}
+				b.WriteString("\n")
+			}
 		}
 
 		if r.Metadata != nil {

--- a/internal/scanner/crawl.go
+++ b/internal/scanner/crawl.go
@@ -1,0 +1,560 @@
+package scanner
+
+import (
+	"bufio"
+	"context"
+	"crypto/tls"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"golang.org/x/net/html"
+)
+
+type CrawlResult struct {
+	Path        string `json:"path"`
+	StatusCode  int    `json:"status_code"`
+	ContentType string `json:"content_type,omitempty"`
+	Title       string `json:"title,omitempty"`
+	RedirectTo  string `json:"redirect_to,omitempty"`
+}
+
+type AppFingerprint struct {
+	Server    string   `json:"server,omitempty"`
+	PoweredBy string   `json:"powered_by,omitempty"`
+	Generator string   `json:"generator,omitempty"`
+	Apps      []string `json:"apps,omitempty"`
+}
+
+var sensitivePaths = []string{
+	"/.env", "/.env.local", "/.env.production", "/.env.backup",
+	"/.git/HEAD", "/.git/config",
+	"/config.php.bak", "/wp-config.php.bak", "/configuration.php.bak",
+	"/.htaccess", "/web.config",
+	"/robots.txt", "/sitemap.xml", "/.well-known/security.txt",
+	"/readme.html", "/README.md", "/CHANGELOG.txt", "/LICENSE.txt",
+	"/admin", "/admin/", "/login", "/signin", "/dashboard",
+	"/api", "/api/v1", "/api/v2", "/api/docs",
+	"/swagger", "/swagger-ui", "/swagger-ui.html", "/swagger.json", "/openapi.json",
+	"/graphql", "/graphiql",
+	"/debug/pprof", "/__debug__/",
+	"/wp-login.php", "/wp-admin/", "/wp-content/", "/wp-includes/", "/xmlrpc.php", "/wp-json/",
+	"/administrator/", "/components/", "/templates/",
+	"/user/login", "/sites/default/", "/core/misc/",
+	"/typo3/", "/typo3temp/", "/typo3conf/",
+	"/magento/", "/skin/frontend/", "/index.php/admin/",
+	"/ghost/", "/ghost/signin",
+	"/umbraco/", "/umbraco/backoffice/",
+	"/wiki/", "/w/index.php",
+	"/phpbb/", "/forum/", "/viewtopic.php",
+	"/moodle/", "/course/view.php",
+	"/concrete/", "/application/",
+	"/elmah.axd", "/trace.axd", "/WebResource.axd", "/ScriptResource.axd",
+	"/phpmyadmin/", "/phpmyadmin/index.php", "/pma/",
+	"/adminer/", "/adminer.php", "/pgadmin/", "/pgadmin4/",
+	"/actuator/", "/actuator/health", "/actuator/info", "/actuator/env",
+	"/_debugbar/", "/laravel/",
+	"/rails/info/", "/rails/info/properties",
+	"/django-admin/",
+	"/cfide/", "/CFIDE/administrator/",
+	"/jenkins/", "/jenkins/view/all/",
+	"/gitlab/", "/users/sign_in",
+	"/gitea/", "/user/sign_in",
+	"/bitbucket/",
+	"/grafana/", "/grafana/login",
+	"/kibana/", "/app/kibana",
+	"/prometheus/", "/metrics", "/-/healthy",
+	"/netdata/", "/netdata/index.html",
+	"/zabbix/", "/nagios/",
+	"/portainer/", "/portainer/api/",
+	"/rancher/", "/dashboard/",
+	"/traefik/", "/traefik/dashboard/",
+	"/auth/admin/", "/auth/realms/", "/keycloak/",
+	"/vault/", "/v1/sys/health",
+	"/consul/", "/v1/agent/self",
+	"/nexus/", "/repository/",
+	"/artifactory/", "/jfrog/",
+	"/sonarqube/", "/sonar/",
+	"/harbor/",
+	"/roundcube/", "/webmail/", "/zimbra/", "/owa/",
+	"/cpanel", "/whm", "/plesk/", "/directadmin/",
+	"/session_login.cgi",
+	"/_cat/health", "/_nodes", "/solr/",
+}
+
+var pathTech = map[string]string{
+	"/wp-login.php":          "WordPress",
+	"/wp-admin/":             "WordPress",
+	"/wp-content/":           "WordPress",
+	"/wp-includes/":          "WordPress",
+	"/xmlrpc.php":            "WordPress",
+	"/wp-json/":              "WordPress",
+	"/wp-config.php.bak":     "WordPress",
+	"/administrator/":        "Joomla",
+	"/components/":           "Joomla",
+	"/templates/":            "Joomla",
+	"/user/login":            "Drupal",
+	"/sites/default/":        "Drupal",
+	"/core/misc/":            "Drupal",
+	"/CHANGELOG.txt":         "Drupal",
+	"/typo3/":                "TYPO3",
+	"/typo3temp/":            "TYPO3",
+	"/typo3conf/":            "TYPO3",
+	"/magento/":              "Magento",
+	"/skin/frontend/":        "Magento",
+	"/ghost/":                "Ghost",
+	"/ghost/signin":          "Ghost",
+	"/umbraco/":              "Umbraco",
+	"/umbraco/backoffice/":   "Umbraco",
+	"/wiki/":                 "MediaWiki",
+	"/w/index.php":           "MediaWiki",
+	"/phpbb/":                "phpBB",
+	"/moodle/":               "Moodle",
+	"/course/view.php":       "Moodle",
+	"/concrete/":             "Concrete CMS",
+	"/elmah.axd":             "ASP.NET",
+	"/trace.axd":             "ASP.NET",
+	"/WebResource.axd":       "ASP.NET",
+	"/ScriptResource.axd":    "ASP.NET",
+	"/phpmyadmin/":           "phpMyAdmin",
+	"/phpmyadmin/index.php":  "phpMyAdmin",
+	"/pma/":                  "phpMyAdmin",
+	"/adminer/":              "Adminer",
+	"/adminer.php":           "Adminer",
+	"/pgadmin/":              "pgAdmin",
+	"/pgadmin4/":             "pgAdmin",
+	"/actuator/":             "Spring Boot",
+	"/actuator/health":       "Spring Boot",
+	"/actuator/info":         "Spring Boot",
+	"/actuator/env":          "Spring Boot",
+	"/_debugbar/":            "Laravel",
+	"/laravel/":              "Laravel",
+	"/rails/info/":           "Ruby on Rails",
+	"/rails/info/properties": "Ruby on Rails",
+	"/django-admin/":         "Django",
+	"/__debug__/":            "Django",
+	"/cfide/":                "ColdFusion",
+	"/CFIDE/administrator/":  "ColdFusion",
+	"/jenkins/":              "Jenkins",
+	"/jenkins/view/all/":     "Jenkins",
+	"/users/sign_in":         "GitLab",
+	"/gitlab/":               "GitLab",
+	"/user/sign_in":          "Gitea",
+	"/grafana/":              "Grafana",
+	"/grafana/login":         "Grafana",
+	"/kibana/":               "Kibana",
+	"/app/kibana":            "Kibana",
+	"/prometheus/":           "Prometheus",
+	"/metrics":               "Prometheus/metrics",
+	"/portainer/":            "Portainer",
+	"/traefik/":              "Traefik",
+	"/auth/admin/":           "Keycloak",
+	"/auth/realms/":          "Keycloak",
+	"/keycloak/":             "Keycloak",
+	"/vault/":                "HashiCorp Vault",
+	"/v1/sys/health":         "HashiCorp Vault",
+	"/v1/agent/self":         "HashiCorp Consul",
+	"/nexus/":                "Nexus Repository",
+	"/repository/":           "Nexus Repository",
+	"/artifactory/":          "JFrog Artifactory",
+	"/sonarqube/":            "SonarQube",
+	"/sonar/":                "SonarQube",
+	"/harbor/":               "Harbor Registry",
+	"/roundcube/":            "Roundcube Webmail",
+	"/webmail/":              "Webmail",
+	"/zimbra/":               "Zimbra",
+	"/owa/":                  "Outlook Web Access",
+	"/cpanel":                "cPanel",
+	"/whm":                   "WHM",
+	"/plesk/":                "Plesk",
+	"/directadmin/":          "DirectAdmin",
+	"/session_login.cgi":     "Webmin",
+	"/_cat/health":           "Elasticsearch",
+	"/_nodes":                "Elasticsearch",
+	"/solr/":                 "Apache Solr",
+	"/netdata/":              "Netdata",
+	"/zabbix/":               "Zabbix",
+	"/nagios/":               "Nagios",
+}
+
+var cookieTech = map[string]string{
+	"wordpress_":   "WordPress",
+	"wp-settings":  "WordPress",
+	"wp_":          "WordPress",
+	"phpsessid":    "PHP",
+	"jsessionid":   "Java/Tomcat",
+	"asp.net_":     "ASP.NET",
+	"laravel_":     "Laravel",
+	"ci_session":   "CodeIgniter",
+	"drupal_":      "Drupal",
+	"symfony":      "Symfony",
+	"yii":          "Yii Framework",
+	"csrftoken":    "Django",
+	"rack.session": "Ruby/Rack",
+	"connect.sid":  "Node.js/Express",
+}
+
+func Crawl(ctx context.Context, scheme, host string, port int, maxDepth int, timeout time.Duration, reqDelay time.Duration) ([]CrawlResult, *AppFingerprint) {
+	displayHost := host
+	if strings.Contains(host, ":") {
+		displayHost = "[" + host + "]"
+	}
+	base := fmt.Sprintf("%s://%s:%d", scheme, displayHost, port)
+
+	crawlTimeout := timeout * 3
+	if crawlTimeout > 8*time.Second {
+		crawlTimeout = 8 * time.Second
+	}
+	client := &http.Client{
+		Timeout: crawlTimeout,
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, //nolint:gosec
+		},
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+
+	type entry struct {
+		path  string
+		depth int
+	}
+
+	visited := make(map[string]bool)
+	appsFound := make(map[string]bool)
+	fp := &AppFingerprint{}
+	var results []CrawlResult
+
+	queue := make([]entry, 0, len(sensitivePaths)+1)
+	for _, p := range sensitivePaths {
+		queue = append(queue, entry{p, 0})
+	}
+	queue = append(queue, entry{"/", 0})
+	head := 0
+
+	var timer *time.Timer
+	if reqDelay > 0 {
+		timer = time.NewTimer(reqDelay)
+		defer timer.Stop()
+	}
+
+	for head < len(queue) {
+		if ctx.Err() != nil {
+			break
+		}
+
+		e := queue[head]
+		head++
+
+		if visited[e.path] {
+			continue
+		}
+		visited[e.path] = true
+
+		if timer != nil {
+			timer.Reset(reqDelay)
+			select {
+			case <-ctx.Done():
+				if fp.Server == "" && fp.PoweredBy == "" && fp.Generator == "" && len(fp.Apps) == 0 {
+					return results, nil
+				}
+				return results, fp
+			case <-timer.C:
+			}
+		}
+
+		cr, body := fetchPath(ctx, client, base, host, e.path, fp, appsFound)
+		if cr == nil {
+			continue
+		}
+		results = append(results, *cr)
+
+		if tech, ok := pathTech[e.path]; ok && cr.StatusCode < 404 && !appsFound[tech] {
+			fp.Apps = append(fp.Apps, tech)
+			appsFound[tech] = true
+		}
+		if e.path == "/" && body != "" && fp.Generator == "" {
+			fp.Generator = extractMeta(body, "generator")
+		}
+
+		if e.path == "/robots.txt" && cr.StatusCode == 200 && body != "" {
+			for _, disallowed := range parseRobotsTxt(body) {
+				if !visited[disallowed] {
+					slog.Info("robots.txt disallow entry (target for crawl)", "path", disallowed)
+					queue = append(queue, entry{disallowed, e.depth})
+				}
+			}
+		}
+
+		if e.depth < maxDepth && strings.Contains(cr.ContentType, "text/html") && body != "" && cr.StatusCode < 400 {
+			for _, link := range extractLinks(body, base) {
+				if !visited[link] {
+					queue = append(queue, entry{link, e.depth + 1})
+				}
+			}
+		}
+	}
+
+	if fp.Server == "" && fp.PoweredBy == "" && fp.Generator == "" && len(fp.Apps) == 0 {
+		return results, nil
+	}
+	return results, fp
+}
+
+func addApp(fp *AppFingerprint, found map[string]bool, tech string) {
+	if tech != "" && !found[tech] {
+		fp.Apps = append(fp.Apps, tech)
+		found[tech] = true
+	}
+}
+
+func fetchPath(ctx context.Context, client *http.Client, base, hostname, path string, fp *AppFingerprint, appsFound map[string]bool) (*CrawlResult, string) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, base+path, nil)
+	if err != nil {
+		return nil, ""
+	}
+	req.Header.Set("User-Agent", "flan-scanner/1.0")
+	req.Host = hostname
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, ""
+	}
+	defer resp.Body.Close()
+
+	cr := &CrawlResult{
+		Path:        path,
+		StatusCode:  resp.StatusCode,
+		ContentType: resp.Header.Get("Content-Type"),
+	}
+
+	if loc := resp.Header.Get("Location"); loc != "" {
+		cr.RedirectTo = loc
+	}
+
+	if s := resp.Header.Get("Server"); s != "" && fp.Server == "" {
+		fp.Server = s
+	}
+	if p := resp.Header.Get("X-Powered-By"); p != "" && fp.PoweredBy == "" {
+		fp.PoweredBy = p
+	}
+	if g := resp.Header.Get("X-Generator"); g != "" && fp.Generator == "" {
+		fp.Generator = g
+	}
+	if resp.Header.Get("X-Drupal-Cache") != "" || resp.Header.Get("X-Drupal-Dynamic-Cache") != "" {
+		addApp(fp, appsFound, "Drupal")
+	}
+	if resp.Header.Get("X-Pingback") != "" {
+		addApp(fp, appsFound, "WordPress")
+	}
+	if resp.Header.Get("X-AspNet-Version") != "" || resp.Header.Get("X-AspNetMvc-Version") != "" {
+		addApp(fp, appsFound, "ASP.NET")
+	}
+	if resp.Header.Get("X-CF-Powered-By") != "" {
+		addApp(fp, appsFound, "ColdFusion")
+	}
+	for _, c := range resp.Cookies() {
+		lower := strings.ToLower(c.Name)
+		for prefix, tech := range cookieTech {
+			if strings.HasPrefix(lower, prefix) {
+				addApp(fp, appsFound, tech)
+				break
+			}
+		}
+	}
+
+	if !strings.Contains(cr.ContentType, "text/") {
+		io.Copy(io.Discard, resp.Body) //nolint:errcheck
+		return cr, ""
+	}
+
+	b, err := io.ReadAll(io.LimitReader(resp.Body, 64*1024))
+	io.Copy(io.Discard, resp.Body) //nolint:errcheck
+	if err != nil {
+		return cr, ""
+	}
+	body := string(b)
+
+	if strings.Contains(cr.ContentType, "text/html") {
+		cr.Title = extractTitle(body)
+	}
+
+	return cr, body
+}
+
+func extractLinks(body, base string) []string {
+	baseURL, err := url.Parse(base)
+	if err != nil {
+		return nil
+	}
+
+	seen := make(map[string]bool)
+	var links []string
+
+	z := html.NewTokenizer(strings.NewReader(body))
+	for {
+		tt := z.Next()
+		if tt == html.ErrorToken {
+			break
+		}
+		if tt != html.StartTagToken && tt != html.SelfClosingTagToken {
+			continue
+		}
+
+		tok := z.Token()
+		var attrName string
+		switch tok.Data {
+		case "a", "link":
+			attrName = "href"
+		case "script", "img":
+			attrName = "src"
+		case "form":
+			attrName = "action"
+		default:
+			continue
+		}
+
+		for _, attr := range tok.Attr {
+			if attr.Key != attrName {
+				continue
+			}
+			raw := strings.TrimSpace(attr.Val)
+			if raw == "" || strings.HasPrefix(raw, "javascript:") ||
+				strings.HasPrefix(raw, "mailto:") ||
+				strings.HasPrefix(raw, "data:") ||
+				strings.HasPrefix(raw, "#") {
+				continue
+			}
+
+			u, err := url.Parse(raw)
+			if err != nil {
+				continue
+			}
+
+			resolved := baseURL.ResolveReference(u)
+			if !sameHost(resolved, baseURL) {
+				continue
+			}
+
+			p := resolved.Path
+			if p == "" {
+				p = "/"
+			}
+			if !seen[p] {
+				seen[p] = true
+				links = append(links, p)
+			}
+		}
+	}
+
+	return links
+}
+
+func sameHost(a, b *url.URL) bool {
+	return normalizeHost(a) == normalizeHost(b)
+}
+
+func normalizeHost(u *url.URL) string {
+	h := u.Hostname()
+	p := u.Port()
+	if p == "" {
+		return h
+	}
+	switch {
+	case u.Scheme == "http" && p == "80":
+		return h
+	case u.Scheme == "https" && p == "443":
+		return h
+	}
+	return h + ":" + p
+}
+
+func extractTitle(body string) string {
+	z := html.NewTokenizer(strings.NewReader(body))
+	for {
+		tt := z.Next()
+		if tt == html.ErrorToken {
+			break
+		}
+		if tt == html.StartTagToken {
+			tok := z.Token()
+			if tok.Data == "title" {
+				if z.Next() == html.TextToken {
+					return strings.TrimSpace(string(z.Text()))
+				}
+			}
+		}
+	}
+	return ""
+}
+
+func extractMeta(body, name string) string {
+	z := html.NewTokenizer(strings.NewReader(body))
+	for {
+		tt := z.Next()
+		if tt == html.ErrorToken {
+			break
+		}
+		if tt != html.SelfClosingTagToken && tt != html.StartTagToken {
+			continue
+		}
+		tok := z.Token()
+		if tok.Data != "meta" {
+			continue
+		}
+		var metaName, content string
+		for _, attr := range tok.Attr {
+			switch attr.Key {
+			case "name":
+				metaName = attr.Val
+			case "content":
+				content = attr.Val
+			}
+		}
+		if strings.EqualFold(metaName, name) && content != "" {
+			return content
+		}
+	}
+	return ""
+}
+
+func parseRobotsTxt(body string) []string {
+	var paths []string
+	sc := bufio.NewScanner(strings.NewReader(body))
+	for sc.Scan() {
+		line := strings.TrimSpace(sc.Text())
+		lower := strings.ToLower(line)
+		if strings.HasPrefix(lower, "disallow:") {
+			path := strings.TrimSpace(line[len("disallow:"):])
+			if path != "" && path != "/" && strings.HasPrefix(path, "/") {
+				paths = append(paths, path)
+			}
+		}
+	}
+	return paths
+}
+
+func IsHTTPService(service string, port int, tls bool) bool {
+	svc := strings.ToLower(service)
+	if strings.Contains(svc, "http") {
+		return true
+	}
+	switch port {
+	case 80, 8080, 8000, 8888, 3000:
+		return true
+	case 443, 8443, 4443:
+		return tls || service == ""
+	}
+	return false
+}
+
+func HTTPScheme(tls bool) string {
+	if tls {
+		return "https"
+	}
+	return "http"
+}

--- a/internal/scanner/crawl_test.go
+++ b/internal/scanner/crawl_test.go
@@ -1,0 +1,137 @@
+package scanner
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestParseRobotsTxt(t *testing.T) {
+	body := "User-agent: *\nDisallow: /admin\nDisallow: /private/\nDisallow: /\nAllow: /public\nDisallow:\n"
+	paths := parseRobotsTxt(body)
+	want := map[string]bool{"/admin": true, "/private/": true}
+	if len(paths) != len(want) {
+		t.Fatalf("expected %d paths, got %d: %v", len(want), len(paths), paths)
+	}
+	for _, p := range paths {
+		if !want[p] {
+			t.Errorf("unexpected path %q", p)
+		}
+	}
+}
+
+func TestExtractLinks(t *testing.T) {
+	body := `<html>
+<a href="/about">About</a>
+<a href="/contact">Contact</a>
+<a href="https://external.com/page">External</a>
+<a href="javascript:void(0)">JS</a>
+<a href="#section">Fragment</a>
+<script src="/static/app.js"></script>
+<form action="/submit"></form>
+</html>`
+
+	links := extractLinks(body, "http://example.com:80")
+	want := map[string]bool{
+		"/about":         true,
+		"/contact":       true,
+		"/static/app.js": true,
+		"/submit":        true,
+	}
+	for _, l := range links {
+		if !want[l] {
+			t.Errorf("unexpected link %q", l)
+		}
+		delete(want, l)
+	}
+	for missing := range want {
+		t.Errorf("expected link %q not found", missing)
+	}
+}
+
+func TestExtractLinksExternalFiltered(t *testing.T) {
+	body := `<a href="https://attacker.com/evil">bad</a><a href="/good">good</a>`
+	links := extractLinks(body, "http://target.com:80")
+	for _, l := range links {
+		if strings.Contains(l, "attacker") {
+			t.Errorf("external link not filtered: %q", l)
+		}
+	}
+	if len(links) != 1 || links[0] != "/good" {
+		t.Errorf("expected [/good], got %v", links)
+	}
+}
+
+func TestIsHTTPService(t *testing.T) {
+	cases := []struct {
+		service string
+		port    int
+		tls     bool
+		want    bool
+	}{
+		{"http", 8080, false, true},
+		{"https", 443, true, true},
+		{"HTTP", 9000, false, true},
+		{"ssh", 22, false, false},
+		{"", 80, false, true},
+		{"", 443, true, true},
+		{"", 8080, false, true},
+		{"mysql", 3306, false, false},
+	}
+	for _, c := range cases {
+		got := IsHTTPService(c.service, c.port, c.tls)
+		if got != c.want {
+			t.Errorf("IsHTTPService(%q, %d, %v) = %v, want %v", c.service, c.port, c.tls, got, c.want)
+		}
+	}
+}
+
+func TestHTTPScheme(t *testing.T) {
+	if HTTPScheme(true) != "https" {
+		t.Error("expected https for tls=true")
+	}
+	if HTTPScheme(false) != "http" {
+		t.Error("expected http for tls=false")
+	}
+}
+
+func TestCrawlSensitivePaths(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/admin":
+			w.WriteHeader(http.StatusForbidden)
+		case "/.env":
+			w.Header().Set("Content-Type", "text/plain")
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte("DB_PASSWORD=secret"))
+		case "/robots.txt":
+			w.Header().Set("Content-Type", "text/plain")
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte("User-agent: *\nDisallow: /hidden\n"))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	results, _ := Crawl(context.Background(), "http", "127.0.0.1", srv.Listener.Addr().(*net.TCPAddr).Port, 0, 5*time.Second, 0)
+
+	byPath := make(map[string]CrawlResult)
+	for _, r := range results {
+		byPath[r.Path] = r
+	}
+
+	if r, ok := byPath["/admin"]; !ok || r.StatusCode != http.StatusForbidden {
+		t.Errorf("/admin: expected 403, got %+v", byPath["/admin"])
+	}
+	if r, ok := byPath["/.env"]; !ok || r.StatusCode != http.StatusOK {
+		t.Errorf("/.env: expected 200, got %+v", r)
+	}
+	if _, ok := byPath["/hidden"]; !ok {
+		t.Error("robots.txt Disallow /hidden should be crawled as a finding")
+	}
+}

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -13,4 +13,6 @@ type ScanResult struct {
 	TLS             *TLSResult      `json:"tls,omitempty"`
 	Metadata        json.RawMessage `json:"metadata,omitempty"`
 	Vulnerabilities []string        `json:"vulnerabilities,omitempty"`
+	Endpoints       []CrawlResult   `json:"endpoints,omitempty"`
+	App             *AppFingerprint `json:"app,omitempty"`
 }


### PR DESCRIPTION

- BFS crawler probes 80+ sensitive paths per HTTP/HTTPS service, detects 60+ apps/CMSes via path hits, response headers, and cookies. 
- Pretty streaming output with TTY detection, brief AI summary auto-runs when TOGETHER_API_KEY is set. 
- Added --crawl and --crawl-depth flags.