### PR TITLE
Add HTTP security header analysis with CDN-aware hostname routing

### DIFF
--- a/cmd/flan/main.go
+++ b/cmd/flan/main.go
@@ -6,6 +6,7 @@ import (
 	"flag"
 	"fmt"
 	"log/slog"
+	"net"
 	"os"
 	"os/signal"
 	"strconv"
@@ -338,6 +339,7 @@ func main() {
 		defer jsonlWriter.Close()
 	}
 
+	hostnameFor := make(map[string]string)
 	var allIPs []string
 	for _, host := range hosts {
 		ips, err := dnsCache.Lookup(host)
@@ -346,7 +348,11 @@ func main() {
 			continue
 		}
 		for _, ip := range ips {
-			allIPs = append(allIPs, ip.String())
+			s := ip.String()
+			allIPs = append(allIPs, s)
+			if net.ParseIP(host) == nil {
+				hostnameFor[s] = host
+			}
 		}
 	}
 
@@ -487,6 +493,11 @@ func main() {
 						endpoints, appFP = scanner.Crawl(ctx, scanner.HTTPScheme(fp.TLS), ip, port, cfg.Scan.CrawlDepth, cfg.Scan.Timeout, 100*time.Millisecond)
 					}
 
+					var secHeaders []scanner.HeaderFinding
+					if scanner.IsHTTPService(fp.Service, port, fp.TLS) {
+						secHeaders = scanner.InspectHeaders(ctx, scanner.HTTPScheme(fp.TLS), ip, hostnameFor[ip], port, cfg.Scan.Timeout)
+					}
+
 					resultsCh <- scanner.ScanResult{
 						Host:            ip,
 						Port:            port,
@@ -499,6 +510,7 @@ func main() {
 						Vulnerabilities: vulns,
 						Endpoints:       endpoints,
 						App:             appFP,
+						SecurityHeaders: secHeaders,
 					}
 					checkpoint.Save(ip, port)
 					return
@@ -514,22 +526,28 @@ func main() {
 
 				var endpoints []scanner.CrawlResult
 				var appFP *scanner.AppFingerprint
+				hasTLS := tlsResult != nil || port == 443 || port == 8443 || port == 4443
 				if *crawlFlag && scanner.IsHTTPService(svc.Name, port, tlsResult != nil) {
-					hasTLS := tlsResult != nil || port == 443 || port == 8443 || port == 4443
 					endpoints, appFP = scanner.Crawl(ctx, scanner.HTTPScheme(hasTLS), ip, port, cfg.Scan.CrawlDepth, cfg.Scan.Timeout, 100*time.Millisecond)
 				}
 
+				var secHeaders []scanner.HeaderFinding
+				if scanner.IsHTTPService(svc.Name, port, tlsResult != nil) {
+					secHeaders = scanner.InspectHeaders(ctx, scanner.HTTPScheme(hasTLS), ip, hostnameFor[ip], port, cfg.Scan.Timeout)
+				}
+
 				resultsCh <- scanner.ScanResult{
-					Host:      ip,
-					Port:      port,
-					Protocol:  "tcp",
-					Service:   svc.Name,
-					Version:   svc.Version,
-					Banner:    svc.Banner,
-					CDN:       cdn,
-					TLS:       tlsResult,
-					Endpoints: endpoints,
-					App:       appFP,
+					Host:            ip,
+					Port:            port,
+					Protocol:        "tcp",
+					Service:         svc.Name,
+					Version:         svc.Version,
+					Banner:          svc.Banner,
+					CDN:             cdn,
+					TLS:             tlsResult,
+					Endpoints:       endpoints,
+					App:             appFP,
+					SecurityHeaders: secHeaders,
 				}
 				checkpoint.Save(ip, port)
 			}(ip, port)
@@ -609,6 +627,7 @@ func main() {
 		fmt.Print("                \r")
 		if err == nil {
 			fmt.Println()
+			fmt.Printf("\033[2m  ──────────────\033[0m \033[1m\033[36mAI Analysis\033[0m \033[2m──────────────\033[0m\n\n")
 			printAnalysis(brief)
 			fmt.Println("\033[2m  Powered by Together AI (deepseek-ai/DeepSeek-V3.1)\033[0m")
 			fmt.Println()
@@ -621,6 +640,7 @@ func main() {
 			slog.Error("analysis failed", "err", err)
 		} else {
 			fmt.Println()
+			fmt.Printf("\033[2m  ──────────────\033[0m \033[1m\033[36mAI Analysis\033[0m \033[2m──────────────\033[0m\n\n")
 			printAnalysis(analysis.Analysis)
 			fmt.Println("\033[2m  Powered by Together AI (deepseek-ai/DeepSeek-V3.1)\033[0m")
 			fmt.Println()
@@ -708,6 +728,14 @@ func printResult(res scanner.ScanResult) {
 		if len(parts) > 0 {
 			fmt.Printf("  %sapp%s  %s\n", cyan, reset, strings.Join(parts, "  ·  "))
 		}
+	}
+
+	for _, f := range res.SecurityHeaders {
+		color := yellow
+		if f.Severity == "HIGH" {
+			color = red
+		}
+		fmt.Printf("  %s✗  %s%s  %s\n", color, f.Header, reset, f.Detail)
 	}
 
 	for _, cve := range res.Vulnerabilities {

--- a/internal/scanner/analyze.go
+++ b/internal/scanner/analyze.go
@@ -27,10 +27,12 @@ type AnalysisUsage struct {
 	TotalTokens      int64 `json:"total_tokens"`
 }
 
-const briefSystemPrompt = `You are a security expert. Summarize the scan results in 3-5 bullet points.
-Focus only on the most critical/high severity issues and quick wins.
-For unknown or unidentified services, analyze the port number itself -- ports have well-known security associations (e.g., 31337 = Back Orifice/elite malware, 4444 = Metasploit default, 9929 = nping-echo, 1337, 6666, etc.). Flag any suspicious or non-standard ports explicitly.
-Be terse and actionable. No preamble or closing remarks.`
+const briefSystemPrompt = `You are a security expert. Summarize the scan results in 5-7 bullet points:
+- Lead with critical/high severity findings; include a one-line remediation for each
+- Cover medium severity issues (missing headers, weak TLS, exposed admin interfaces, version disclosure)
+- Flag suspicious or non-standard ports by number -- apply known associations (31337 = Back Orifice, 4444 = Metasploit, 9929 = nping-echo, 6666 = IRC/malware)
+- Close with one sentence on overall risk posture
+Each bullet: what it is, why it matters, what to do. No preamble.`
 
 const systemPrompt = `You are a security expert analyzing network scan results. For each finding, provide:
 
@@ -190,6 +192,13 @@ func buildSummary(results []ScanResult) string {
 
 		if len(r.Vulnerabilities) > 0 {
 			fmt.Fprintf(&b, "  CVEs: %s\n", strings.Join(r.Vulnerabilities, ", "))
+		}
+
+		if len(r.SecurityHeaders) > 0 {
+			fmt.Fprintf(&b, "  Security header findings:\n")
+			for _, f := range r.SecurityHeaders {
+				fmt.Fprintf(&b, "    [%s] %s: %s\n", f.Severity, f.Header, f.Detail)
+			}
 		}
 
 		if r.App != nil {

--- a/internal/scanner/headers.go
+++ b/internal/scanner/headers.go
@@ -1,0 +1,135 @@
+package scanner
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+)
+
+type HeaderFinding struct {
+	Header   string `json:"header"`
+	Severity string `json:"severity"`
+	Detail   string `json:"detail"`
+}
+
+func InspectHeaders(ctx context.Context, scheme, ip, hostname string, port int, timeout time.Duration) []HeaderFinding {
+	displayHost := ip
+	if strings.Contains(ip, ":") {
+		displayHost = "[" + ip + "]"
+	}
+	target := fmt.Sprintf("%s://%s:%d/", scheme, displayHost, port)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, target, nil)
+	if err != nil {
+		return nil
+	}
+	host := ip
+	if hostname != "" {
+		host = hostname
+	}
+	req.Host = host
+	req.Header.Set("User-Agent", "flan-scanner/1.0")
+
+	client := &http.Client{
+		Timeout: timeout * 2,
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true, ServerName: host}, //nolint:gosec
+		},
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			if len(via) >= 2 {
+				return http.ErrUseLastResponse
+			}
+			return nil
+		},
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil
+	}
+	defer resp.Body.Close()
+	defer io.Copy(io.Discard, resp.Body) //nolint:errcheck
+
+	var findings []HeaderFinding
+
+	check := func(header, severity, detail string) {
+		findings = append(findings, HeaderFinding{Header: header, Severity: severity, Detail: detail})
+	}
+
+	h := resp.Header
+
+	if scheme == "https" && h.Get("Strict-Transport-Security") == "" {
+		check("Strict-Transport-Security", "HIGH", "missing HSTS header; browsers may connect over HTTP")
+	}
+	if h.Get("Content-Security-Policy") == "" {
+		check("Content-Security-Policy", "MEDIUM", "missing CSP; XSS and injection attacks not mitigated")
+	}
+	if h.Get("X-Frame-Options") == "" && h.Get("Content-Security-Policy") == "" {
+		check("X-Frame-Options", "MEDIUM", "missing; page may be embedded in iframes (clickjacking risk)")
+	}
+	if h.Get("X-Content-Type-Options") == "" {
+		check("X-Content-Type-Options", "LOW", "missing; MIME sniffing enabled")
+	}
+	if h.Get("Referrer-Policy") == "" {
+		check("Referrer-Policy", "LOW", "missing; full URL may be sent as Referer to third parties")
+	}
+	if h.Get("Permissions-Policy") == "" {
+		check("Permissions-Policy", "LOW", "missing; browser features (camera, mic, geolocation) unrestricted")
+	}
+
+	if sv := h.Get("Server"); sv != "" && containsVersion(sv) {
+		check("Server", "LOW", fmt.Sprintf("version disclosed: %s", sv))
+	}
+	if xp := h.Get("X-Powered-By"); xp != "" {
+		check("X-Powered-By", "LOW", fmt.Sprintf("technology disclosed: %s", xp))
+	}
+
+	for _, cookie := range resp.Cookies() {
+		var issues []string
+		if scheme == "https" && !cookie.Secure {
+			issues = append(issues, "missing Secure flag")
+		}
+		if !cookie.HttpOnly {
+			issues = append(issues, "missing HttpOnly flag")
+		}
+		if cookie.SameSite == http.SameSiteDefaultMode {
+			issues = append(issues, "missing SameSite attribute")
+		}
+		if len(issues) > 0 {
+			check("Set-Cookie", "MEDIUM", fmt.Sprintf("cookie %q: %s", cookie.Name, strings.Join(issues, ", ")))
+		}
+	}
+
+	for _, header := range []string{"Via", "X-Forwarded-For", "X-Real-IP", "X-Forwarded-Host"} {
+		if v := h.Get(header); v != "" && isInternalIP(v) {
+			check(header, "MEDIUM", fmt.Sprintf("internal IP leaked in %s: %s", header, v))
+		}
+	}
+
+	return findings
+}
+
+func containsVersion(s string) bool {
+	for _, c := range s {
+		if c >= '0' && c <= '9' {
+			return true
+		}
+	}
+	return false
+}
+
+func isInternalIP(s string) bool {
+	return strings.Contains(s, "10.") ||
+		strings.Contains(s, "172.16.") ||
+		strings.Contains(s, "172.17.") ||
+		strings.Contains(s, "172.18.") ||
+		strings.Contains(s, "172.19.") ||
+		strings.Contains(s, "172.2") ||
+		strings.Contains(s, "172.3") ||
+		strings.Contains(s, "192.168.") ||
+		strings.Contains(s, "127.")
+}

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -15,4 +15,5 @@ type ScanResult struct {
 	Vulnerabilities []string        `json:"vulnerabilities,omitempty"`
 	Endpoints       []CrawlResult   `json:"endpoints,omitempty"`
 	App             *AppFingerprint `json:"app,omitempty"`
+	SecurityHeaders []HeaderFinding `json:"security_headers,omitempty"`
 }


### PR DESCRIPTION

- Adds InspectHeaders to detect missing HSTS, CSP, X-Frame-Options, X-Content-Type-Options, Referrer-Policy, Permissions-Policy, insecure cookie flags, server version disclosure, and internal IP leakage. 
- Runs automatically on every HTTP/HTTPS service, no flag needed.

Key fixes: 
- Preserved hostname → IP mapping through DNS resolution so CDN-hosted targets receive correct Host header and TLS SNI (without this, CDNs return generic responses with no security headers, producing false positives for every CDN-backed site). 
- Follows one HTTP→HTTPS redirect to evaluate final response headers. Verified accurate against `curl -I and fingerprintx`.
- AI analysis header and prompt updated for richer output.