### PR TITLE
Add context-aware AI analysis with policy compliance checking

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,14 @@ Scan with detailed AI-powered analysis (requires `TOGETHER_API_KEY`):
 flan -t scanme.nmap.org --analyze
 ```
 
+Use a custom asset context file for policy-aware AI analysis:
+
+```
+flan -t api.example.com --context /path/to/context.yaml
+```
+
+Context is automatically loaded from `config/context.yaml` when present. It defines asset criticality, data classification, and security policies (TLS minimum version, SSH auth requirements, allowed ports). Policy violations are flagged before AI analysis runs.
+
 ## Flags
 
 | Flag | Description |
@@ -145,6 +153,7 @@ flan -t scanme.nmap.org --analyze
 | `--udp` | Enable UDP scanning (ports 53, 123, 161, 500 by default) |
 | `--crawl` | Crawl HTTP/HTTPS services for endpoints, sensitive paths, and app fingerprinting |
 | `--crawl-depth` | Max crawl depth (default: 2) |
+| `--context` | Asset context YAML file (auto-loads `config/context.yaml` if present) |
 | `--analyze` | Detailed AI security analysis via Together API (requires `TOGETHER_API_KEY`) |
 | `--json` | JSON output |
 | `--jsonl` | JSONL streaming output |

--- a/cmd/flan/main.go
+++ b/cmd/flan/main.go
@@ -58,6 +58,7 @@ CONFIGURATION:
   --udp                    enable UDP scanning (ports 53,123,161,500 by default)
   --crawl                  crawl HTTP/HTTPS services for endpoints and sensitive paths
   --crawl-depth int        max crawl depth (default: 2)
+  --context string         YAML file with asset context and policies for AI analysis
   --analyze                AI-powered analysis via Together API (requires TOGETHER_API_KEY)
 
 OUTPUT:
@@ -150,6 +151,7 @@ func main() {
 	udpFlag := flag.Bool("udp", false, "")
 	crawlFlag := flag.Bool("crawl", false, "")
 	crawlDepth := flag.Int("crawl-depth", 0, "")
+	contextFile := flag.String("context", "", "")
 	analyze := flag.Bool("analyze", false, "")
 	jsonFlag := flag.Bool("json", false, "")
 	jsonlFlag := flag.Bool("jsonl", false, "")
@@ -175,6 +177,18 @@ func main() {
 
 	if set["crawl-depth"] && *crawlDepth > 0 {
 		cfg.Scan.CrawlDepth = *crawlDepth
+	}
+
+	var scanCtx *scanner.ScanContext
+	ctxPath := *contextFile
+	if ctxPath == "" {
+		ctxPath = "config/context.yaml"
+	}
+	if sc, err := scanner.LoadContext(ctxPath); err == nil {
+		scanCtx = sc
+	} else if *contextFile != "" {
+		slog.Error("failed to load context file", "err", err)
+		os.Exit(1)
 	}
 
 	if *passiveOnly && dom == "" {
@@ -495,7 +509,8 @@ func main() {
 
 					var secHeaders []scanner.HeaderFinding
 					if scanner.IsHTTPService(fp.Service, port, fp.TLS) {
-						secHeaders = scanner.InspectHeaders(ctx, scanner.HTTPScheme(fp.TLS), ip, hostnameFor[ip], port, cfg.Scan.Timeout)
+						isTLS := fp.TLS || port == 443 || port == 8443 || port == 4443
+						secHeaders = scanner.InspectHeaders(ctx, scanner.HTTPScheme(isTLS), ip, hostnameFor[ip], port, cfg.Scan.Timeout)
 					}
 
 					resultsCh <- scanner.ScanResult{
@@ -621,9 +636,31 @@ func main() {
 		"ports_scanned", progress.PortsScanned.Load(),
 	)
 
+	if scanCtx != nil && len(results) > 0 {
+		violations := scanner.CheckPolicies(results, scanCtx)
+		if len(violations) > 0 && prettyMode {
+			fmt.Println()
+			fmt.Printf("\033[2m  ──────────────\033[0m \033[1m\033[31mPolicy Violations\033[0m \033[2m──────────────\033[0m\n\n")
+			for _, v := range violations {
+				color := "\033[33m"
+				if v.Severity == "CRITICAL" {
+					color = "\033[1m\033[31m"
+				} else if v.Severity == "HIGH" {
+					color = "\033[31m"
+				}
+				loc := v.Host
+				if v.Port > 0 {
+					loc = fmt.Sprintf("%s:%d", v.Host, v.Port)
+				}
+				fmt.Printf("  %s[%s]%s  %s  %s\n", color, v.Severity, "\033[0m", loc, v.Detail)
+			}
+			fmt.Println()
+		}
+	}
+
 	if prettyMode && !*analyze && os.Getenv("TOGETHER_API_KEY") != "" && len(results) > 0 {
 		fmt.Print("\033[2m  Analyzing...\033[0m\r")
-		brief, err := scanner.AnalyzeBrief(ctx, results)
+		brief, err := scanner.AnalyzeBrief(ctx, results, scanCtx)
 		fmt.Print("                \r")
 		if err == nil {
 			fmt.Println()
@@ -635,7 +672,7 @@ func main() {
 	}
 
 	if *analyze && len(results) > 0 {
-		analysis, err := scanner.Analyze(ctx, results, cfg.Output.Directory)
+		analysis, err := scanner.Analyze(ctx, results, cfg.Output.Directory, scanCtx)
 		if err != nil {
 			slog.Error("analysis failed", "err", err)
 		} else {

--- a/config/context.yaml
+++ b/config/context.yaml
@@ -1,0 +1,18 @@
+assets:
+  api.together.xyz:
+    role: production API gateway
+    criticality: high
+    data: user API keys, model inference requests, billing data
+  api.together.ai:
+    role: production API gateway
+    criticality: high
+    data: user API keys, model inference requests, billing data
+  scanme.nmap.org:
+    role: intentionally vulnerable test target
+    criticality: low
+    data: none - public test server, treat all findings as real vulnerabilities
+
+policies:
+  tls_min_version: "1.2"
+  ssh_password_auth: false
+  allowed_ports: [80, 443]

--- a/internal/scanner/analyze.go
+++ b/internal/scanner/analyze.go
@@ -51,7 +51,7 @@ Prioritize findings by risk. Be concise and actionable. Focus on:
 
 Do not repeat raw scan data. Summarize and analyze.`
 
-func Analyze(ctx context.Context, results []ScanResult, outputDir string) (*AnalysisResult, error) {
+func Analyze(ctx context.Context, results []ScanResult, outputDir string, sc *ScanContext) (*AnalysisResult, error) {
 	apiKey := os.Getenv("TOGETHER_API_KEY")
 	if apiKey == "" {
 		return nil, fmt.Errorf("TOGETHER_API_KEY not set")
@@ -60,6 +60,9 @@ func Analyze(ctx context.Context, results []ScanResult, outputDir string) (*Anal
 	client := together.NewClient(option.WithAPIKey(apiKey))
 
 	summary := buildSummary(results)
+	if ctxSummary := BuildContextSummary(sc); ctxSummary != "" {
+		summary = ctxSummary + "\n" + summary
+	}
 	slog.Info("sending scan results to Together AI for analysis", "services", len(results))
 
 	resp, err := client.Chat.Completions.New(ctx, together.ChatCompletionNewParams{
@@ -118,7 +121,7 @@ func Analyze(ctx context.Context, results []ScanResult, outputDir string) (*Anal
 	return analysis, nil
 }
 
-func AnalyzeBrief(ctx context.Context, results []ScanResult) (string, error) {
+func AnalyzeBrief(ctx context.Context, results []ScanResult, sc *ScanContext) (string, error) {
 	apiKey := os.Getenv("TOGETHER_API_KEY")
 	if apiKey == "" {
 		return "", fmt.Errorf("TOGETHER_API_KEY not set")
@@ -126,6 +129,9 @@ func AnalyzeBrief(ctx context.Context, results []ScanResult) (string, error) {
 
 	client := together.NewClient(option.WithAPIKey(apiKey))
 	summary := buildSummary(results)
+	if ctxSummary := BuildContextSummary(sc); ctxSummary != "" {
+		summary = ctxSummary + "\n" + summary
+	}
 
 	resp, err := client.Chat.Completions.New(ctx, together.ChatCompletionNewParams{
 		Model: "deepseek-ai/DeepSeek-V3.1",

--- a/internal/scanner/context.go
+++ b/internal/scanner/context.go
@@ -1,0 +1,133 @@
+package scanner
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+type AssetContext struct {
+	Role        string `yaml:"role"`
+	Criticality string `yaml:"criticality"`
+	Data        string `yaml:"data"`
+}
+
+type ScanContext struct {
+	Assets   map[string]AssetContext `yaml:"assets"`
+	Policies struct {
+		TLSMinVersion   string   `yaml:"tls_min_version"`
+		SSHPasswordAuth *bool    `yaml:"ssh_password_auth"`
+		AllowedPorts    []int    `yaml:"allowed_ports"`
+	} `yaml:"policies"`
+}
+
+type PolicyViolation struct {
+	Host     string `json:"host"`
+	Port     int    `json:"port,omitempty"`
+	Severity string `json:"severity"`
+	Detail   string `json:"detail"`
+}
+
+func LoadContext(path string) (*ScanContext, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read context file: %w", err)
+	}
+	var sc ScanContext
+	if err := yaml.Unmarshal(data, &sc); err != nil {
+		return nil, fmt.Errorf("parse context file: %w", err)
+	}
+	return &sc, nil
+}
+
+func CheckPolicies(results []ScanResult, sc *ScanContext) []PolicyViolation {
+	if sc == nil {
+		return nil
+	}
+
+	tlsOrder := map[string]int{
+		"TLS1.0": 0, "TLS1.1": 1, "TLS1.2": 2, "TLS1.3": 3,
+	}
+	minRequired := tlsOrder[sc.Policies.TLSMinVersion]
+
+	allowedSet := make(map[int]bool, len(sc.Policies.AllowedPorts))
+	for _, p := range sc.Policies.AllowedPorts {
+		allowedSet[p] = true
+	}
+
+	var violations []PolicyViolation
+
+	for _, r := range results {
+		if len(sc.Policies.AllowedPorts) > 0 && !allowedSet[r.Port] {
+			violations = append(violations, PolicyViolation{
+				Host:     r.Host,
+				Port:     r.Port,
+				Severity: "HIGH",
+				Detail:   fmt.Sprintf("port %d not in allowed_ports policy", r.Port),
+			})
+		}
+
+		if r.TLS != nil && sc.Policies.TLSMinVersion != "" {
+			if v, ok := tlsOrder[r.TLS.Version]; ok && v < minRequired {
+				violations = append(violations, PolicyViolation{
+					Host:     r.Host,
+					Port:     r.Port,
+					Severity: "HIGH",
+					Detail:   fmt.Sprintf("TLS %s below policy minimum %s", r.TLS.Version, sc.Policies.TLSMinVersion),
+				})
+			}
+		}
+
+		if sc.Policies.SSHPasswordAuth != nil && !*sc.Policies.SSHPasswordAuth {
+			if strings.EqualFold(r.Service, "ssh") && r.Metadata != nil {
+				if strings.Contains(string(r.Metadata), `"passwordAuthEnabled":true`) {
+					violations = append(violations, PolicyViolation{
+						Host:     r.Host,
+						Port:     r.Port,
+						Severity: "CRITICAL",
+						Detail:   "SSH password authentication enabled; policy requires key-based auth only",
+					})
+				}
+			}
+		}
+	}
+
+	return violations
+}
+
+func BuildContextSummary(sc *ScanContext) string {
+	if sc == nil {
+		return ""
+	}
+	var b strings.Builder
+	if len(sc.Assets) > 0 {
+		b.WriteString("Asset context:\n")
+		for host, a := range sc.Assets {
+			b.WriteString(fmt.Sprintf("  %s: role=%s criticality=%s", host, a.Role, a.Criticality))
+			if a.Data != "" {
+				b.WriteString(fmt.Sprintf(" data=%s", a.Data))
+			}
+			b.WriteString("\n")
+		}
+	}
+	p := sc.Policies
+	if p.TLSMinVersion != "" || p.SSHPasswordAuth != nil || len(p.AllowedPorts) > 0 {
+		b.WriteString("Policies:\n")
+		if p.TLSMinVersion != "" {
+			b.WriteString(fmt.Sprintf("  tls_min_version: %s\n", p.TLSMinVersion))
+		}
+		if p.SSHPasswordAuth != nil {
+			b.WriteString(fmt.Sprintf("  ssh_password_auth: %v\n", *p.SSHPasswordAuth))
+		}
+		if len(p.AllowedPorts) > 0 {
+			ports := make([]string, len(p.AllowedPorts))
+			for i, port := range p.AllowedPorts {
+				ports[i] = fmt.Sprintf("%d", port)
+			}
+			b.WriteString(fmt.Sprintf("  allowed_ports: [%s]\n", strings.Join(ports, ", ")))
+		}
+	}
+	return b.String()
+}

--- a/internal/scanner/headers.go
+++ b/internal/scanner/headers.go
@@ -17,33 +17,27 @@ type HeaderFinding struct {
 }
 
 func InspectHeaders(ctx context.Context, scheme, ip, hostname string, port int, timeout time.Duration) []HeaderFinding {
-	displayHost := ip
-	if strings.Contains(ip, ":") {
-		displayHost = "[" + ip + "]"
+	urlHost := ip
+	if hostname != "" {
+		urlHost = hostname
+	} else if strings.Contains(ip, ":") {
+		urlHost = "[" + ip + "]"
 	}
-	target := fmt.Sprintf("%s://%s:%d/", scheme, displayHost, port)
+	target := fmt.Sprintf("%s://%s:%d/", scheme, urlHost, port)
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, target, nil)
 	if err != nil {
 		return nil
 	}
-	host := ip
-	if hostname != "" {
-		host = hostname
-	}
-	req.Host = host
 	req.Header.Set("User-Agent", "flan-scanner/1.0")
 
 	client := &http.Client{
 		Timeout: timeout * 2,
 		Transport: &http.Transport{
-			TLSClientConfig: &tls.Config{InsecureSkipVerify: true, ServerName: host}, //nolint:gosec
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, //nolint:gosec
 		},
 		CheckRedirect: func(req *http.Request, via []*http.Request) error {
-			if len(via) >= 2 {
-				return http.ErrUseLastResponse
-			}
-			return nil
+			return http.ErrUseLastResponse
 		},
 	}
 
@@ -61,24 +55,27 @@ func InspectHeaders(ctx context.Context, scheme, ip, hostname string, port int, 
 	}
 
 	h := resp.Header
+	isHTTPRedirect := scheme == "http" && resp.StatusCode >= 300 && resp.StatusCode < 400
 
-	if scheme == "https" && h.Get("Strict-Transport-Security") == "" {
-		check("Strict-Transport-Security", "HIGH", "missing HSTS header; browsers may connect over HTTP")
-	}
-	if h.Get("Content-Security-Policy") == "" {
-		check("Content-Security-Policy", "MEDIUM", "missing CSP; XSS and injection attacks not mitigated")
-	}
-	if h.Get("X-Frame-Options") == "" && h.Get("Content-Security-Policy") == "" {
-		check("X-Frame-Options", "MEDIUM", "missing; page may be embedded in iframes (clickjacking risk)")
-	}
-	if h.Get("X-Content-Type-Options") == "" {
-		check("X-Content-Type-Options", "LOW", "missing; MIME sniffing enabled")
-	}
-	if h.Get("Referrer-Policy") == "" {
-		check("Referrer-Policy", "LOW", "missing; full URL may be sent as Referer to third parties")
-	}
-	if h.Get("Permissions-Policy") == "" {
-		check("Permissions-Policy", "LOW", "missing; browser features (camera, mic, geolocation) unrestricted")
+	if !isHTTPRedirect {
+		if scheme == "https" && h.Get("Strict-Transport-Security") == "" {
+			check("Strict-Transport-Security", "HIGH", "missing HSTS header; browsers may connect over HTTP")
+		}
+		if h.Get("Content-Security-Policy") == "" {
+			check("Content-Security-Policy", "MEDIUM", "missing CSP; XSS and injection attacks not mitigated")
+		}
+		if h.Get("X-Frame-Options") == "" && h.Get("Content-Security-Policy") == "" {
+			check("X-Frame-Options", "MEDIUM", "missing; page may be embedded in iframes (clickjacking risk)")
+		}
+		if h.Get("X-Content-Type-Options") == "" {
+			check("X-Content-Type-Options", "LOW", "missing; MIME sniffing enabled")
+		}
+		if h.Get("Referrer-Policy") == "" {
+			check("Referrer-Policy", "LOW", "missing; full URL may be sent as Referer to third parties")
+		}
+		if h.Get("Permissions-Policy") == "" {
+			check("Permissions-Policy", "LOW", "missing; browser features (camera, mic, geolocation) unrestricted")
+		}
 	}
 
 	if sv := h.Get("Server"); sv != "" && containsVersion(sv) {


### PR DESCRIPTION

- Added `--context` flag (YAML) for asset criticality and data classification injected into AI prompt.
-  config/context.yaml auto-loads by default, `--context` overrides it.
- Deterministic policy checks (allowed ports, TLS min version, SSH password auth) print violations before AI runs. 
- Fixes InspectHeaders CDN routing: connect using hostname URL instead of IP so Cloudflare/CDN edge nodes serve the correct site.
- Port-based HTTPS fallback when fingerprintx returns tls:false on port 443. 
- Skip missing-header checks on HTTP redirects only, not HTTPS. TEST: Verified against curl -sI on api.together.ai and api.together.xyz.


<img width="1503" height="710" alt="Screenshot 2026-02-25 at 3 30 54 PM" src="https://github.com/user-attachments/assets/9b032fce-0684-40a1-95d0-e35672e119a7" />
