### PR TITLE
Add PTR lookups, ASN via Cymru DNS, SRV/SOA/CAA records

### DIFF
--- a/cmd/flan/main.go
+++ b/cmd/flan/main.go
@@ -59,6 +59,7 @@ CONFIGURATION:
   --crawl                  crawl HTTP/HTTPS services for endpoints and sensitive paths
   --crawl-depth int        max crawl depth (default: 2)
   --tls-enum               enumerate supported TLS versions and cipher suites (~60 connections per TLS port)
+  --asn                    look up ASN and organization for each host via Cymru DNS
   --context string         YAML file with asset context and policies for AI analysis
   --analyze                AI-powered analysis via Together API (requires TOGETHER_API_KEY)
 
@@ -153,6 +154,7 @@ func main() {
 	crawlFlag := flag.Bool("crawl", false, "")
 	crawlDepth := flag.Int("crawl-depth", 0, "")
 	tlsEnumFlag := flag.Bool("tls-enum", false, "")
+	asnFlag := flag.Bool("asn", false, "")
 	contextFile := flag.String("context", "", "")
 	analyze := flag.Bool("analyze", false, "")
 	jsonFlag := flag.Bool("json", false, "")
@@ -356,6 +358,9 @@ func main() {
 	}
 
 	hostnameFor := make(map[string]string)
+	asnFor := make(map[string]string)
+	orgFor := make(map[string]string)
+	ptrFor := make(map[string]string)
 	var allIPs []string
 	for _, host := range hosts {
 		ips, err := dnsCache.Lookup(host)
@@ -368,6 +373,16 @@ func main() {
 			allIPs = append(allIPs, s)
 			if net.ParseIP(host) == nil {
 				hostnameFor[s] = host
+			}
+			if *asnFlag {
+				asn, org := scanner.LookupASN(ctx, s, cfg.Scan.Timeout)
+				if asn != "" {
+					asnFor[s] = asn
+					orgFor[s] = org
+				}
+				if ptrs := scanner.LookupPTR(s); len(ptrs) > 0 {
+					ptrFor[s] = ptrs[0]
+				}
 			}
 		}
 	}
@@ -534,6 +549,9 @@ func main() {
 						App:             appFP,
 						SecurityHeaders: secHeaders,
 						TLSEnum:         tlsEnum,
+						Hostname:        ptrFor[ip],
+						ASN:             asnFor[ip],
+						Org:             orgFor[ip],
 					}
 					checkpoint.Save(ip, port)
 					return
@@ -577,6 +595,9 @@ func main() {
 					App:             appFP,
 					SecurityHeaders: secHeaders,
 					TLSEnum:         tlsEnum,
+					Hostname:        ptrFor[ip],
+					ASN:             asnFor[ip],
+					Org:             orgFor[ip],
 				}
 				checkpoint.Save(ip, port)
 			}(ip, port)
@@ -765,6 +786,21 @@ func printResult(res scanner.ScanResult) {
 		cyan, res.Service, reset,
 		version, tls,
 	)
+
+	if res.Hostname != "" || res.ASN != "" {
+		var meta []string
+		if res.Hostname != "" {
+			meta = append(meta, res.Hostname)
+		}
+		if res.ASN != "" {
+			label := "AS" + res.ASN
+			if res.Org != "" {
+				label += " " + res.Org
+			}
+			meta = append(meta, label)
+		}
+		fmt.Printf("  %sasn%s  %s\n", cyan, reset, strings.Join(meta, "  ·  "))
+	}
 
 	if res.App != nil {
 		var parts []string

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/therandomsecurityguy/flan-go-scan
 go 1.24.2
 
 require (
+	github.com/miekg/dns v1.1.62
 	github.com/praetorian-inc/fingerprintx v1.1.19
 	github.com/projectdiscovery/subfinder/v2 v2.12.0
 	github.com/spf13/viper v1.17.0
@@ -10,6 +11,7 @@ require (
 	golang.org/x/net v0.47.0
 	golang.org/x/sync v0.18.0
 	golang.org/x/time v0.11.0
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
@@ -67,7 +69,6 @@ require (
 	github.com/mattn/go-runewidth v0.0.16 // indirect
 	github.com/mholt/archives v0.1.0 // indirect
 	github.com/microcosm-cc/bluemonday v1.0.27 // indirect
-	github.com/miekg/dns v1.1.62 // indirect
 	github.com/minio/selfupdate v0.6.1-0.20230907112617-f11e74f84ca7 // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
@@ -143,5 +144,4 @@ require (
 	golang.org/x/tools v0.38.0 // indirect
 	gopkg.in/djherbis/times.v1 v1.3.0 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/internal/scanner/analyze.go
+++ b/internal/scanner/analyze.go
@@ -200,6 +200,13 @@ func buildSummary(results []ScanResult) string {
 			fmt.Fprintf(&b, "  CVEs: %s\n", strings.Join(r.Vulnerabilities, ", "))
 		}
 
+		if r.Hostname != "" {
+			fmt.Fprintf(&b, "  PTR: %s\n", r.Hostname)
+		}
+		if r.ASN != "" {
+			fmt.Fprintf(&b, "  ASN: AS%s %s\n", r.ASN, r.Org)
+		}
+
 		if r.TLSEnum != nil {
 			fmt.Fprintf(&b, "  TLS versions supported: %s\n", strings.Join(r.TLSEnum.SupportedVersions, ", "))
 			if len(r.TLSEnum.WeakVersions) > 0 {

--- a/internal/scanner/dns_extra.go
+++ b/internal/scanner/dns_extra.go
@@ -1,0 +1,174 @@
+package scanner
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"strings"
+	"time"
+
+	"github.com/miekg/dns"
+)
+
+type SRVRecord struct {
+	Service  string `json:"service"`
+	Target   string `json:"target"`
+	Port     uint16 `json:"port"`
+	Priority uint16 `json:"priority"`
+	Weight   uint16 `json:"weight"`
+}
+
+type SOARecord struct {
+	NS      string `json:"ns"`
+	MBox    string `json:"mbox"`
+	Serial  uint32 `json:"serial"`
+	Refresh uint32 `json:"refresh"`
+	Retry   uint32 `json:"retry"`
+	Expire  uint32 `json:"expire"`
+}
+
+type CAARecord struct {
+	Tag   string `json:"tag"`
+	Value string `json:"value"`
+}
+
+type DNSExtra struct {
+	PTR []string    `json:"ptr,omitempty"`
+	SRV []SRVRecord `json:"srv,omitempty"`
+	SOA *SOARecord  `json:"soa,omitempty"`
+	CAA []CAARecord `json:"caa,omitempty"`
+	ASN string      `json:"asn,omitempty"`
+	Org string      `json:"org,omitempty"`
+}
+
+func LookupPTR(ip string) []string {
+	names, err := net.LookupAddr(ip)
+	if err != nil {
+		return nil
+	}
+	for i, n := range names {
+		names[i] = strings.TrimSuffix(n, ".")
+	}
+	return names
+}
+
+func LookupSRV(service, proto, domain string) []SRVRecord {
+	_, addrs, err := net.LookupSRV(service, proto, domain)
+	if err != nil {
+		return nil
+	}
+	records := make([]SRVRecord, 0, len(addrs))
+	for _, a := range addrs {
+		records = append(records, SRVRecord{
+			Service:  fmt.Sprintf("_%s._%s.%s", service, proto, domain),
+			Target:   a.Target,
+			Port:     a.Port,
+			Priority: a.Priority,
+			Weight:   a.Weight,
+		})
+	}
+	return records
+}
+
+func LookupSOA(domain string, timeout time.Duration) *SOARecord {
+	c := new(dns.Client)
+	c.Timeout = timeout
+	m := new(dns.Msg)
+	m.SetQuestion(dns.Fqdn(domain), dns.TypeSOA)
+	m.RecursionDesired = true
+
+	r, _, err := c.Exchange(m, "8.8.8.8:53")
+	if err != nil || r == nil {
+		return nil
+	}
+	for _, ans := range r.Answer {
+		if soa, ok := ans.(*dns.SOA); ok {
+			return &SOARecord{
+				NS:      soa.Ns,
+				MBox:    soa.Mbox,
+				Serial:  soa.Serial,
+				Refresh: soa.Refresh,
+				Retry:   soa.Retry,
+				Expire:  soa.Expire,
+			}
+		}
+	}
+	return nil
+}
+
+func LookupCAA(domain string, timeout time.Duration) []CAARecord {
+	c := new(dns.Client)
+	c.Timeout = timeout
+	m := new(dns.Msg)
+	m.SetQuestion(dns.Fqdn(domain), dns.TypeCAA)
+	m.RecursionDesired = true
+
+	r, _, err := c.Exchange(m, "8.8.8.8:53")
+	if err != nil || r == nil {
+		return nil
+	}
+	var records []CAARecord
+	for _, ans := range r.Answer {
+		if caa, ok := ans.(*dns.CAA); ok {
+			records = append(records, CAARecord{
+				Tag:   caa.Tag,
+				Value: caa.Value,
+			})
+		}
+	}
+	return records
+}
+
+func LookupASN(ctx context.Context, ip string, timeout time.Duration) (asn, org string) {
+	reversed, err := reverseIP(ip)
+	if err != nil {
+		return "", ""
+	}
+	query := reversed + ".origin.asn.cymru.com"
+
+	c := new(dns.Client)
+	c.Timeout = timeout
+	m := new(dns.Msg)
+	m.SetQuestion(dns.Fqdn(query), dns.TypeTXT)
+	m.RecursionDesired = true
+
+	r, _, err := c.Exchange(m, "8.8.8.8:53")
+	if err != nil || r == nil {
+		return "", ""
+	}
+	for _, ans := range r.Answer {
+		if txt, ok := ans.(*dns.TXT); ok {
+			for _, s := range txt.Txt {
+				parts := strings.Split(s, " | ")
+				if len(parts) >= 1 {
+					asn = strings.TrimSpace(parts[0])
+				}
+				if len(parts) >= 3 {
+					org = strings.TrimSpace(parts[2])
+				}
+				return asn, org
+			}
+		}
+	}
+	return "", ""
+}
+
+func reverseIP(ip string) (string, error) {
+	parsed := net.ParseIP(ip)
+	if parsed == nil {
+		return "", fmt.Errorf("invalid IP")
+	}
+	if parsed.To4() != nil {
+		parts := strings.Split(ip, ".")
+		for i, j := 0, len(parts)-1; i < j; i, j = i+1, j-1 {
+			parts[i], parts[j] = parts[j], parts[i]
+		}
+		return strings.Join(parts, "."), nil
+	}
+	full := fmt.Sprintf("%032x", []byte(parsed.To16()))
+	runes := []rune(full)
+	for i, j := 0, len(runes)-1; i < j; i, j = i+1, j-1 {
+		runes[i], runes[j] = runes[j], runes[i]
+	}
+	return strings.Join(strings.Split(string(runes), ""), "."), nil
+}

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -17,4 +17,7 @@ type ScanResult struct {
 	App             *AppFingerprint `json:"app,omitempty"`
 	SecurityHeaders []HeaderFinding `json:"security_headers,omitempty"`
 	TLSEnum         *TLSEnum       `json:"tls_enum,omitempty"`
+	Hostname        string         `json:"hostname,omitempty"`
+	ASN             string         `json:"asn,omitempty"`
+	Org             string         `json:"org,omitempty"`
 }


### PR DESCRIPTION

- Adds `--asn` flag (off by default) for PTR reverse lookups and ASN/org lookup via Cymru DNS (<reversed ip>.origin.asn.cymru.com TXT) : no HTTP, no rate limit, bulk-safe. ASN/hostname shown in CLI output and included in AI prompt.
- Adds SRV via net.LookupSRV, SOA and CAA via miekg/dns (promoted to direct dep, already transitive via subfinder). PTR trailing dot stripped.