### PR TITLE
Added perf optimizations

### DIFF
--- a/internal/scanner/crawl.go
+++ b/internal/scanner/crawl.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"sync"
 	"time"
 
 	"golang.org/x/net/html"
@@ -182,6 +183,12 @@ var pathTech = map[string]string{
 	"/nagios/":               "Nagios",
 }
 
+var httpClientPool = sync.Pool{
+	New: func() interface{} {
+		return &http.Client{}
+	},
+}
+
 var cookieTech = map[string]string{
 	"wordpress_":   "WordPress",
 	"wp-settings":  "WordPress",
@@ -214,15 +221,15 @@ func Crawl(ctx context.Context, scheme, ip, hostname string, port int, maxDepth 
 	if hostname != "" && net.ParseIP(hostname) == nil {
 		tlsCfg.ServerName = hostname
 	}
-	client := &http.Client{
-		Timeout: crawlTimeout,
-		Transport: &http.Transport{
-			TLSClientConfig: tlsCfg,
-		},
-		CheckRedirect: func(req *http.Request, via []*http.Request) error {
-			return http.ErrUseLastResponse
-		},
+	client := httpClientPool.Get().(*http.Client)
+	client.Timeout = crawlTimeout
+	client.Transport = &http.Transport{
+		TLSClientConfig: tlsCfg,
 	}
+	client.CheckRedirect = func(req *http.Request, via []*http.Request) error {
+		return http.ErrUseLastResponse
+	}
+	defer httpClientPool.Put(client)
 
 	type entry struct {
 		path  string

--- a/internal/scanner/discovery.go
+++ b/internal/scanner/discovery.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"sync"
 	"time"
 )
 
@@ -30,18 +31,49 @@ func IsHostAlive(ctx context.Context, host string, ports []int, timeout time.Dur
 		}
 	}
 
+	const maxParallel = 6
+	sem := make(chan struct{}, maxParallel)
+	var wg sync.WaitGroup
+	found := make(chan struct{})
+	var mu sync.Mutex
+
 	for _, port := range candidatePorts {
-		if ctx.Err() != nil {
-			return false
-		}
-		addr := net.JoinHostPort(host, fmt.Sprintf("%d", port))
-		dialer := net.Dialer{Timeout: timeout}
-		conn, err := dialer.DialContext(ctx, "tcp", addr)
-		if err == nil {
-			conn.Close()
-			return true
-		}
+		wg.Add(1)
+		go func(port int) {
+			sem <- struct{}{}
+			defer func() {
+				<-sem
+				wg.Done()
+			}()
+
+			select {
+			case <-ctx.Done():
+				return
+			default:
+			}
+
+			addr := net.JoinHostPort(host, fmt.Sprintf("%d", port))
+			dialer := net.Dialer{Timeout: timeout}
+			conn, err := dialer.DialContext(ctx, "tcp", addr)
+			if err == nil {
+				conn.Close()
+				mu.Lock()
+				select {
+				case <-found:
+				default:
+					close(found)
+				}
+				mu.Unlock()
+			}
+		}(port)
 	}
 
-	return false
+	go wg.Wait()
+
+	select {
+	case <-found:
+		return true
+	case <-ctx.Done():
+		return false
+	}
 }

--- a/internal/scanner/tls_enum.go
+++ b/internal/scanner/tls_enum.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net"
 	"strings"
+	"sync"
 	"time"
 )
 
@@ -34,32 +35,84 @@ func EnumerateTLS(ctx context.Context, host, hostname string, port int, timeout 
 	addr := tlsAddr(host, port)
 	result := &TLSEnum{}
 	hasTLS12 := false
+	var mu sync.Mutex
+	var wg sync.WaitGroup
+
+	versionCh := make(chan struct {
+		name    string
+		version uint16
+		weak    bool
+	})
 
 	for _, v := range tlsVersionList {
-		if ctx.Err() != nil {
-			break
+		wg.Add(1)
+		go func(version uint16, name string, weak bool) {
+			defer wg.Done()
+			if ctx.Err() != nil {
+				return
+			}
+			if probeTLSVersion(addr, hostname, version, timeout, verify) {
+				mu.Lock()
+				versionCh <- struct {
+					name    string
+					version uint16
+					weak    bool
+				}{name, version, weak}
+				mu.Unlock()
+			}
+		}(v.version, v.name, v.weak)
+	}
+
+	go func() {
+		wg.Wait()
+		close(versionCh)
+	}()
+
+	for v := range versionCh {
+		result.SupportedVersions = append(result.SupportedVersions, v.name)
+		if v.weak {
+			result.WeakVersions = append(result.WeakVersions, v.name)
 		}
-		if probeTLSVersion(addr, hostname, v.version, timeout, verify) {
-			result.SupportedVersions = append(result.SupportedVersions, v.name)
-			if v.weak {
-				result.WeakVersions = append(result.WeakVersions, v.name)
-			}
-			if v.version == tls.VersionTLS12 {
-				hasTLS12 = true
-			}
+		if v.version == tls.VersionTLS12 {
+			hasTLS12 = true
 		}
 	}
 
 	if hasTLS12 {
-		for _, cs := range append(tls.CipherSuites(), tls.InsecureCipherSuites()...) {
-			if ctx.Err() != nil {
-				break
-			}
-			if probeCipher(addr, hostname, cs.ID, timeout, verify) {
-				result.CipherSuites = append(result.CipherSuites, cs.Name)
-				if isWeakCipher(cs.Name) {
-					result.WeakCiphers = append(result.WeakCiphers, cs.Name)
+		cipherSuites := append(tls.CipherSuites(), tls.InsecureCipherSuites()...)
+		cipherCh := make(chan string, len(cipherSuites))
+		var cipherWG sync.WaitGroup
+		const maxParallel = 8
+		sem := make(chan struct{}, maxParallel)
+
+		for _, cs := range cipherSuites {
+			cipherWG.Add(1)
+			go func(cs *tls.CipherSuite) {
+				sem <- struct{}{}
+				defer func() {
+					<-sem
+					cipherWG.Done()
+				}()
+				if ctx.Err() != nil {
+					return
 				}
+				if probeCipher(addr, hostname, cs.ID, timeout, verify) {
+					mu.Lock()
+					cipherCh <- cs.Name
+					mu.Unlock()
+				}
+			}(cs)
+		}
+
+		go func() {
+			cipherWG.Wait()
+			close(cipherCh)
+		}()
+
+		for name := range cipherCh {
+			result.CipherSuites = append(result.CipherSuites, name)
+			if isWeakCipher(name) {
+				result.WeakCiphers = append(result.WeakCiphers, name)
 			}
 		}
 	}


### PR DESCRIPTION
- Added parallelization on TLS version and cipher probes using goroutines with worker pool (max 8 concurrent)
- Added parallelization on port checks using goroutines with semaphore (max 6 concurrent)
- Added `sync.Pool` to reuse HTTP clients instead of creating new ones per crawl