### PR TITLE
Cloudflare: Add CF target discovery

### DIFF
--- a/.github/workflows/cloudflare-baseline-scan.yml
+++ b/.github/workflows/cloudflare-baseline-scan.yml
@@ -40,10 +40,10 @@ jobs:
       WORKFLOW_CLOUDFLARE_INCLUDE: ${{ inputs.cloudflare_include || '' }}
       WORKFLOW_CLOUDFLARE_EXCLUDE: ${{ inputs.cloudflare_exclude || '' }}
       WORKFLOW_TOP_PORTS: ${{ inputs.top_ports || '' }}
-      REPO_CLOUDFLARE_ZONES: ${{ vars.CLOUDFLARE_ZONES || '' }}
-      REPO_CLOUDFLARE_INCLUDE: ${{ vars.CLOUDFLARE_INCLUDE || '' }}
-      REPO_CLOUDFLARE_EXCLUDE: ${{ vars.CLOUDFLARE_EXCLUDE || '' }}
-      REPO_TOP_PORTS: ${{ vars.CLOUDFLARE_TOP_PORTS || '' }}
+      SECRET_CLOUDFLARE_ZONES: ${{ secrets.CLOUDFLARE_ZONES || '' }}
+      SECRET_CLOUDFLARE_INCLUDE: ${{ secrets.CLOUDFLARE_INCLUDE || '' }}
+      SECRET_CLOUDFLARE_EXCLUDE: ${{ secrets.CLOUDFLARE_EXCLUDE || '' }}
+      SECRET_TOP_PORTS: ${{ secrets.CLOUDFLARE_TOP_PORTS || '' }}
 
     steps:
       - name: Checkout
@@ -65,10 +65,10 @@ jobs:
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
         run: |
-          zones="${WORKFLOW_CLOUDFLARE_ZONES:-${REPO_CLOUDFLARE_ZONES}}"
-          include="${WORKFLOW_CLOUDFLARE_INCLUDE:-${REPO_CLOUDFLARE_INCLUDE}}"
-          exclude="${WORKFLOW_CLOUDFLARE_EXCLUDE:-${REPO_CLOUDFLARE_EXCLUDE}}"
-          top_ports="${WORKFLOW_TOP_PORTS:-${REPO_TOP_PORTS}}"
+          zones="${WORKFLOW_CLOUDFLARE_ZONES:-${SECRET_CLOUDFLARE_ZONES}}"
+          include="${WORKFLOW_CLOUDFLARE_INCLUDE:-${SECRET_CLOUDFLARE_INCLUDE}}"
+          exclude="${WORKFLOW_CLOUDFLARE_EXCLUDE:-${SECRET_CLOUDFLARE_EXCLUDE}}"
+          top_ports="${WORKFLOW_TOP_PORTS:-${SECRET_TOP_PORTS}}"
 
           args=(
             --cloudflare

--- a/.github/workflows/cloudflare-baseline-scan.yml
+++ b/.github/workflows/cloudflare-baseline-scan.yml
@@ -2,6 +2,23 @@ name: Cloudflare Baseline Scan
 
 on:
   workflow_dispatch:
+    inputs:
+      cloudflare_zones:
+        description: Comma-separated Cloudflare zones to scan
+        required: false
+        type: string
+      cloudflare_include:
+        description: Comma-separated hostname include filters
+        required: false
+        type: string
+      cloudflare_exclude:
+        description: Comma-separated hostname exclude filters
+        required: false
+        type: string
+      top_ports:
+        description: Top port preset for scanning (100, 1000, 2000, 5000)
+        required: false
+        type: string
   schedule:
     - cron: "43 3 * * *"
 
@@ -19,6 +36,14 @@ jobs:
     env:
       REPORTS_DIR: reports
       INVENTORY_PATH: reports/cloudflare-inventory-baseline.json
+      WORKFLOW_CLOUDFLARE_ZONES: ${{ inputs.cloudflare_zones || '' }}
+      WORKFLOW_CLOUDFLARE_INCLUDE: ${{ inputs.cloudflare_include || '' }}
+      WORKFLOW_CLOUDFLARE_EXCLUDE: ${{ inputs.cloudflare_exclude || '' }}
+      WORKFLOW_TOP_PORTS: ${{ inputs.top_ports || '' }}
+      REPO_CLOUDFLARE_ZONES: ${{ vars.CLOUDFLARE_ZONES || '' }}
+      REPO_CLOUDFLARE_INCLUDE: ${{ vars.CLOUDFLARE_INCLUDE || '' }}
+      REPO_CLOUDFLARE_EXCLUDE: ${{ vars.CLOUDFLARE_EXCLUDE || '' }}
+      REPO_TOP_PORTS: ${{ vars.CLOUDFLARE_TOP_PORTS || '' }}
 
     steps:
       - name: Checkout
@@ -40,9 +65,29 @@ jobs:
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
         run: |
-          ./flan \
-            --cloudflare \
+          zones="${WORKFLOW_CLOUDFLARE_ZONES:-${REPO_CLOUDFLARE_ZONES}}"
+          include="${WORKFLOW_CLOUDFLARE_INCLUDE:-${REPO_CLOUDFLARE_INCLUDE}}"
+          exclude="${WORKFLOW_CLOUDFLARE_EXCLUDE:-${REPO_CLOUDFLARE_EXCLUDE}}"
+          top_ports="${WORKFLOW_TOP_PORTS:-${REPO_TOP_PORTS}}"
+
+          args=(
+            --cloudflare
             --cloudflare-inventory-out "${INVENTORY_PATH}"
+          )
+          if [[ -n "${zones}" ]]; then
+            args+=(--cloudflare-zones "${zones}")
+          fi
+          if [[ -n "${include}" ]]; then
+            args+=(--cloudflare-include "${include}")
+          fi
+          if [[ -n "${exclude}" ]]; then
+            args+=(--cloudflare-exclude "${exclude}")
+          fi
+          if [[ -n "${top_ports}" ]]; then
+            args+=(--top-ports "${top_ports}")
+          fi
+
+          ./flan "${args[@]}"
 
       - name: Upload baseline inventory snapshot
         uses: actions/upload-artifact@v4

--- a/.github/workflows/cloudflare-baseline-scan.yml
+++ b/.github/workflows/cloudflare-baseline-scan.yml
@@ -47,10 +47,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.5.0
         with:
           go-version-file: go.mod
           cache: true
@@ -90,7 +90,7 @@ jobs:
           ./flan "${args[@]}"
 
       - name: Upload baseline inventory snapshot
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: cloudflare-baseline-inventory-${{ github.run_id }}
           path: ${{ env.INVENTORY_PATH }}
@@ -98,7 +98,7 @@ jobs:
           retention-days: 30
 
       - name: Upload baseline scan reports
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: cloudflare-baseline-reports-${{ github.run_id }}
           path: ${{ env.REPORTS_DIR }}

--- a/.github/workflows/cloudflare-baseline-scan.yml
+++ b/.github/workflows/cloudflare-baseline-scan.yml
@@ -1,0 +1,61 @@
+name: Cloudflare Baseline Scan
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "43 3 * * *"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: cloudflare-baseline-scan
+  cancel-in-progress: false
+
+jobs:
+  baseline-scan:
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    env:
+      REPORTS_DIR: reports
+      INVENTORY_PATH: reports/cloudflare-inventory-baseline.json
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Build flan
+        run: go build -o flan ./cmd/flan
+
+      - name: Prepare reports directory
+        run: mkdir -p "${REPORTS_DIR}"
+
+      - name: Run Cloudflare baseline scan
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+        run: |
+          ./flan \
+            --cloudflare \
+            --cloudflare-inventory-out "${INVENTORY_PATH}"
+
+      - name: Upload baseline inventory snapshot
+        uses: actions/upload-artifact@v4
+        with:
+          name: cloudflare-baseline-inventory-${{ github.run_id }}
+          path: ${{ env.INVENTORY_PATH }}
+          if-no-files-found: error
+          retention-days: 30
+
+      - name: Upload baseline scan reports
+        uses: actions/upload-artifact@v4
+        with:
+          name: cloudflare-baseline-reports-${{ github.run_id }}
+          path: ${{ env.REPORTS_DIR }}
+          if-no-files-found: warn
+          retention-days: 30

--- a/.github/workflows/cloudflare-delta-scan.yml
+++ b/.github/workflows/cloudflare-delta-scan.yml
@@ -1,0 +1,99 @@
+name: Cloudflare Delta Scan
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "17 */6 * * *"
+
+permissions:
+  contents: read
+  actions: read
+
+concurrency:
+  group: cloudflare-delta-scan
+  cancel-in-progress: false
+
+jobs:
+  delta-scan:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    env:
+      REPORTS_DIR: reports
+      INVENTORY_PATH: reports/cloudflare-inventory.json
+      PREVIOUS_INVENTORY_PATH: reports/previous-cloudflare-inventory.json
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Build flan
+        run: go build -o flan ./cmd/flan
+
+      - name: Prepare reports directory
+        run: mkdir -p "${REPORTS_DIR}"
+
+      - name: Locate previous inventory artifact
+        id: previous-artifact
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const artifacts = await github.paginate(
+              github.rest.actions.listArtifactsForRepo,
+              {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                per_page: 100,
+              }
+            );
+            const latest = artifacts
+              .filter((artifact) => !artifact.expired && artifact.name === "cloudflare-inventory-latest")
+              .sort((a, b) => new Date(b.created_at) - new Date(a.created_at))[0];
+            core.setOutput("url", latest ? latest.archive_download_url : "");
+
+      - name: Download previous inventory artifact
+        if: steps.previous-artifact.outputs.url != ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          curl -fsSL \
+            -H "Authorization: Bearer ${GH_TOKEN}" \
+            -H "Accept: application/vnd.github+json" \
+            "${{ steps.previous-artifact.outputs.url }}" \
+            -o "${RUNNER_TEMP}/cloudflare-inventory.zip"
+          unzip -o "${RUNNER_TEMP}/cloudflare-inventory.zip" -d "${RUNNER_TEMP}/cloudflare-inventory"
+          previous_inventory="$(find "${RUNNER_TEMP}/cloudflare-inventory" -type f -name 'cloudflare-inventory.json' | head -n 1)"
+          if [[ -n "${previous_inventory}" ]]; then
+            cp "${previous_inventory}" "${PREVIOUS_INVENTORY_PATH}"
+          fi
+
+      - name: Run Cloudflare delta scan
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+        run: |
+          ./flan \
+            --cloudflare \
+            --cloudflare-inventory-out "${INVENTORY_PATH}" \
+            --cloudflare-diff-against "${PREVIOUS_INVENTORY_PATH}" \
+            --cloudflare-delta-only
+
+      - name: Upload latest inventory snapshot
+        uses: actions/upload-artifact@v4
+        with:
+          name: cloudflare-inventory-latest
+          path: ${{ env.INVENTORY_PATH }}
+          if-no-files-found: error
+          retention-days: 30
+
+      - name: Upload delta scan reports
+        uses: actions/upload-artifact@v4
+        with:
+          name: cloudflare-delta-reports-${{ github.run_id }}
+          path: ${{ env.REPORTS_DIR }}
+          if-no-files-found: warn
+          retention-days: 30

--- a/.github/workflows/cloudflare-delta-scan.yml
+++ b/.github/workflows/cloudflare-delta-scan.yml
@@ -49,10 +49,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.5.0
         with:
           go-version-file: go.mod
           cache: true
@@ -65,7 +65,7 @@ jobs:
 
       - name: Locate previous inventory artifact
         id: previous-artifact
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.0.1
         with:
           script: |
             const runs = await github.paginate(
@@ -113,10 +113,12 @@ jobs:
             "${{ steps.previous-artifact.outputs.url }}" \
             -o "${RUNNER_TEMP}/cloudflare-inventory.zip"
           unzip -o "${RUNNER_TEMP}/cloudflare-inventory.zip" -d "${RUNNER_TEMP}/cloudflare-inventory"
-          previous_inventory="$(find "${RUNNER_TEMP}/cloudflare-inventory" -type f -name 'cloudflare-inventory.json' | head -n 1)"
-          if [[ -n "${previous_inventory}" ]]; then
-            cp "${previous_inventory}" "${PREVIOUS_INVENTORY_PATH}"
+          previous_inventory="${RUNNER_TEMP}/cloudflare-inventory/cloudflare-inventory.json"
+          if [[ ! -f "${previous_inventory}" ]]; then
+            echo "previous inventory artifact missing expected cloudflare-inventory.json payload" >&2
+            exit 1
           fi
+          cp "${previous_inventory}" "${PREVIOUS_INVENTORY_PATH}"
 
       - name: Run Cloudflare delta scan
         env:
@@ -149,7 +151,7 @@ jobs:
           ./flan "${args[@]}"
 
       - name: Upload latest inventory snapshot
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: cloudflare-inventory-latest
           path: ${{ env.INVENTORY_PATH }}
@@ -157,7 +159,7 @@ jobs:
           retention-days: 30
 
       - name: Upload delta scan reports
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: cloudflare-delta-reports-${{ github.run_id }}
           path: ${{ env.REPORTS_DIR }}

--- a/.github/workflows/cloudflare-delta-scan.yml
+++ b/.github/workflows/cloudflare-delta-scan.yml
@@ -2,6 +2,23 @@ name: Cloudflare Delta Scan
 
 on:
   workflow_dispatch:
+    inputs:
+      cloudflare_zones:
+        description: Comma-separated Cloudflare zones to scan
+        required: false
+        type: string
+      cloudflare_include:
+        description: Comma-separated hostname include filters
+        required: false
+        type: string
+      cloudflare_exclude:
+        description: Comma-separated hostname exclude filters
+        required: false
+        type: string
+      top_ports:
+        description: Top port preset for scanning (100, 1000, 2000, 5000)
+        required: false
+        type: string
   schedule:
     - cron: "17 */6 * * *"
 
@@ -21,6 +38,14 @@ jobs:
       REPORTS_DIR: reports
       INVENTORY_PATH: reports/cloudflare-inventory.json
       PREVIOUS_INVENTORY_PATH: reports/previous-cloudflare-inventory.json
+      WORKFLOW_CLOUDFLARE_ZONES: ${{ inputs.cloudflare_zones || '' }}
+      WORKFLOW_CLOUDFLARE_INCLUDE: ${{ inputs.cloudflare_include || '' }}
+      WORKFLOW_CLOUDFLARE_EXCLUDE: ${{ inputs.cloudflare_exclude || '' }}
+      WORKFLOW_TOP_PORTS: ${{ inputs.top_ports || '' }}
+      REPO_CLOUDFLARE_ZONES: ${{ vars.CLOUDFLARE_ZONES || '' }}
+      REPO_CLOUDFLARE_INCLUDE: ${{ vars.CLOUDFLARE_INCLUDE || '' }}
+      REPO_CLOUDFLARE_EXCLUDE: ${{ vars.CLOUDFLARE_EXCLUDE || '' }}
+      REPO_TOP_PORTS: ${{ vars.CLOUDFLARE_TOP_PORTS || '' }}
 
     steps:
       - name: Checkout
@@ -76,11 +101,31 @@ jobs:
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
         run: |
-          ./flan \
-            --cloudflare \
-            --cloudflare-inventory-out "${INVENTORY_PATH}" \
-            --cloudflare-diff-against "${PREVIOUS_INVENTORY_PATH}" \
+          zones="${WORKFLOW_CLOUDFLARE_ZONES:-${REPO_CLOUDFLARE_ZONES}}"
+          include="${WORKFLOW_CLOUDFLARE_INCLUDE:-${REPO_CLOUDFLARE_INCLUDE}}"
+          exclude="${WORKFLOW_CLOUDFLARE_EXCLUDE:-${REPO_CLOUDFLARE_EXCLUDE}}"
+          top_ports="${WORKFLOW_TOP_PORTS:-${REPO_TOP_PORTS}}"
+
+          args=(
+            --cloudflare
+            --cloudflare-inventory-out "${INVENTORY_PATH}"
+            --cloudflare-diff-against "${PREVIOUS_INVENTORY_PATH}"
             --cloudflare-delta-only
+          )
+          if [[ -n "${zones}" ]]; then
+            args+=(--cloudflare-zones "${zones}")
+          fi
+          if [[ -n "${include}" ]]; then
+            args+=(--cloudflare-include "${include}")
+          fi
+          if [[ -n "${exclude}" ]]; then
+            args+=(--cloudflare-exclude "${exclude}")
+          fi
+          if [[ -n "${top_ports}" ]]; then
+            args+=(--top-ports "${top_ports}")
+          fi
+
+          ./flan "${args[@]}"
 
       - name: Upload latest inventory snapshot
         uses: actions/upload-artifact@v4

--- a/.github/workflows/cloudflare-delta-scan.yml
+++ b/.github/workflows/cloudflare-delta-scan.yml
@@ -42,10 +42,10 @@ jobs:
       WORKFLOW_CLOUDFLARE_INCLUDE: ${{ inputs.cloudflare_include || '' }}
       WORKFLOW_CLOUDFLARE_EXCLUDE: ${{ inputs.cloudflare_exclude || '' }}
       WORKFLOW_TOP_PORTS: ${{ inputs.top_ports || '' }}
-      REPO_CLOUDFLARE_ZONES: ${{ vars.CLOUDFLARE_ZONES || '' }}
-      REPO_CLOUDFLARE_INCLUDE: ${{ vars.CLOUDFLARE_INCLUDE || '' }}
-      REPO_CLOUDFLARE_EXCLUDE: ${{ vars.CLOUDFLARE_EXCLUDE || '' }}
-      REPO_TOP_PORTS: ${{ vars.CLOUDFLARE_TOP_PORTS || '' }}
+      SECRET_CLOUDFLARE_ZONES: ${{ secrets.CLOUDFLARE_ZONES || '' }}
+      SECRET_CLOUDFLARE_INCLUDE: ${{ secrets.CLOUDFLARE_INCLUDE || '' }}
+      SECRET_CLOUDFLARE_EXCLUDE: ${{ secrets.CLOUDFLARE_EXCLUDE || '' }}
+      SECRET_TOP_PORTS: ${{ secrets.CLOUDFLARE_TOP_PORTS || '' }}
 
     steps:
       - name: Checkout
@@ -68,17 +68,38 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const artifacts = await github.paginate(
-              github.rest.actions.listArtifactsForRepo,
+            const runs = await github.paginate(
+              github.rest.actions.listWorkflowRuns,
               {
                 owner: context.repo.owner,
                 repo: context.repo.repo,
+                workflow_id: "cloudflare-delta-scan.yml",
+                branch: context.ref.replace("refs/heads/", ""),
+                status: "completed",
                 per_page: 100,
-              }
+              },
             );
-            const latest = artifacts
-              .filter((artifact) => !artifact.expired && artifact.name === "cloudflare-inventory-latest")
-              .sort((a, b) => new Date(b.created_at) - new Date(a.created_at))[0];
+
+            let latest = null;
+            for (const run of runs) {
+              if (run.id === context.runId || run.conclusion !== "success") {
+                continue;
+              }
+              const artifacts = await github.paginate(
+                github.rest.actions.listWorkflowRunArtifacts,
+                {
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  run_id: run.id,
+                  per_page: 100,
+                },
+              );
+              latest = artifacts.find((artifact) => !artifact.expired && artifact.name === "cloudflare-inventory-latest");
+              if (latest) {
+                break;
+              }
+            }
+
             core.setOutput("url", latest ? latest.archive_download_url : "");
 
       - name: Download previous inventory artifact
@@ -101,10 +122,10 @@ jobs:
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
         run: |
-          zones="${WORKFLOW_CLOUDFLARE_ZONES:-${REPO_CLOUDFLARE_ZONES}}"
-          include="${WORKFLOW_CLOUDFLARE_INCLUDE:-${REPO_CLOUDFLARE_INCLUDE}}"
-          exclude="${WORKFLOW_CLOUDFLARE_EXCLUDE:-${REPO_CLOUDFLARE_EXCLUDE}}"
-          top_ports="${WORKFLOW_TOP_PORTS:-${REPO_TOP_PORTS}}"
+          zones="${WORKFLOW_CLOUDFLARE_ZONES:-${SECRET_CLOUDFLARE_ZONES}}"
+          include="${WORKFLOW_CLOUDFLARE_INCLUDE:-${SECRET_CLOUDFLARE_INCLUDE}}"
+          exclude="${WORKFLOW_CLOUDFLARE_EXCLUDE:-${SECRET_CLOUDFLARE_EXCLUDE}}"
+          top_ports="${WORKFLOW_TOP_PORTS:-${SECRET_TOP_PORTS}}"
 
           args=(
             --cloudflare

--- a/README.md
+++ b/README.md
@@ -158,6 +158,12 @@ Diff the current Cloudflare inventory against a previous snapshot:
 flan --cloudflare --cloudflare-zones together.ai --cloudflare-inventory-out reports/cloudflare-together-ai.json --cloudflare-diff-against reports/cloudflare-together-ai-prev.json
 ```
 
+Scan only added/changed Cloudflare hosts when a previous snapshot exists:
+
+```
+flan --cloudflare --cloudflare-zones together.ai --cloudflare-inventory-out reports/cloudflare-together-ai.json --cloudflare-delta-only
+```
+
 Enable UDP scanning:
 
 ```
@@ -195,7 +201,7 @@ Header inspection behavior: security-header findings are generated for HTTP `2xx
 DNS resolution behavior: Flan uses a deterministic resolver chain (custom resolver when provided, otherwise system resolver, then configured fallbacks) and records resolver/cache stats in scan metadata.
 
 Cloudflare discovery behavior: Flan uses zones as the discovery boundary, keeps `A`, `AAAA`, and `CNAME` scan candidates, and skips validation, wildcard, and non-public-IP records by default.
-When Cloudflare discovery is enabled, Flan can also persist a normalized inventory snapshot and compare it against a prior snapshot for later diffing and scheduled scan workflows.
+When Cloudflare discovery is enabled, Flan can also persist a normalized inventory snapshot, compare it against a prior snapshot, and optionally narrow scans to added/changed hosts for scheduled delta workflows.
 
 Guardrails and DNS policy are configurable in `config/config.yaml`:
 
@@ -217,6 +223,7 @@ cloudflare:
   timeout: 15s
   inventory_out: ""
   diff_against: ""
+  delta_only: false
 ```
 
 ## Flags
@@ -238,6 +245,7 @@ cloudflare:
 | `--cloudflare-exclude` | Comma-separated hostname exclude filters |
 | `--cloudflare-inventory-out` | Write normalized Cloudflare inventory snapshot to this path |
 | `--cloudflare-diff-against` | Compare the current Cloudflare inventory against a previous snapshot |
+| `--cloudflare-delta-only` | Scan only added/changed Cloudflare hosts when a previous snapshot is available |
 | `--passive-only` | Skip brute-force, use passive sources only |
 | `--subdomains-only` | Print discovered subdomains and exit (no port scan) |
 | `--subfinder-sources` | Comma-separated passive sources override |

--- a/README.md
+++ b/README.md
@@ -146,6 +146,12 @@ Print Cloudflare-discovered hostnames only:
 flan --cloudflare --cloudflare-zones together.ai --subdomains-only
 ```
 
+Write a normalized Cloudflare inventory snapshot for later diffing:
+
+```
+flan --cloudflare --cloudflare-zones together.ai --cloudflare-inventory-out reports/cloudflare-together-ai.json
+```
+
 Enable UDP scanning:
 
 ```
@@ -183,6 +189,7 @@ Header inspection behavior: security-header findings are generated for HTTP `2xx
 DNS resolution behavior: Flan uses a deterministic resolver chain (custom resolver when provided, otherwise system resolver, then configured fallbacks) and records resolver/cache stats in scan metadata.
 
 Cloudflare discovery behavior: Flan uses zones as the discovery boundary, keeps `A`, `AAAA`, and `CNAME` scan candidates, and skips validation, wildcard, and non-public-IP records by default.
+When Cloudflare discovery is enabled, Flan can also persist a normalized inventory snapshot for later diffing and scheduled scan workflows.
 
 Guardrails and DNS policy are configurable in `config/config.yaml`:
 
@@ -202,6 +209,7 @@ cloudflare:
   exclude: []
   token_env: CLOUDFLARE_API_TOKEN
   timeout: 15s
+  inventory_out: ""
 ```
 
 ## Flags
@@ -221,6 +229,7 @@ cloudflare:
 | `--cloudflare-zones` | Comma-separated Cloudflare zone filter |
 | `--cloudflare-include` | Comma-separated hostname include filters |
 | `--cloudflare-exclude` | Comma-separated hostname exclude filters |
+| `--cloudflare-inventory-out` | Write normalized Cloudflare inventory snapshot to this path |
 | `--passive-only` | Skip brute-force, use passive sources only |
 | `--subdomains-only` | Print discovered subdomains and exit (no port scan) |
 | `--subfinder-sources` | Comma-separated passive sources override |

--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ Header inspection behavior: security-header findings are generated for HTTP `2xx
 DNS resolution behavior: Flan uses a deterministic resolver chain (custom resolver when provided, otherwise system resolver, then configured fallbacks) and records resolver/cache stats in scan metadata.
 
 Cloudflare discovery behavior: Flan uses zones as the discovery boundary, keeps `A`, `AAAA`, and `CNAME` scan candidates, and skips validation, wildcard, and non-public-IP records by default.
-When Cloudflare discovery is enabled, Flan can also persist a normalized inventory snapshot, compare it against a prior snapshot, and optionally narrow scans to added/changed hosts for scheduled delta workflows.
+When Cloudflare discovery is enabled, Flan can also persist a normalized inventory snapshot, compare it against a prior snapshot, and optionally narrow scans to added/changed hosts for scheduled delta workflows. If `--cloudflare-diff-against` is omitted but `--cloudflare-inventory-out` is set, Flan reuses the inventory output path as the diff base.
 
 For GitHub Actions automation, set the repository secret `CLOUDFLARE_API_TOKEN`. If you do not want Cloudflare scope in plaintext repo settings, either pass zones/include/exclude as manual workflow inputs or store them in secrets named `CLOUDFLARE_ZONES`, `CLOUDFLARE_INCLUDE`, `CLOUDFLARE_EXCLUDE`, and `CLOUDFLARE_TOP_PORTS`.
 
@@ -250,7 +250,7 @@ cloudflare:
 | `--cloudflare-include` | Comma-separated hostname include filters |
 | `--cloudflare-exclude` | Comma-separated hostname exclude filters |
 | `--cloudflare-inventory-out` | Write normalized Cloudflare inventory snapshot to this path |
-| `--cloudflare-diff-against` | Compare the current Cloudflare inventory against a previous snapshot |
+| `--cloudflare-diff-against` | Compare the current Cloudflare inventory against a previous snapshot; defaults to `--cloudflare-inventory-out` when omitted |
 | `--cloudflare-delta-only` | Scan only added/changed Cloudflare hosts when a previous snapshot is available |
 | `--passive-only` | Skip brute-force, use passive sources only |
 | `--subdomains-only` | Print discovered subdomains and exit (no port scan) |

--- a/README.md
+++ b/README.md
@@ -131,37 +131,37 @@ flan -d example.com --scan-cdn
 Discover scan targets from Cloudflare zones:
 
 ```
-flan --cloudflare --cloudflare-zones together.ai,together.xyz
+flan --cloudflare --cloudflare-zones example.net --cloudflare-include api.example.net
 ```
 
 Limit Cloudflare discovery to matching hostnames:
 
 ```
-flan --cloudflare --cloudflare-zones together.ai --cloudflare-include "*.together.ai" --cloudflare-exclude "internal.together.ai"
+flan --cloudflare --cloudflare-zones example.net --cloudflare-include "api.example.net" --cloudflare-exclude "internal.example.net"
 ```
 
 Print Cloudflare-discovered hostnames only:
 
 ```
-flan --cloudflare --cloudflare-zones together.ai --subdomains-only
+flan --cloudflare --cloudflare-zones example.net --cloudflare-include "api.example.net" --subdomains-only
 ```
 
 Write a normalized Cloudflare inventory snapshot for later diffing:
 
 ```
-flan --cloudflare --cloudflare-zones together.ai --cloudflare-inventory-out reports/cloudflare-together-ai.json
+flan --cloudflare --cloudflare-zones example.net --cloudflare-include "api.example.net" --cloudflare-inventory-out reports/cloudflare-example-net.json
 ```
 
 Diff the current Cloudflare inventory against a previous snapshot:
 
 ```
-flan --cloudflare --cloudflare-zones together.ai --cloudflare-inventory-out reports/cloudflare-together-ai.json --cloudflare-diff-against reports/cloudflare-together-ai-prev.json
+flan --cloudflare --cloudflare-zones example.net --cloudflare-include "api.example.net" --cloudflare-inventory-out reports/cloudflare-example-net.json --cloudflare-diff-against reports/cloudflare-example-net-prev.json
 ```
 
 Scan only added/changed Cloudflare hosts when a previous snapshot exists:
 
 ```
-flan --cloudflare --cloudflare-zones together.ai --cloudflare-inventory-out reports/cloudflare-together-ai.json --cloudflare-delta-only
+flan --cloudflare --cloudflare-zones example.net --cloudflare-include "api.example.net" --cloudflare-inventory-out reports/cloudflare-example-net.json --cloudflare-delta-only
 ```
 
 Enable UDP scanning:
@@ -203,7 +203,7 @@ DNS resolution behavior: Flan uses a deterministic resolver chain (custom resolv
 Cloudflare discovery behavior: Flan uses zones as the discovery boundary, keeps `A`, `AAAA`, and `CNAME` scan candidates, and skips validation, wildcard, and non-public-IP records by default.
 When Cloudflare discovery is enabled, Flan can also persist a normalized inventory snapshot, compare it against a prior snapshot, and optionally narrow scans to added/changed hosts for scheduled delta workflows.
 
-For GitHub Actions automation, set the repository secret `CLOUDFLARE_API_TOKEN`. Optional repository variables for the Cloudflare workflows are `CLOUDFLARE_ZONES`, `CLOUDFLARE_INCLUDE`, `CLOUDFLARE_EXCLUDE`, and `CLOUDFLARE_TOP_PORTS`. Manual workflow runs can override those values with workflow inputs.
+For GitHub Actions automation, set the repository secret `CLOUDFLARE_API_TOKEN`. If you do not want Cloudflare scope in plaintext repo settings, either pass zones/include/exclude as manual workflow inputs or store them in secrets named `CLOUDFLARE_ZONES`, `CLOUDFLARE_INCLUDE`, `CLOUDFLARE_EXCLUDE`, and `CLOUDFLARE_TOP_PORTS`.
 
 Guardrails and DNS policy are configurable in `config/config.yaml`:
 

--- a/README.md
+++ b/README.md
@@ -203,6 +203,8 @@ DNS resolution behavior: Flan uses a deterministic resolver chain (custom resolv
 Cloudflare discovery behavior: Flan uses zones as the discovery boundary, keeps `A`, `AAAA`, and `CNAME` scan candidates, and skips validation, wildcard, and non-public-IP records by default.
 When Cloudflare discovery is enabled, Flan can also persist a normalized inventory snapshot, compare it against a prior snapshot, and optionally narrow scans to added/changed hosts for scheduled delta workflows.
 
+For GitHub Actions automation, set the repository secret `CLOUDFLARE_API_TOKEN`. Optional repository variables for the Cloudflare workflows are `CLOUDFLARE_ZONES`, `CLOUDFLARE_INCLUDE`, `CLOUDFLARE_EXCLUDE`, and `CLOUDFLARE_TOP_PORTS`. Manual workflow runs can override those values with workflow inputs.
+
 Guardrails and DNS policy are configurable in `config/config.yaml`:
 
 ```yaml

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ A swiss-army scanner in Go. Successor to [Flan Scan](https://github.com/cloudfla
 - Passive subdomain enumeration via 10 no-key sources (crt.sh, Common Crawl, Wayback Machine, RapidDNS, Anubis, Digitorus, HudsonRock, SiteDossier, THC, ThreatCrowd)
 - CDN detection (Cloudflare) — limits scan to ports 80/443 by default on CDN hosts
 - DNS enumeration with wildcard detection and custom wordlist/resolver support
+- Cloudflare zone-based target discovery via `CLOUDFLARE_API_TOKEN`
 - NS, MX, TXT, CNAME record lookups
 - CIDR and stdin input support
 - nmap top 100/1000 port lists with expanded 2000/5000 presets
@@ -127,6 +128,24 @@ Scan all ports on CDN hosts (default is 80/443 only):
 flan -d example.com --scan-cdn
 ```
 
+Discover scan targets from Cloudflare zones:
+
+```
+flan --cloudflare --cloudflare-zones together.ai,together.xyz
+```
+
+Limit Cloudflare discovery to matching hostnames:
+
+```
+flan --cloudflare --cloudflare-zones together.ai --cloudflare-include "*.together.ai" --cloudflare-exclude "internal.together.ai"
+```
+
+Print Cloudflare-discovered hostnames only:
+
+```
+flan --cloudflare --cloudflare-zones together.ai --subdomains-only
+```
+
 Enable UDP scanning:
 
 ```
@@ -163,6 +182,8 @@ Header inspection behavior: security-header findings are generated for HTTP `2xx
 
 DNS resolution behavior: Flan uses a deterministic resolver chain (custom resolver when provided, otherwise system resolver, then configured fallbacks) and records resolver/cache stats in scan metadata.
 
+Cloudflare discovery behavior: Flan uses zones as the discovery boundary, keeps `A`, `AAAA`, and `CNAME` scan candidates, and skips validation, wildcard, and non-public-IP records by default.
+
 Guardrails and DNS policy are configurable in `config/config.yaml`:
 
 ```yaml
@@ -174,6 +195,13 @@ dns:
   resolver: ""
   fallback_resolvers: ["1.1.1.1:53", "8.8.8.8:53"]
   lookup_timeout: 3s
+cloudflare:
+  enabled: false
+  zones: []
+  include: []
+  exclude: []
+  token_env: CLOUDFLARE_API_TOKEN
+  timeout: 15s
 ```
 
 ## Flags
@@ -189,6 +217,10 @@ dns:
 | `-c` | Config file (default `config/config.yaml`) |
 | `-w` | Custom DNS subdomain wordlist |
 | `-r` | Custom DNS resolver (ip:port) |
+| `--cloudflare` | Discover scan targets from Cloudflare zone DNS records |
+| `--cloudflare-zones` | Comma-separated Cloudflare zone filter |
+| `--cloudflare-include` | Comma-separated hostname include filters |
+| `--cloudflare-exclude` | Comma-separated hostname exclude filters |
 | `--passive-only` | Skip brute-force, use passive sources only |
 | `--subdomains-only` | Print discovered subdomains and exit (no port scan) |
 | `--subfinder-sources` | Comma-separated passive sources override |

--- a/README.md
+++ b/README.md
@@ -152,6 +152,12 @@ Write a normalized Cloudflare inventory snapshot for later diffing:
 flan --cloudflare --cloudflare-zones together.ai --cloudflare-inventory-out reports/cloudflare-together-ai.json
 ```
 
+Diff the current Cloudflare inventory against a previous snapshot:
+
+```
+flan --cloudflare --cloudflare-zones together.ai --cloudflare-inventory-out reports/cloudflare-together-ai.json --cloudflare-diff-against reports/cloudflare-together-ai-prev.json
+```
+
 Enable UDP scanning:
 
 ```
@@ -189,7 +195,7 @@ Header inspection behavior: security-header findings are generated for HTTP `2xx
 DNS resolution behavior: Flan uses a deterministic resolver chain (custom resolver when provided, otherwise system resolver, then configured fallbacks) and records resolver/cache stats in scan metadata.
 
 Cloudflare discovery behavior: Flan uses zones as the discovery boundary, keeps `A`, `AAAA`, and `CNAME` scan candidates, and skips validation, wildcard, and non-public-IP records by default.
-When Cloudflare discovery is enabled, Flan can also persist a normalized inventory snapshot for later diffing and scheduled scan workflows.
+When Cloudflare discovery is enabled, Flan can also persist a normalized inventory snapshot and compare it against a prior snapshot for later diffing and scheduled scan workflows.
 
 Guardrails and DNS policy are configurable in `config/config.yaml`:
 
@@ -210,6 +216,7 @@ cloudflare:
   token_env: CLOUDFLARE_API_TOKEN
   timeout: 15s
   inventory_out: ""
+  diff_against: ""
 ```
 
 ## Flags
@@ -230,6 +237,7 @@ cloudflare:
 | `--cloudflare-include` | Comma-separated hostname include filters |
 | `--cloudflare-exclude` | Comma-separated hostname exclude filters |
 | `--cloudflare-inventory-out` | Write normalized Cloudflare inventory snapshot to this path |
+| `--cloudflare-diff-against` | Compare the current Cloudflare inventory against a previous snapshot |
 | `--passive-only` | Skip brute-force, use passive sources only |
 | `--subdomains-only` | Print discovered subdomains and exit (no port scan) |
 | `--subfinder-sources` | Comma-separated passive sources override |

--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 # flan
 
+[![Go 1.23+](https://img.shields.io/badge/Go-1.23%2B-00ADD8?logo=go&logoColor=white)](https://go.dev/dl/)
+[![License: BSD 3-Clause](https://img.shields.io/badge/License-BSD%203--Clause-blue.svg)](LICENSE)
+[![CI](https://github.com/therandomsecurityguy/flan-go-scan/actions/workflows/ci.yml/badge.svg)](https://github.com/therandomsecurityguy/flan-go-scan/actions/workflows/ci.yml)
+
 A swiss-army scanner in Go. Successor to [Flan Scan](https://github.com/cloudflare/flan).
 
 ## Features

--- a/cmd/flan/main.go
+++ b/cmd/flan/main.go
@@ -63,7 +63,7 @@ CONFIGURATION:
   --cloudflare-include string comma-separated hostname include filters
   --cloudflare-exclude string comma-separated hostname exclude filters
   --cloudflare-inventory-out string write normalized Cloudflare inventory snapshot to this path
-  --cloudflare-diff-against string compare the current Cloudflare inventory against a previous snapshot
+  --cloudflare-diff-against string compare the current Cloudflare inventory against a previous snapshot (defaults to --cloudflare-inventory-out when omitted)
   --cloudflare-delta-only scan only added/changed Cloudflare hosts when a previous snapshot is available
   --passive-only           skip brute-force, use passive sources only
   --subdomains-only        print discovered subdomains and exit (subfinder-style)
@@ -418,6 +418,7 @@ func main() {
 		deltaOnly := cfg.Cloudflare.DeltaOnly || *cloudflareDeltaOnly
 		if diffAgainst == "" && inventoryOut != "" {
 			diffAgainst = inventoryOut
+			slog.Info("cloudflare inventory diff base defaults to inventory output", "path", diffAgainst)
 		}
 		if diffAgainst != "" {
 			previous, err := output.ReadCloudflareInventory(diffAgainst)

--- a/cmd/flan/main.go
+++ b/cmd/flan/main.go
@@ -63,6 +63,7 @@ CONFIGURATION:
   --cloudflare-include string comma-separated hostname include filters
   --cloudflare-exclude string comma-separated hostname exclude filters
   --cloudflare-inventory-out string write normalized Cloudflare inventory snapshot to this path
+  --cloudflare-diff-against string compare the current Cloudflare inventory against a previous snapshot
   --passive-only           skip brute-force, use passive sources only
   --subdomains-only        print discovered subdomains and exit (subfinder-style)
   --subfinder-sources string comma-separated passive sources override
@@ -231,6 +232,7 @@ func main() {
 	cloudflareInclude := flag.String("cloudflare-include", "", "")
 	cloudflareExclude := flag.String("cloudflare-exclude", "", "")
 	cloudflareInventoryOut := flag.String("cloudflare-inventory-out", "", "")
+	cloudflareDiffAgainst := flag.String("cloudflare-diff-against", "", "")
 	passiveOnly := flag.Bool("passive-only", false, "")
 	subdomainsOnly := flag.Bool("subdomains-only", false, "")
 	subfinderSources := flag.String("subfinder-sources", "", "")
@@ -406,6 +408,27 @@ func main() {
 			inventoryOut = strings.TrimSpace(*cloudflareInventoryOut)
 		}
 		snapshot := cfprovider.BuildInventorySnapshot(scanStarted, assets, discoverOpts)
+		diffAgainst := strings.TrimSpace(cfg.Cloudflare.DiffAgainst)
+		if set["cloudflare-diff-against"] {
+			diffAgainst = strings.TrimSpace(*cloudflareDiffAgainst)
+		}
+		if diffAgainst == "" && inventoryOut != "" {
+			diffAgainst = inventoryOut
+		}
+		if diffAgainst != "" {
+			previous, err := output.ReadCloudflareInventory(diffAgainst)
+			if err == nil {
+				diff := cfprovider.DiffInventory(scanStarted, previous, snapshot)
+				slog.Info("cloudflare inventory diff", "added", diff.AddedCount, "removed", diff.RemovedCount, "changed", diff.ChangedCount)
+				if path, err := output.WriteCloudflareInventoryDiff(cfg.Output.Directory, inventoryOut, diff); err != nil {
+					slog.Warn("failed to write cloudflare inventory diff", "err", err)
+				} else if path != "" {
+					slog.Info("cloudflare inventory diff written", "path", path)
+				}
+			} else if !os.IsNotExist(err) {
+				slog.Warn("failed to read previous cloudflare inventory", "path", diffAgainst, "err", err)
+			}
+		}
 		if path, err := output.WriteCloudflareInventory(cfg.Output.Directory, inventoryOut, snapshot); err != nil {
 			slog.Warn("failed to write cloudflare inventory", "err", err)
 		} else if path != "" {

--- a/cmd/flan/main.go
+++ b/cmd/flan/main.go
@@ -64,6 +64,7 @@ CONFIGURATION:
   --cloudflare-exclude string comma-separated hostname exclude filters
   --cloudflare-inventory-out string write normalized Cloudflare inventory snapshot to this path
   --cloudflare-diff-against string compare the current Cloudflare inventory against a previous snapshot
+  --cloudflare-delta-only scan only added/changed Cloudflare hosts when a previous snapshot is available
   --passive-only           skip brute-force, use passive sources only
   --subdomains-only        print discovered subdomains and exit (subfinder-style)
   --subfinder-sources string comma-separated passive sources override
@@ -233,6 +234,7 @@ func main() {
 	cloudflareExclude := flag.String("cloudflare-exclude", "", "")
 	cloudflareInventoryOut := flag.String("cloudflare-inventory-out", "", "")
 	cloudflareDiffAgainst := flag.String("cloudflare-diff-against", "", "")
+	cloudflareDeltaOnly := flag.Bool("cloudflare-delta-only", false, "")
 	passiveOnly := flag.Bool("passive-only", false, "")
 	subdomainsOnly := flag.Bool("subdomains-only", false, "")
 	subfinderSources := flag.String("subfinder-sources", "", "")
@@ -359,6 +361,7 @@ func main() {
 	}()
 
 	var hosts []string
+	noTargetsFromDelta := false
 
 	if tgt != "" {
 		hosts = append(hosts, tgt)
@@ -402,7 +405,7 @@ func main() {
 			os.Exit(1)
 		}
 		cfHosts := cfprovider.Hostnames(assets)
-		hosts = append(hosts, cfHosts...)
+		selectedCFHosts := cfHosts
 		inventoryOut := strings.TrimSpace(cfg.Cloudflare.InventoryOut)
 		if set["cloudflare-inventory-out"] {
 			inventoryOut = strings.TrimSpace(*cloudflareInventoryOut)
@@ -412,6 +415,7 @@ func main() {
 		if set["cloudflare-diff-against"] {
 			diffAgainst = strings.TrimSpace(*cloudflareDiffAgainst)
 		}
+		deltaOnly := cfg.Cloudflare.DeltaOnly || *cloudflareDeltaOnly
 		if diffAgainst == "" && inventoryOut != "" {
 			diffAgainst = inventoryOut
 		}
@@ -420,6 +424,11 @@ func main() {
 			if err == nil {
 				diff := cfprovider.DiffInventory(scanStarted, previous, snapshot)
 				slog.Info("cloudflare inventory diff", "added", diff.AddedCount, "removed", diff.RemovedCount, "changed", diff.ChangedCount)
+				if deltaOnly {
+					selectedCFHosts = cfprovider.HostnamesFromDiff(diff)
+					noTargetsFromDelta = len(selectedCFHosts) == 0
+					slog.Info("cloudflare delta scan selection", "hosts", len(selectedCFHosts))
+				}
 				if path, err := output.WriteCloudflareInventoryDiff(cfg.Output.Directory, inventoryOut, diff); err != nil {
 					slog.Warn("failed to write cloudflare inventory diff", "err", err)
 				} else if path != "" {
@@ -427,14 +436,19 @@ func main() {
 				}
 			} else if !os.IsNotExist(err) {
 				slog.Warn("failed to read previous cloudflare inventory", "path", diffAgainst, "err", err)
+			} else if deltaOnly {
+				slog.Info("cloudflare delta scan fallback to full inventory; previous snapshot not found", "path", diffAgainst)
 			}
+		} else if deltaOnly {
+			slog.Info("cloudflare delta scan fallback to full inventory; no previous snapshot configured")
 		}
 		if path, err := output.WriteCloudflareInventory(cfg.Output.Directory, inventoryOut, snapshot); err != nil {
 			slog.Warn("failed to write cloudflare inventory", "err", err)
 		} else if path != "" {
 			slog.Info("cloudflare inventory written", "path", path)
 		}
-		slog.Info("cloudflare discovery complete", "assets", len(assets), "hosts", len(cfHosts))
+		hosts = append(hosts, selectedCFHosts...)
+		slog.Info("cloudflare discovery complete", "assets", len(assets), "hosts", len(cfHosts), "scan_hosts", len(selectedCFHosts))
 		if *subdomainsOnly && dom == "" {
 			for _, host := range cfHosts {
 				fmt.Println(host)
@@ -558,6 +572,10 @@ func main() {
 	}
 
 	if len(hosts) == 0 {
+		if noTargetsFromDelta {
+			slog.Info("no Cloudflare delta hosts to scan")
+			return
+		}
 		slog.Error("no hosts to scan, provide -t, -d, or -l")
 		os.Exit(1)
 	}

--- a/cmd/flan/main.go
+++ b/cmd/flan/main.go
@@ -20,6 +20,7 @@ import (
 	"github.com/therandomsecurityguy/flan-go-scan/internal/config"
 	"github.com/therandomsecurityguy/flan-go-scan/internal/dns"
 	"github.com/therandomsecurityguy/flan-go-scan/internal/output"
+	cfprovider "github.com/therandomsecurityguy/flan-go-scan/internal/providers/cloudflare"
 	"github.com/therandomsecurityguy/flan-go-scan/internal/scanner"
 	"golang.org/x/sync/singleflight"
 )
@@ -57,6 +58,10 @@ CONFIGURATION:
   -c, -config string       path to config file (default "config/config.yaml")
   -w, -wordlist string     custom DNS subdomain wordlist file
   -r, -resolver string     custom DNS resolver (ip:port)
+  --cloudflare             discover scan targets from Cloudflare zones
+  --cloudflare-zones string comma-separated Cloudflare zone filter
+  --cloudflare-include string comma-separated hostname include filters
+  --cloudflare-exclude string comma-separated hostname exclude filters
   --passive-only           skip brute-force, use passive sources only
   --subdomains-only        print discovered subdomains and exit (subfinder-style)
   --subfinder-sources string comma-separated passive sources override
@@ -86,6 +91,7 @@ EXAMPLES:
   flan -t scanme.nmap.org
   flan -l targets.txt --top-ports 1000
   flan -d together.ai
+  flan --cloudflare --cloudflare-zones together.ai,together.xyz
   flan -d together.ai --subdomains-only
   echo "10.0.0.0/24" | flan -l -
 
@@ -219,6 +225,10 @@ func main() {
 	wordlistShort := flag.String("w", "", "")
 	resolver := flag.String("resolver", "", "")
 	resolverShort := flag.String("r", "", "")
+	cloudflareFlag := flag.Bool("cloudflare", false, "")
+	cloudflareZones := flag.String("cloudflare-zones", "", "")
+	cloudflareInclude := flag.String("cloudflare-include", "", "")
+	cloudflareExclude := flag.String("cloudflare-exclude", "", "")
 	passiveOnly := flag.Bool("passive-only", false, "")
 	subdomainsOnly := flag.Bool("subdomains-only", false, "")
 	subfinderSources := flag.String("subfinder-sources", "", "")
@@ -288,8 +298,9 @@ func main() {
 	if *passiveOnly && dom == "" {
 		slog.Warn("--passive-only has no effect without -d")
 	}
-	if *subdomainsOnly && dom == "" {
-		slog.Error("--subdomains-only requires -d/--domain")
+	cloudflareEnabled := *cloudflareFlag || cfg.Cloudflare.Enabled
+	if *subdomainsOnly && dom == "" && !cloudflareEnabled {
+		slog.Error("--subdomains-only requires -d/--domain or --cloudflare")
 		os.Exit(1)
 	}
 	if *subdomainsOnly {
@@ -347,7 +358,56 @@ func main() {
 
 	if tgt != "" {
 		hosts = append(hosts, tgt)
-	} else if dom != "" {
+	}
+	if cloudflareEnabled {
+		tokenEnv := strings.TrimSpace(cfg.Cloudflare.TokenEnv)
+		if tokenEnv == "" {
+			tokenEnv = "CLOUDFLARE_API_TOKEN"
+		}
+		token := strings.TrimSpace(os.Getenv(tokenEnv))
+		if token == "" {
+			slog.Error("cloudflare token env var is not set", "env", tokenEnv)
+			os.Exit(1)
+		}
+
+		client, err := cfprovider.NewClient(token, cfg.Cloudflare.Timeout)
+		if err != nil {
+			slog.Error("failed to initialize cloudflare client", "err", err)
+			os.Exit(1)
+		}
+
+		discoverOpts := cfprovider.DiscoverOptions{
+			Zones:   cfg.Cloudflare.Zones,
+			Include: cfg.Cloudflare.Include,
+			Exclude: cfg.Cloudflare.Exclude,
+		}
+		if set["cloudflare-zones"] {
+			discoverOpts.Zones = splitCSV(*cloudflareZones)
+		}
+		if set["cloudflare-include"] {
+			discoverOpts.Include = splitCSV(*cloudflareInclude)
+		}
+		if set["cloudflare-exclude"] {
+			discoverOpts.Exclude = splitCSV(*cloudflareExclude)
+		}
+
+		slog.Info("discovering targets from Cloudflare", "zones", len(discoverOpts.Zones))
+		assets, err := client.Discover(ctx, discoverOpts)
+		if err != nil {
+			slog.Error("cloudflare discovery failed", "err", err)
+			os.Exit(1)
+		}
+		cfHosts := cfprovider.Hostnames(assets)
+		hosts = append(hosts, cfHosts...)
+		slog.Info("cloudflare discovery complete", "assets", len(assets), "hosts", len(cfHosts))
+		if *subdomainsOnly && dom == "" {
+			for _, host := range cfHosts {
+				fmt.Println(host)
+			}
+			return
+		}
+	}
+	if dom != "" {
 		slog.Info("enumerating subdomains", "domain", dom)
 
 		slog.Info("running passive enumeration")
@@ -453,7 +513,8 @@ func main() {
 		if err == nil && len(txtRecords) > 0 {
 			slog.Info("TXT records", "records", txtRecords)
 		}
-	} else {
+	}
+	if tgt == "" && dom == "" && !cloudflareEnabled {
 		hosts, err = readHosts(ipsFile)
 		if err != nil {
 			slog.Error("failed to read hosts", "err", err)
@@ -517,7 +578,7 @@ func main() {
 	}
 	aliveTargets := len(targets)
 	metaInput := scanMetadataInput{
-		mode:            scanMode(dom != ""),
+		mode:            scanMode(dom != "", cloudflareEnabled),
 		inputTargets:    inputTargets,
 		resolvedTargets: resolvedTargets,
 		aliveTargets:    aliveTargets,
@@ -1563,7 +1624,13 @@ func enforceScanGuardrails(targetCount, portCount int, cfg *config.Config) error
 	return nil
 }
 
-func scanMode(domainMode bool) string {
+func scanMode(domainMode bool, cloudflareMode bool) string {
+	if domainMode && cloudflareMode {
+		return "cloudflare+domain"
+	}
+	if cloudflareMode {
+		return "cloudflare"
+	}
 	if domainMode {
 		return "domain"
 	}

--- a/cmd/flan/main.go
+++ b/cmd/flan/main.go
@@ -62,6 +62,7 @@ CONFIGURATION:
   --cloudflare-zones string comma-separated Cloudflare zone filter
   --cloudflare-include string comma-separated hostname include filters
   --cloudflare-exclude string comma-separated hostname exclude filters
+  --cloudflare-inventory-out string write normalized Cloudflare inventory snapshot to this path
   --passive-only           skip brute-force, use passive sources only
   --subdomains-only        print discovered subdomains and exit (subfinder-style)
   --subfinder-sources string comma-separated passive sources override
@@ -229,6 +230,7 @@ func main() {
 	cloudflareZones := flag.String("cloudflare-zones", "", "")
 	cloudflareInclude := flag.String("cloudflare-include", "", "")
 	cloudflareExclude := flag.String("cloudflare-exclude", "", "")
+	cloudflareInventoryOut := flag.String("cloudflare-inventory-out", "", "")
 	passiveOnly := flag.Bool("passive-only", false, "")
 	subdomainsOnly := flag.Bool("subdomains-only", false, "")
 	subfinderSources := flag.String("subfinder-sources", "", "")
@@ -399,6 +401,16 @@ func main() {
 		}
 		cfHosts := cfprovider.Hostnames(assets)
 		hosts = append(hosts, cfHosts...)
+		inventoryOut := strings.TrimSpace(cfg.Cloudflare.InventoryOut)
+		if set["cloudflare-inventory-out"] {
+			inventoryOut = strings.TrimSpace(*cloudflareInventoryOut)
+		}
+		snapshot := cfprovider.BuildInventorySnapshot(scanStarted, assets, discoverOpts)
+		if path, err := output.WriteCloudflareInventory(cfg.Output.Directory, inventoryOut, snapshot); err != nil {
+			slog.Warn("failed to write cloudflare inventory", "err", err)
+		} else if path != "" {
+			slog.Info("cloudflare inventory written", "path", path)
+		}
 		slog.Info("cloudflare discovery complete", "assets", len(assets), "hosts", len(cfHosts))
 		if *subdomainsOnly && dom == "" {
 			for _, host := range cfHosts {

--- a/cmd/flan/main.go
+++ b/cmd/flan/main.go
@@ -1095,12 +1095,13 @@ func printResult(res scanner.ScanResult) {
 
 	if scanner.IsHTTPService(res.Service, res.Port, res.TLS != nil) {
 		eligible, statusCode := headerInspectionEligible(res)
+		displayFindings := displaySecurityHeaderFindings(res)
 		if !eligible {
 			fmt.Printf("  %s~  security headers skipped on HTTP status %d%s\n", dim, statusCode, reset)
-		} else if len(res.SecurityHeaders) == 0 {
+		} else if len(displayFindings) == 0 {
 			fmt.Printf("  %s✓  security headers OK%s\n", green, reset)
 		} else {
-			for _, f := range res.SecurityHeaders {
+			for _, f := range displayFindings {
 				color := yellow
 				if f.Severity == "HIGH" {
 					color = red
@@ -1636,6 +1637,35 @@ func headerInspectionEligible(res scanner.ScanResult) (bool, int) {
 		return true, meta.StatusCode
 	}
 	return false, meta.StatusCode
+}
+
+func displaySecurityHeaderFindings(res scanner.ScanResult) []scanner.HeaderFinding {
+	findings := make([]scanner.HeaderFinding, 0, len(res.SecurityHeaders))
+	for _, finding := range res.SecurityHeaders {
+		if suppressPrettyHeaderFinding(res, finding) {
+			continue
+		}
+		findings = append(findings, finding)
+	}
+	return findings
+}
+
+func suppressPrettyHeaderFinding(res scanner.ScanResult, finding scanner.HeaderFinding) bool {
+	if finding.Header != "HTTP Probe" || !strings.EqualFold(finding.Severity, "LOW") {
+		return false
+	}
+
+	host := strings.ToLower(strings.TrimSpace(res.Hostname))
+	version := strings.ToLower(strings.TrimSpace(res.Version))
+	detail := strings.ToLower(finding.Detail)
+
+	if strings.Contains(host, ".internal.") || strings.HasPrefix(version, "awselb/") {
+		return strings.Contains(detail, "connection reset") ||
+			strings.Contains(detail, "context deadline exceeded") ||
+			strings.Contains(detail, "client.timeout exceeded")
+	}
+
+	return false
 }
 
 func pick(set map[string]bool, long string, longVal *string, short string, shortVal *string, def string) string {

--- a/cmd/flan/main.go
+++ b/cmd/flan/main.go
@@ -93,9 +93,9 @@ OUTPUT:
 EXAMPLES:
   flan -t scanme.nmap.org
   flan -l targets.txt --top-ports 1000
-  flan -d together.ai
-  flan --cloudflare --cloudflare-zones together.ai,together.xyz
-  flan -d together.ai --subdomains-only
+  flan -d example.net
+  flan --cloudflare --cloudflare-zones example.net --cloudflare-include api.example.net
+  flan -d example.net --subdomains-only
   echo "10.0.0.0/24" | flan -l -
 
 `)
@@ -450,7 +450,7 @@ func main() {
 		hosts = append(hosts, selectedCFHosts...)
 		slog.Info("cloudflare discovery complete", "assets", len(assets), "hosts", len(cfHosts), "scan_hosts", len(selectedCFHosts))
 		if *subdomainsOnly && dom == "" {
-			for _, host := range cfHosts {
+			for _, host := range cloudflareOutputHosts(cfHosts, selectedCFHosts, deltaOnly) {
 				fmt.Println(host)
 			}
 			return
@@ -1648,6 +1648,13 @@ func displaySecurityHeaderFindings(res scanner.ScanResult) []scanner.HeaderFindi
 		findings = append(findings, finding)
 	}
 	return findings
+}
+
+func cloudflareOutputHosts(allHosts, selectedHosts []string, deltaOnly bool) []string {
+	if deltaOnly {
+		return selectedHosts
+	}
+	return allHosts
 }
 
 func suppressPrettyHeaderFinding(res scanner.ScanResult, finding scanner.HeaderFinding) bool {

--- a/cmd/flan/main_test.go
+++ b/cmd/flan/main_test.go
@@ -203,3 +203,38 @@ func TestIsTransientAPIValidationError(t *testing.T) {
 		t.Fatal("did not expect authorization failures to be transient")
 	}
 }
+
+func TestDisplaySecurityHeaderFindingsSuppressesInternalProbeNoise(t *testing.T) {
+	res := scanner.ScanResult{
+		Hostname: "metricstore.internal.together.ai",
+		Service:  "http",
+		Version:  "awselb/2.0",
+		SecurityHeaders: []scanner.HeaderFinding{
+			{Header: "HTTP Probe", Severity: "LOW", Detail: "header inspection failed: read tcp 1.2.3.4:123->5.6.7.8:443: read: connection reset by peer"},
+			{Header: "Content-Security-Policy", Severity: "MEDIUM", Detail: "missing CSP"},
+		},
+	}
+
+	findings := displaySecurityHeaderFindings(res)
+	if len(findings) != 1 {
+		t.Fatalf("expected one visible finding, got %d: %#v", len(findings), findings)
+	}
+	if findings[0].Header != "Content-Security-Policy" {
+		t.Fatalf("unexpected visible finding: %#v", findings[0])
+	}
+}
+
+func TestDisplaySecurityHeaderFindingsKeepsPublicProbeNoise(t *testing.T) {
+	res := scanner.ScanResult{
+		Hostname: "api-aws.together.ai",
+		Service:  "http",
+		SecurityHeaders: []scanner.HeaderFinding{
+			{Header: "HTTP Probe", Severity: "LOW", Detail: "header inspection failed: Get \"http://1.2.3.4:80/\": context deadline exceeded"},
+		},
+	}
+
+	findings := displaySecurityHeaderFindings(res)
+	if len(findings) != 1 {
+		t.Fatalf("expected public probe failure to remain visible, got %#v", findings)
+	}
+}

--- a/cmd/flan/main_test.go
+++ b/cmd/flan/main_test.go
@@ -206,7 +206,7 @@ func TestIsTransientAPIValidationError(t *testing.T) {
 
 func TestDisplaySecurityHeaderFindingsSuppressesInternalProbeNoise(t *testing.T) {
 	res := scanner.ScanResult{
-		Hostname: "metricstore.internal.together.ai",
+		Hostname: "internal-api.example.net",
 		Service:  "http",
 		Version:  "awselb/2.0",
 		SecurityHeaders: []scanner.HeaderFinding{
@@ -226,7 +226,7 @@ func TestDisplaySecurityHeaderFindingsSuppressesInternalProbeNoise(t *testing.T)
 
 func TestDisplaySecurityHeaderFindingsKeepsPublicProbeNoise(t *testing.T) {
 	res := scanner.ScanResult{
-		Hostname: "api-aws.together.ai",
+		Hostname: "api.example.net",
 		Service:  "http",
 		SecurityHeaders: []scanner.HeaderFinding{
 			{Header: "HTTP Probe", Severity: "LOW", Detail: "header inspection failed: Get \"http://1.2.3.4:80/\": context deadline exceeded"},
@@ -236,5 +236,20 @@ func TestDisplaySecurityHeaderFindingsKeepsPublicProbeNoise(t *testing.T) {
 	findings := displaySecurityHeaderFindings(res)
 	if len(findings) != 1 {
 		t.Fatalf("expected public probe failure to remain visible, got %#v", findings)
+	}
+}
+
+func TestCloudflareOutputHostsUsesDeltaSelection(t *testing.T) {
+	allHosts := []string{"api.example.net", "admin.example.net"}
+	selectedHosts := []string{"api.example.net"}
+
+	got := cloudflareOutputHosts(allHosts, selectedHosts, true)
+	if !reflect.DeepEqual(got, selectedHosts) {
+		t.Fatalf("unexpected delta hosts: got %v want %v", got, selectedHosts)
+	}
+
+	got = cloudflareOutputHosts(allHosts, selectedHosts, false)
+	if !reflect.DeepEqual(got, allHosts) {
+		t.Fatalf("unexpected full hosts: got %v want %v", got, allHosts)
 	}
 }

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -33,3 +33,10 @@ output:
   directory: ./reports
 checkpoint:
   file: scan-state.json
+cloudflare:
+  enabled: false
+  zones: []
+  include: []
+  exclude: []
+  token_env: CLOUDFLARE_API_TOKEN
+  timeout: 15s

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -40,3 +40,4 @@ cloudflare:
   exclude: []
   token_env: CLOUDFLARE_API_TOKEN
   timeout: 15s
+  inventory_out: ""

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -41,3 +41,4 @@ cloudflare:
   token_env: CLOUDFLARE_API_TOKEN
   timeout: 15s
   inventory_out: ""
+  diff_against: ""

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -42,3 +42,4 @@ cloudflare:
   timeout: 15s
   inventory_out: ""
   diff_against: ""
+  delta_only: false

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -90,9 +90,6 @@ func defaults() *Config {
 	cfg.Output.Directory = "-"
 	cfg.Checkpoint.File = "scan-state.json"
 	cfg.Cloudflare.Enabled = false
-	cfg.Cloudflare.Zones = nil
-	cfg.Cloudflare.Include = nil
-	cfg.Cloudflare.Exclude = nil
 	cfg.Cloudflare.TokenEnv = "CLOUDFLARE_API_TOKEN"
 	cfg.Cloudflare.Timeout = 15 * time.Second
 	cfg.Cloudflare.InventoryOut = ""

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -46,6 +46,14 @@ type Config struct {
 	Checkpoint struct {
 		File string `mapstructure:"file"`
 	} `mapstructure:"checkpoint"`
+	Cloudflare struct {
+		Enabled  bool          `mapstructure:"enabled"`
+		Zones    []string      `mapstructure:"zones"`
+		Include  []string      `mapstructure:"include"`
+		Exclude  []string      `mapstructure:"exclude"`
+		TokenEnv string        `mapstructure:"token_env"`
+		Timeout  time.Duration `mapstructure:"timeout"`
+	} `mapstructure:"cloudflare"`
 }
 
 func defaults() *Config {
@@ -78,6 +86,12 @@ func defaults() *Config {
 	cfg.Output.Format = "jsonl"
 	cfg.Output.Directory = "-"
 	cfg.Checkpoint.File = "scan-state.json"
+	cfg.Cloudflare.Enabled = false
+	cfg.Cloudflare.Zones = nil
+	cfg.Cloudflare.Include = nil
+	cfg.Cloudflare.Exclude = nil
+	cfg.Cloudflare.TokenEnv = "CLOUDFLARE_API_TOKEN"
+	cfg.Cloudflare.Timeout = 15 * time.Second
 	return cfg
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -54,6 +54,7 @@ type Config struct {
 		TokenEnv     string        `mapstructure:"token_env"`
 		Timeout      time.Duration `mapstructure:"timeout"`
 		InventoryOut string        `mapstructure:"inventory_out"`
+		DiffAgainst  string        `mapstructure:"diff_against"`
 	} `mapstructure:"cloudflare"`
 }
 
@@ -94,6 +95,7 @@ func defaults() *Config {
 	cfg.Cloudflare.TokenEnv = "CLOUDFLARE_API_TOKEN"
 	cfg.Cloudflare.Timeout = 15 * time.Second
 	cfg.Cloudflare.InventoryOut = ""
+	cfg.Cloudflare.DiffAgainst = ""
 	return cfg
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -55,6 +55,7 @@ type Config struct {
 		Timeout      time.Duration `mapstructure:"timeout"`
 		InventoryOut string        `mapstructure:"inventory_out"`
 		DiffAgainst  string        `mapstructure:"diff_against"`
+		DeltaOnly    bool          `mapstructure:"delta_only"`
 	} `mapstructure:"cloudflare"`
 }
 
@@ -96,6 +97,7 @@ func defaults() *Config {
 	cfg.Cloudflare.Timeout = 15 * time.Second
 	cfg.Cloudflare.InventoryOut = ""
 	cfg.Cloudflare.DiffAgainst = ""
+	cfg.Cloudflare.DeltaOnly = false
 	return cfg
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -47,12 +47,13 @@ type Config struct {
 		File string `mapstructure:"file"`
 	} `mapstructure:"checkpoint"`
 	Cloudflare struct {
-		Enabled  bool          `mapstructure:"enabled"`
-		Zones    []string      `mapstructure:"zones"`
-		Include  []string      `mapstructure:"include"`
-		Exclude  []string      `mapstructure:"exclude"`
-		TokenEnv string        `mapstructure:"token_env"`
-		Timeout  time.Duration `mapstructure:"timeout"`
+		Enabled      bool          `mapstructure:"enabled"`
+		Zones        []string      `mapstructure:"zones"`
+		Include      []string      `mapstructure:"include"`
+		Exclude      []string      `mapstructure:"exclude"`
+		TokenEnv     string        `mapstructure:"token_env"`
+		Timeout      time.Duration `mapstructure:"timeout"`
+		InventoryOut string        `mapstructure:"inventory_out"`
 	} `mapstructure:"cloudflare"`
 }
 
@@ -92,6 +93,7 @@ func defaults() *Config {
 	cfg.Cloudflare.Exclude = nil
 	cfg.Cloudflare.TokenEnv = "CLOUDFLARE_API_TOKEN"
 	cfg.Cloudflare.Timeout = 15 * time.Second
+	cfg.Cloudflare.InventoryOut = ""
 	return cfg
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -55,6 +55,9 @@ func TestLoadConfigMissingFileUsesDefaults(t *testing.T) {
 	if cfg.Cloudflare.DiffAgainst != "" {
 		t.Fatalf("unexpected default cloudflare diff_against: %q", cfg.Cloudflare.DiffAgainst)
 	}
+	if cfg.Cloudflare.DeltaOnly {
+		t.Fatal("unexpected default cloudflare delta_only to be true")
+	}
 }
 
 func TestLoadConfigFromFileOverridesDefaults(t *testing.T) {
@@ -91,6 +94,7 @@ cloudflare:
   timeout: 11s
   inventory_out: ./reports/cloudflare.json
   diff_against: ./reports/cloudflare-prev.json
+  delta_only: true
 `
 	if err := os.WriteFile(path, []byte(body), 0600); err != nil {
 		t.Fatalf("write config: %v", err)
@@ -165,5 +169,8 @@ cloudflare:
 	}
 	if cfg.Cloudflare.DiffAgainst != "./reports/cloudflare-prev.json" {
 		t.Fatalf("unexpected cloudflare diff_against override: %s", cfg.Cloudflare.DiffAgainst)
+	}
+	if !cfg.Cloudflare.DeltaOnly {
+		t.Fatal("expected cloudflare delta_only override to be true")
 	}
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -52,6 +52,9 @@ func TestLoadConfigMissingFileUsesDefaults(t *testing.T) {
 	if cfg.Cloudflare.InventoryOut != "" {
 		t.Fatalf("unexpected default cloudflare inventory out: %q", cfg.Cloudflare.InventoryOut)
 	}
+	if cfg.Cloudflare.DiffAgainst != "" {
+		t.Fatalf("unexpected default cloudflare diff_against: %q", cfg.Cloudflare.DiffAgainst)
+	}
 }
 
 func TestLoadConfigFromFileOverridesDefaults(t *testing.T) {
@@ -87,6 +90,7 @@ cloudflare:
   token_env: CF_TOKEN
   timeout: 11s
   inventory_out: ./reports/cloudflare.json
+  diff_against: ./reports/cloudflare-prev.json
 `
 	if err := os.WriteFile(path, []byte(body), 0600); err != nil {
 		t.Fatalf("write config: %v", err)
@@ -158,5 +162,8 @@ cloudflare:
 	}
 	if cfg.Cloudflare.InventoryOut != "./reports/cloudflare.json" {
 		t.Fatalf("unexpected cloudflare inventory_out override: %s", cfg.Cloudflare.InventoryOut)
+	}
+	if cfg.Cloudflare.DiffAgainst != "./reports/cloudflare-prev.json" {
+		t.Fatalf("unexpected cloudflare diff_against override: %s", cfg.Cloudflare.DiffAgainst)
 	}
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -43,6 +43,12 @@ func TestLoadConfigMissingFileUsesDefaults(t *testing.T) {
 	if len(cfg.DNS.FallbackResolvers) != 2 {
 		t.Fatalf("unexpected default fallback resolver count: %d", len(cfg.DNS.FallbackResolvers))
 	}
+	if cfg.Cloudflare.TokenEnv != "CLOUDFLARE_API_TOKEN" {
+		t.Fatalf("unexpected default cloudflare token env: %s", cfg.Cloudflare.TokenEnv)
+	}
+	if cfg.Cloudflare.Timeout != 15*time.Second {
+		t.Fatalf("unexpected default cloudflare timeout: %v", cfg.Cloudflare.Timeout)
+	}
 }
 
 func TestLoadConfigFromFileOverridesDefaults(t *testing.T) {
@@ -67,6 +73,16 @@ dns:
   fallback_resolvers:
     - "1.1.1.1:53"
   lookup_timeout: 4s
+cloudflare:
+  enabled: true
+  zones:
+    - together.ai
+  include:
+    - "*.together.ai"
+  exclude:
+    - "internal.together.ai"
+  token_env: CF_TOKEN
+  timeout: 11s
 `
 	if err := os.WriteFile(path, []byte(body), 0600); err != nil {
 		t.Fatalf("write config: %v", err)
@@ -117,5 +133,23 @@ dns:
 	}
 	if cfg.DNS.LookupTimeout != 4*time.Second {
 		t.Fatalf("expected dns lookup timeout override, got %v", cfg.DNS.LookupTimeout)
+	}
+	if !cfg.Cloudflare.Enabled {
+		t.Fatal("expected cloudflare enabled override to be true")
+	}
+	if len(cfg.Cloudflare.Zones) != 1 || cfg.Cloudflare.Zones[0] != "together.ai" {
+		t.Fatalf("unexpected cloudflare zones override: %v", cfg.Cloudflare.Zones)
+	}
+	if len(cfg.Cloudflare.Include) != 1 || cfg.Cloudflare.Include[0] != "*.together.ai" {
+		t.Fatalf("unexpected cloudflare include override: %v", cfg.Cloudflare.Include)
+	}
+	if len(cfg.Cloudflare.Exclude) != 1 || cfg.Cloudflare.Exclude[0] != "internal.together.ai" {
+		t.Fatalf("unexpected cloudflare exclude override: %v", cfg.Cloudflare.Exclude)
+	}
+	if cfg.Cloudflare.TokenEnv != "CF_TOKEN" {
+		t.Fatalf("unexpected cloudflare token env override: %s", cfg.Cloudflare.TokenEnv)
+	}
+	if cfg.Cloudflare.Timeout != 11*time.Second {
+		t.Fatalf("unexpected cloudflare timeout override: %v", cfg.Cloudflare.Timeout)
 	}
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -49,6 +49,9 @@ func TestLoadConfigMissingFileUsesDefaults(t *testing.T) {
 	if cfg.Cloudflare.Timeout != 15*time.Second {
 		t.Fatalf("unexpected default cloudflare timeout: %v", cfg.Cloudflare.Timeout)
 	}
+	if cfg.Cloudflare.InventoryOut != "" {
+		t.Fatalf("unexpected default cloudflare inventory out: %q", cfg.Cloudflare.InventoryOut)
+	}
 }
 
 func TestLoadConfigFromFileOverridesDefaults(t *testing.T) {
@@ -83,6 +86,7 @@ cloudflare:
     - "internal.together.ai"
   token_env: CF_TOKEN
   timeout: 11s
+  inventory_out: ./reports/cloudflare.json
 `
 	if err := os.WriteFile(path, []byte(body), 0600); err != nil {
 		t.Fatalf("write config: %v", err)
@@ -151,5 +155,8 @@ cloudflare:
 	}
 	if cfg.Cloudflare.Timeout != 11*time.Second {
 		t.Fatalf("unexpected cloudflare timeout override: %v", cfg.Cloudflare.Timeout)
+	}
+	if cfg.Cloudflare.InventoryOut != "./reports/cloudflare.json" {
+		t.Fatalf("unexpected cloudflare inventory_out override: %s", cfg.Cloudflare.InventoryOut)
 	}
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -85,11 +85,11 @@ dns:
 cloudflare:
   enabled: true
   zones:
-    - together.ai
+    - example.net
   include:
-    - "*.together.ai"
+    - "*.example.net"
   exclude:
-    - "internal.together.ai"
+    - "internal.example.net"
   token_env: CF_TOKEN
   timeout: 11s
   inventory_out: ./reports/cloudflare.json
@@ -149,13 +149,13 @@ cloudflare:
 	if !cfg.Cloudflare.Enabled {
 		t.Fatal("expected cloudflare enabled override to be true")
 	}
-	if len(cfg.Cloudflare.Zones) != 1 || cfg.Cloudflare.Zones[0] != "together.ai" {
+	if len(cfg.Cloudflare.Zones) != 1 || cfg.Cloudflare.Zones[0] != "example.net" {
 		t.Fatalf("unexpected cloudflare zones override: %v", cfg.Cloudflare.Zones)
 	}
-	if len(cfg.Cloudflare.Include) != 1 || cfg.Cloudflare.Include[0] != "*.together.ai" {
+	if len(cfg.Cloudflare.Include) != 1 || cfg.Cloudflare.Include[0] != "*.example.net" {
 		t.Fatalf("unexpected cloudflare include override: %v", cfg.Cloudflare.Include)
 	}
-	if len(cfg.Cloudflare.Exclude) != 1 || cfg.Cloudflare.Exclude[0] != "internal.together.ai" {
+	if len(cfg.Cloudflare.Exclude) != 1 || cfg.Cloudflare.Exclude[0] != "internal.example.net" {
 		t.Fatalf("unexpected cloudflare exclude override: %v", cfg.Cloudflare.Exclude)
 	}
 	if cfg.Cloudflare.TokenEnv != "CF_TOKEN" {

--- a/internal/output/cloudflare_inventory.go
+++ b/internal/output/cloudflare_inventory.go
@@ -39,3 +39,47 @@ func WriteCloudflareInventory(outputDir string, explicitPath string, snapshot cf
 	}
 	return path, nil
 }
+
+func ReadCloudflareInventory(path string) (cfprovider.InventorySnapshot, error) {
+	var snapshot cfprovider.InventorySnapshot
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return snapshot, fmt.Errorf("read cloudflare inventory: %w", err)
+	}
+	if err := json.Unmarshal(data, &snapshot); err != nil {
+		return snapshot, fmt.Errorf("parse cloudflare inventory: %w", err)
+	}
+	return snapshot, nil
+}
+
+func WriteCloudflareInventoryDiff(outputDir string, inventoryPath string, diff cfprovider.InventoryDiff) (string, error) {
+	path := ""
+	if trimmed := strings.TrimSpace(inventoryPath); trimmed != "" {
+		ext := filepath.Ext(trimmed)
+		base := strings.TrimSuffix(trimmed, ext)
+		if ext == "" {
+			path = base + "-diff.json"
+		} else {
+			path = base + "-diff" + ext
+		}
+	} else if outputDir != "" && outputDir != "-" {
+		path = filepath.Join(outputDir, fmt.Sprintf("cloudflare-inventory-diff-%s.json", time.Now().Format("20060102-150405")))
+	}
+	if path == "" {
+		return "", nil
+	}
+	dir := filepath.Dir(path)
+	if dir != "" && dir != "." {
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			return "", fmt.Errorf("create inventory diff directory: %w", err)
+		}
+	}
+	data, err := json.MarshalIndent(diff, "", "  ")
+	if err != nil {
+		return "", fmt.Errorf("marshal cloudflare inventory diff: %w", err)
+	}
+	if err := os.WriteFile(path, data, 0600); err != nil {
+		return "", fmt.Errorf("write cloudflare inventory diff: %w", err)
+	}
+	return path, nil
+}

--- a/internal/output/cloudflare_inventory.go
+++ b/internal/output/cloudflare_inventory.go
@@ -19,23 +19,8 @@ func WriteCloudflareInventory(outputDir string, explicitPath string, snapshot cf
 		}
 		path = filepath.Join(outputDir, fmt.Sprintf("cloudflare-inventory-%s.json", time.Now().Format("20060102-150405")))
 	}
-
-	dir := filepath.Dir(path)
-	if dir == "." && !strings.Contains(path, string(filepath.Separator)) {
-		dir = ""
-	}
-	if dir != "" {
-		if err := os.MkdirAll(dir, 0755); err != nil {
-			return "", fmt.Errorf("create inventory directory: %w", err)
-		}
-	}
-
-	data, err := json.MarshalIndent(snapshot, "", "  ")
-	if err != nil {
-		return "", fmt.Errorf("marshal cloudflare inventory: %w", err)
-	}
-	if err := os.WriteFile(path, data, 0600); err != nil {
-		return "", fmt.Errorf("write cloudflare inventory: %w", err)
+	if err := writeCloudflareJSON(path, snapshot); err != nil {
+		return "", err
 	}
 	return path, nil
 }
@@ -68,18 +53,36 @@ func WriteCloudflareInventoryDiff(outputDir string, inventoryPath string, diff c
 	if path == "" {
 		return "", nil
 	}
-	dir := filepath.Dir(path)
-	if dir != "" && dir != "." {
-		if err := os.MkdirAll(dir, 0755); err != nil {
-			return "", fmt.Errorf("create inventory diff directory: %w", err)
-		}
-	}
-	data, err := json.MarshalIndent(diff, "", "  ")
-	if err != nil {
-		return "", fmt.Errorf("marshal cloudflare inventory diff: %w", err)
-	}
-	if err := os.WriteFile(path, data, 0600); err != nil {
-		return "", fmt.Errorf("write cloudflare inventory diff: %w", err)
+	if err := writeCloudflareJSON(path, diff); err != nil {
+		return "", err
 	}
 	return path, nil
+}
+
+func writeCloudflareJSON(path string, value any) error {
+	if err := ensureCloudflareOutputDir(path); err != nil {
+		return err
+	}
+	data, err := json.MarshalIndent(value, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal cloudflare json: %w", err)
+	}
+	if err := os.WriteFile(path, data, 0600); err != nil {
+		return fmt.Errorf("write cloudflare json: %w", err)
+	}
+	return nil
+}
+
+func ensureCloudflareOutputDir(path string) error {
+	dir := filepath.Dir(path)
+	if dir == "." && !strings.Contains(path, string(filepath.Separator)) {
+		return nil
+	}
+	if dir == "" || dir == "." {
+		return nil
+	}
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return fmt.Errorf("create cloudflare output directory: %w", err)
+	}
+	return nil
 }

--- a/internal/output/cloudflare_inventory.go
+++ b/internal/output/cloudflare_inventory.go
@@ -1,0 +1,41 @@
+package output
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	cfprovider "github.com/therandomsecurityguy/flan-go-scan/internal/providers/cloudflare"
+)
+
+func WriteCloudflareInventory(outputDir string, explicitPath string, snapshot cfprovider.InventorySnapshot) (string, error) {
+	path := strings.TrimSpace(explicitPath)
+	if path == "" {
+		if outputDir == "" || outputDir == "-" {
+			return "", nil
+		}
+		path = filepath.Join(outputDir, fmt.Sprintf("cloudflare-inventory-%s.json", time.Now().Format("20060102-150405")))
+	}
+
+	dir := filepath.Dir(path)
+	if dir == "." && !strings.Contains(path, string(filepath.Separator)) {
+		dir = ""
+	}
+	if dir != "" {
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			return "", fmt.Errorf("create inventory directory: %w", err)
+		}
+	}
+
+	data, err := json.MarshalIndent(snapshot, "", "  ")
+	if err != nil {
+		return "", fmt.Errorf("marshal cloudflare inventory: %w", err)
+	}
+	if err := os.WriteFile(path, data, 0600); err != nil {
+		return "", fmt.Errorf("write cloudflare inventory: %w", err)
+	}
+	return path, nil
+}

--- a/internal/output/cloudflare_inventory.go
+++ b/internal/output/cloudflare_inventory.go
@@ -75,9 +75,6 @@ func writeCloudflareJSON(path string, value any) error {
 
 func ensureCloudflareOutputDir(path string) error {
 	dir := filepath.Dir(path)
-	if dir == "." && !strings.Contains(path, string(filepath.Separator)) {
-		return nil
-	}
 	if dir == "" || dir == "." {
 		return nil
 	}

--- a/internal/output/report_writer_test.go
+++ b/internal/output/report_writer_test.go
@@ -126,7 +126,7 @@ func TestWriteCloudflareInventoryUsesOutputDir(t *testing.T) {
 		Source:      "cloudflare",
 		AssetCount:  1,
 		Assets: []cfprovider.Asset{
-			{Zone: "together.ai", Hostname: "api.together.ai", RecordType: "CNAME", Value: "svc.example.net", Proxied: true, Source: "cloudflare"},
+			{Zone: "example.net", Hostname: "api.example.net", RecordType: "CNAME", Value: "svc.example.net", Proxied: true, Source: "cloudflare"},
 		},
 	})
 	if err != nil {
@@ -174,7 +174,7 @@ func TestReadCloudflareInventory(t *testing.T) {
 		Source:      "cloudflare",
 		AssetCount:  1,
 		Assets: []cfprovider.Asset{
-			{Zone: "together.ai", Hostname: "api.together.ai", RecordType: "CNAME", Value: "svc.example.net", Proxied: true, Source: "cloudflare"},
+			{Zone: "example.net", Hostname: "api.example.net", RecordType: "CNAME", Value: "svc.example.net", Proxied: true, Source: "cloudflare"},
 		},
 	}
 	if _, err := WriteCloudflareInventory("", path, expected); err != nil {

--- a/internal/output/report_writer_test.go
+++ b/internal/output/report_writer_test.go
@@ -165,3 +165,45 @@ func TestWriteCloudflareInventoryExplicitPath(t *testing.T) {
 		t.Fatalf("expected inventory file at explicit path: %v", err)
 	}
 }
+
+func TestReadCloudflareInventory(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "cloudflare.json")
+	expected := cfprovider.InventorySnapshot{
+		GeneratedAt: "2026-03-07T00:00:00Z",
+		Source:      "cloudflare",
+		AssetCount:  1,
+		Assets: []cfprovider.Asset{
+			{Zone: "together.ai", Hostname: "api.together.ai", RecordType: "CNAME", Value: "svc.example.net", Proxied: true, Source: "cloudflare"},
+		},
+	}
+	if _, err := WriteCloudflareInventory("", path, expected); err != nil {
+		t.Fatalf("WriteCloudflareInventory failed: %v", err)
+	}
+	got, err := ReadCloudflareInventory(path)
+	if err != nil {
+		t.Fatalf("ReadCloudflareInventory failed: %v", err)
+	}
+	if got.AssetCount != expected.AssetCount || len(got.Assets) != len(expected.Assets) {
+		t.Fatalf("unexpected inventory readback: %#v", got)
+	}
+}
+
+func TestWriteCloudflareInventoryDiff(t *testing.T) {
+	dir := t.TempDir()
+	inventoryPath := filepath.Join(dir, "cloudflare.json")
+	path, err := WriteCloudflareInventoryDiff("", inventoryPath, cfprovider.InventoryDiff{
+		GeneratedAt: "2026-03-07T01:00:00Z",
+		Source:      "cloudflare",
+		AddedCount:  1,
+	})
+	if err != nil {
+		t.Fatalf("WriteCloudflareInventoryDiff failed: %v", err)
+	}
+	if path != filepath.Join(dir, "cloudflare-diff.json") {
+		t.Fatalf("unexpected diff path: %s", path)
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("expected diff file: %v", err)
+	}
+}

--- a/internal/output/report_writer_test.go
+++ b/internal/output/report_writer_test.go
@@ -1,11 +1,13 @@
 package output
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
+	cfprovider "github.com/therandomsecurityguy/flan-go-scan/internal/providers/cloudflare"
 	"github.com/therandomsecurityguy/flan-go-scan/internal/scanner"
 )
 
@@ -114,5 +116,52 @@ func TestWriteScanMetadata(t *testing.T) {
 	}
 	if !strings.Contains(string(data), `"mode": "target"`) {
 		t.Fatalf("unexpected metadata content: %s", string(data))
+	}
+}
+
+func TestWriteCloudflareInventoryUsesOutputDir(t *testing.T) {
+	dir := t.TempDir()
+	path, err := WriteCloudflareInventory(dir, "", cfprovider.InventorySnapshot{
+		GeneratedAt: "2026-03-07T00:00:00Z",
+		Source:      "cloudflare",
+		AssetCount:  1,
+		Assets: []cfprovider.Asset{
+			{Zone: "together.ai", Hostname: "api.together.ai", RecordType: "CNAME", Value: "svc.example.net", Proxied: true, Source: "cloudflare"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("WriteCloudflareInventory failed: %v", err)
+	}
+	if path == "" {
+		t.Fatal("expected inventory file path")
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read inventory file: %v", err)
+	}
+	var snapshot cfprovider.InventorySnapshot
+	if err := json.Unmarshal(data, &snapshot); err != nil {
+		t.Fatalf("unmarshal inventory: %v", err)
+	}
+	if snapshot.AssetCount != 1 || len(snapshot.Assets) != 1 {
+		t.Fatalf("unexpected inventory content: %#v", snapshot)
+	}
+}
+
+func TestWriteCloudflareInventoryExplicitPath(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "inventory", "cloudflare.json")
+	writtenPath, err := WriteCloudflareInventory("", path, cfprovider.InventorySnapshot{
+		GeneratedAt: "2026-03-07T00:00:00Z",
+		Source:      "cloudflare",
+	})
+	if err != nil {
+		t.Fatalf("WriteCloudflareInventory failed: %v", err)
+	}
+	if writtenPath != path {
+		t.Fatalf("unexpected written path: got %s want %s", writtenPath, path)
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("expected inventory file at explicit path: %v", err)
 	}
 }

--- a/internal/providers/cloudflare/cloudflare.go
+++ b/internal/providers/cloudflare/cloudflare.go
@@ -305,14 +305,14 @@ func BuildInventorySnapshot(now time.Time, assets []Asset, opts DiscoverOptions)
 }
 
 func DiffInventory(now time.Time, previous, current InventorySnapshot) InventoryDiff {
-	prevByIdentity := make(map[string]Asset, len(previous.Assets))
-	currByIdentity := make(map[string]Asset, len(current.Assets))
+	prevByKey := make(map[string]Asset, len(previous.Assets))
+	currByKey := make(map[string]Asset, len(current.Assets))
 
 	for _, asset := range previous.Assets {
-		prevByIdentity[assetIdentity(asset)] = asset
+		prevByKey[assetChangeKey(asset)] = asset
 	}
 	for _, asset := range current.Assets {
-		currByIdentity[assetIdentity(asset)] = asset
+		currByKey[assetChangeKey(asset)] = asset
 	}
 
 	diff := InventoryDiff{
@@ -322,19 +322,21 @@ func DiffInventory(now time.Time, previous, current InventorySnapshot) Inventory
 		CurrentGeneratedAt:  current.GeneratedAt,
 	}
 
-	for identity, currentAsset := range currByIdentity {
-		previousAsset, existed := prevByIdentity[identity]
+	for key, currentAsset := range currByKey {
+		previousAsset, existed := prevByKey[key]
 		if !existed {
 			diff.Added = append(diff.Added, currentAsset)
 			continue
 		}
-		if previousAsset.Proxied != currentAsset.Proxied || previousAsset.Source != currentAsset.Source {
+		if assetIdentity(previousAsset) != assetIdentity(currentAsset) ||
+			previousAsset.Proxied != currentAsset.Proxied ||
+			previousAsset.Source != currentAsset.Source {
 			diff.Changed = append(diff.Changed, AssetChange{Before: previousAsset, After: currentAsset})
 		}
 	}
 
-	for identity, previousAsset := range prevByIdentity {
-		if _, exists := currByIdentity[identity]; !exists {
+	for key, previousAsset := range prevByKey {
+		if _, exists := currByKey[key]; !exists {
 			diff.Removed = append(diff.Removed, previousAsset)
 		}
 	}
@@ -346,7 +348,7 @@ func DiffInventory(now time.Time, previous, current InventorySnapshot) Inventory
 		return assetKey(diff.Removed[i]) < assetKey(diff.Removed[j])
 	})
 	sort.Slice(diff.Changed, func(i, j int) bool {
-		return assetIdentity(diff.Changed[i].After) < assetIdentity(diff.Changed[j].After)
+		return assetChangeKey(diff.Changed[i].After) < assetChangeKey(diff.Changed[j].After)
 	})
 
 	diff.AddedCount = len(diff.Added)
@@ -542,6 +544,10 @@ func uniqueSortedValues(values []string) []string {
 
 func assetIdentity(asset Asset) string {
 	return asset.Zone + "|" + asset.Hostname + "|" + asset.RecordType + "|" + asset.Value
+}
+
+func assetChangeKey(asset Asset) string {
+	return asset.Zone + "|" + asset.Hostname + "|" + asset.RecordType
 }
 
 func assetKey(asset Asset) string {

--- a/internal/providers/cloudflare/cloudflare.go
+++ b/internal/providers/cloudflare/cloudflare.go
@@ -159,11 +159,11 @@ func (c *Client) Discover(ctx context.Context, opts DiscoverOptions) ([]Asset, e
 			if !ok {
 				continue
 			}
-			key := asset.Zone + "|" + asset.Hostname + "|" + asset.RecordType + "|" + asset.Value
-			if _, exists := seen[key]; exists {
+			identity := assetIdentity(asset)
+			if _, exists := seen[identity]; exists {
 				continue
 			}
-			seen[key] = struct{}{}
+			seen[identity] = struct{}{}
 			assets = append(assets, asset)
 		}
 	}
@@ -282,20 +282,10 @@ func Hostnames(assets []Asset) []string {
 }
 
 func BuildInventorySnapshot(now time.Time, assets []Asset, opts DiscoverOptions) InventorySnapshot {
-	zones := uniqueSortedValues(func() []string {
-		values := make([]string, 0, len(assets))
-		for _, asset := range assets {
-			if zone := normalizeHost(asset.Zone); zone != "" {
-				values = append(values, zone)
-			}
-		}
-		return values
-	}())
-
 	return InventorySnapshot{
 		GeneratedAt: now.UTC().Format(time.RFC3339),
 		Source:      "cloudflare",
-		Zones:       zones,
+		Zones:       zonesFromAssets(assets),
 		ZoneFilters: uniqueSortedValues(opts.Zones),
 		Include:     uniqueSortedValues(opts.Include),
 		Exclude:     uniqueSortedValues(opts.Exclude),
@@ -540,6 +530,16 @@ func uniqueSortedValues(values []string) []string {
 	}
 	sort.Strings(normalized)
 	return normalized
+}
+
+func zonesFromAssets(assets []Asset) []string {
+	values := make([]string, 0, len(assets))
+	for _, asset := range assets {
+		if zone := normalizeHost(asset.Zone); zone != "" {
+			values = append(values, zone)
+		}
+	}
+	return uniqueSortedValues(values)
 }
 
 func assetIdentity(asset Asset) string {

--- a/internal/providers/cloudflare/cloudflare.go
+++ b/internal/providers/cloudflare/cloudflare.go
@@ -1,0 +1,410 @@
+package cloudflare
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/http"
+	"net/url"
+	"path"
+	"sort"
+	"strings"
+	"time"
+)
+
+const defaultBaseURL = "https://api.cloudflare.com/client/v4"
+
+type Client struct {
+	token      string
+	baseURL    string
+	httpClient *http.Client
+}
+
+type Zone struct {
+	ID     string `json:"id"`
+	Name   string `json:"name"`
+	Status string `json:"status"`
+	Paused bool   `json:"paused"`
+	Type   string `json:"type"`
+}
+
+type DNSRecord struct {
+	ID      string `json:"id"`
+	Name    string `json:"name"`
+	Type    string `json:"type"`
+	Content string `json:"content"`
+	Proxied bool   `json:"proxied"`
+}
+
+type Asset struct {
+	Zone       string `json:"zone"`
+	Hostname   string `json:"hostname"`
+	RecordType string `json:"record_type"`
+	Value      string `json:"value"`
+	Proxied    bool   `json:"proxied"`
+	Source     string `json:"source"`
+}
+
+type DiscoverOptions struct {
+	Zones    []string
+	Include  []string
+	Exclude  []string
+	PageSize int
+}
+
+type apiEnvelope[T any] struct {
+	Success bool `json:"success"`
+	Errors  []struct {
+		Message string `json:"message"`
+	} `json:"errors"`
+	Result     []T `json:"result"`
+	ResultInfo struct {
+		Page       int `json:"page"`
+		PerPage    int `json:"per_page"`
+		Count      int `json:"count"`
+		TotalPages int `json:"total_pages"`
+		TotalCount int `json:"total_count"`
+	} `json:"result_info"`
+}
+
+func NewClient(token string, timeout time.Duration) (*Client, error) {
+	if strings.TrimSpace(token) == "" {
+		return nil, fmt.Errorf("cloudflare token is required")
+	}
+	if timeout <= 0 {
+		timeout = 15 * time.Second
+	}
+	return &Client{
+		token:      token,
+		baseURL:    defaultBaseURL,
+		httpClient: &http.Client{Timeout: timeout},
+	}, nil
+}
+
+func NewClientForTesting(token string, baseURL string, httpClient *http.Client) (*Client, error) {
+	if strings.TrimSpace(token) == "" {
+		return nil, fmt.Errorf("cloudflare token is required")
+	}
+	if strings.TrimSpace(baseURL) == "" {
+		return nil, fmt.Errorf("cloudflare base url is required")
+	}
+	if httpClient == nil {
+		httpClient = &http.Client{Timeout: 15 * time.Second}
+	}
+	return &Client{
+		token:      token,
+		baseURL:    strings.TrimRight(baseURL, "/"),
+		httpClient: httpClient,
+	}, nil
+}
+
+func (c *Client) Discover(ctx context.Context, opts DiscoverOptions) ([]Asset, error) {
+	zones, err := c.ListZones(ctx, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	zoneFilter := normalizeSet(opts.Zones)
+	include := normalizePatterns(opts.Include)
+	exclude := normalizePatterns(opts.Exclude)
+	pageSize := opts.PageSize
+	if pageSize <= 0 {
+		pageSize = 500
+	}
+
+	seen := make(map[string]struct{})
+	var assets []Asset
+	for _, zone := range zones {
+		if len(zoneFilter) > 0 {
+			if _, ok := zoneFilter[normalizeHost(zone.Name)]; !ok {
+				continue
+			}
+		}
+		records, err := c.ListDNSRecords(ctx, zone.ID, pageSize)
+		if err != nil {
+			return nil, fmt.Errorf("list dns records for zone %s: %w", zone.Name, err)
+		}
+		for _, record := range records {
+			asset, ok := normalizeAsset(zone, record, include, exclude)
+			if !ok {
+				continue
+			}
+			key := asset.Zone + "|" + asset.Hostname + "|" + asset.RecordType + "|" + asset.Value
+			if _, exists := seen[key]; exists {
+				continue
+			}
+			seen[key] = struct{}{}
+			assets = append(assets, asset)
+		}
+	}
+
+	sort.Slice(assets, func(i, j int) bool {
+		if assets[i].Zone != assets[j].Zone {
+			return assets[i].Zone < assets[j].Zone
+		}
+		if assets[i].Hostname != assets[j].Hostname {
+			return assets[i].Hostname < assets[j].Hostname
+		}
+		if assets[i].RecordType != assets[j].RecordType {
+			return assets[i].RecordType < assets[j].RecordType
+		}
+		return assets[i].Value < assets[j].Value
+	})
+	return assets, nil
+}
+
+func (c *Client) ListZones(ctx context.Context, opts DiscoverOptions) ([]Zone, error) {
+	pageSize := opts.PageSize
+	if pageSize <= 0 {
+		pageSize = 50
+	}
+	var zones []Zone
+	for page := 1; ; page++ {
+		var env apiEnvelope[Zone]
+		if err := c.get(ctx, "/zones", url.Values{
+			"page":     []string{fmt.Sprintf("%d", page)},
+			"per_page": []string{fmt.Sprintf("%d", pageSize)},
+		}, &env); err != nil {
+			return nil, fmt.Errorf("list zones page %d: %w", page, err)
+		}
+		zones = append(zones, env.Result...)
+		if env.ResultInfo.TotalPages <= page || len(env.Result) == 0 {
+			break
+		}
+	}
+	sort.Slice(zones, func(i, j int) bool {
+		return normalizeHost(zones[i].Name) < normalizeHost(zones[j].Name)
+	})
+	return zones, nil
+}
+
+func (c *Client) ListDNSRecords(ctx context.Context, zoneID string, pageSize int) ([]DNSRecord, error) {
+	if strings.TrimSpace(zoneID) == "" {
+		return nil, fmt.Errorf("zone id is required")
+	}
+	if pageSize <= 0 {
+		pageSize = 500
+	}
+	var records []DNSRecord
+	for page := 1; ; page++ {
+		var env apiEnvelope[DNSRecord]
+		if err := c.get(ctx, path.Join("/zones", zoneID, "dns_records"), url.Values{
+			"page":     []string{fmt.Sprintf("%d", page)},
+			"per_page": []string{fmt.Sprintf("%d", pageSize)},
+		}, &env); err != nil {
+			return nil, fmt.Errorf("list dns records page %d: %w", page, err)
+		}
+		records = append(records, env.Result...)
+		if env.ResultInfo.TotalPages <= page || len(env.Result) == 0 {
+			break
+		}
+	}
+	return records, nil
+}
+
+func normalizeAsset(zone Zone, record DNSRecord, include, exclude []string) (Asset, bool) {
+	recordType := strings.ToUpper(strings.TrimSpace(record.Type))
+	if !isScannableRecordType(recordType) {
+		return Asset{}, false
+	}
+
+	hostname := normalizeHost(record.Name)
+	if hostname == "" || isValidationRecordName(hostname) {
+		return Asset{}, false
+	}
+	if !matchesAny(hostname, include, true) || matchesAny(hostname, exclude, false) {
+		return Asset{}, false
+	}
+
+	value := strings.TrimSpace(record.Content)
+	if recordType == "A" || recordType == "AAAA" {
+		if !isPublicIP(value) {
+			return Asset{}, false
+		}
+	}
+
+	return Asset{
+		Zone:       normalizeHost(zone.Name),
+		Hostname:   hostname,
+		RecordType: recordType,
+		Value:      value,
+		Proxied:    record.Proxied,
+		Source:     "cloudflare",
+	}, true
+}
+
+func Hostnames(assets []Asset) []string {
+	seen := make(map[string]struct{}, len(assets))
+	hostnames := make([]string, 0, len(assets))
+	for _, asset := range assets {
+		hostname := normalizeHost(asset.Hostname)
+		if hostname == "" {
+			continue
+		}
+		if _, ok := seen[hostname]; ok {
+			continue
+		}
+		seen[hostname] = struct{}{}
+		hostnames = append(hostnames, hostname)
+	}
+	sort.Strings(hostnames)
+	return hostnames
+}
+
+func (c *Client) get(ctx context.Context, endpoint string, query url.Values, dst any) error {
+	u, err := url.Parse(c.baseURL)
+	if err != nil {
+		return fmt.Errorf("parse base url: %w", err)
+	}
+	u.Path = strings.TrimRight(u.Path, "/") + endpoint
+	if len(query) > 0 {
+		u.RawQuery = query.Encode()
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
+	if err != nil {
+		return fmt.Errorf("build request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+c.token)
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("send request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("unexpected status: %s", resp.Status)
+	}
+	if err := json.NewDecoder(resp.Body).Decode(dst); err != nil {
+		return fmt.Errorf("decode response: %w", err)
+	}
+
+	switch v := dst.(type) {
+	case *apiEnvelope[Zone]:
+		if !v.Success {
+			return fmt.Errorf("cloudflare api error: %s", joinErrors(v.Errors))
+		}
+	case *apiEnvelope[DNSRecord]:
+		if !v.Success {
+			return fmt.Errorf("cloudflare api error: %s", joinErrors(v.Errors))
+		}
+	}
+
+	return nil
+}
+
+func joinErrors(errs []struct {
+	Message string `json:"message"`
+}) string {
+	if len(errs) == 0 {
+		return "unknown error"
+	}
+	parts := make([]string, 0, len(errs))
+	for _, err := range errs {
+		if strings.TrimSpace(err.Message) != "" {
+			parts = append(parts, err.Message)
+		}
+	}
+	if len(parts) == 0 {
+		return "unknown error"
+	}
+	return strings.Join(parts, "; ")
+}
+
+func normalizeSet(values []string) map[string]struct{} {
+	if len(values) == 0 {
+		return nil
+	}
+	normalized := make(map[string]struct{}, len(values))
+	for _, value := range values {
+		value = normalizeHost(value)
+		if value == "" {
+			continue
+		}
+		normalized[value] = struct{}{}
+	}
+	if len(normalized) == 0 {
+		return nil
+	}
+	return normalized
+}
+
+func normalizePatterns(values []string) []string {
+	patterns := make([]string, 0, len(values))
+	for _, value := range values {
+		value = normalizeHost(value)
+		if value == "" {
+			continue
+		}
+		patterns = append(patterns, value)
+	}
+	return patterns
+}
+
+func normalizeHost(value string) string {
+	return strings.TrimSuffix(strings.ToLower(strings.TrimSpace(value)), ".")
+}
+
+func isScannableRecordType(recordType string) bool {
+	switch recordType {
+	case "A", "AAAA", "CNAME":
+		return true
+	default:
+		return false
+	}
+}
+
+func isValidationRecordName(name string) bool {
+	labels := strings.Split(normalizeHost(name), ".")
+	if len(labels) == 0 {
+		return true
+	}
+	if labels[0] == "*" {
+		return true
+	}
+	for _, label := range labels {
+		if strings.HasPrefix(label, "_") {
+			return true
+		}
+	}
+	return false
+}
+
+func matchesAny(host string, patterns []string, emptyDefault bool) bool {
+	if len(patterns) == 0 {
+		return emptyDefault
+	}
+	for _, pattern := range patterns {
+		if patternMatches(host, pattern) {
+			return true
+		}
+	}
+	return false
+}
+
+func patternMatches(host, pattern string) bool {
+	if strings.ContainsAny(pattern, "*?[") {
+		ok, err := path.Match(pattern, host)
+		return err == nil && ok
+	}
+	return host == pattern || strings.HasSuffix(host, "."+pattern)
+}
+
+func isPublicIP(value string) bool {
+	ip := net.ParseIP(strings.TrimSpace(value))
+	if ip == nil {
+		return false
+	}
+	if ip.IsUnspecified() || ip.IsLoopback() || ip.IsPrivate() || ip.IsMulticast() || ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast() {
+		return false
+	}
+	if ip4 := ip.To4(); ip4 != nil {
+		if ip4[0] == 0 || (ip4[0] == 169 && ip4[1] == 254) {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/providers/cloudflare/cloudflare.go
+++ b/internal/providers/cloudflare/cloudflare.go
@@ -356,6 +356,15 @@ func DiffInventory(now time.Time, previous, current InventorySnapshot) Inventory
 	return diff
 }
 
+func HostnamesFromDiff(diff InventoryDiff) []string {
+	var assets []Asset
+	assets = append(assets, diff.Added...)
+	for _, change := range diff.Changed {
+		assets = append(assets, change.After)
+	}
+	return Hostnames(assets)
+}
+
 func (c *Client) get(ctx context.Context, endpoint string, query url.Values, dst any) error {
 	u, err := url.Parse(c.baseURL)
 	if err != nil {

--- a/internal/providers/cloudflare/cloudflare.go
+++ b/internal/providers/cloudflare/cloudflare.go
@@ -46,6 +46,17 @@ type Asset struct {
 	Source     string `json:"source"`
 }
 
+type InventorySnapshot struct {
+	GeneratedAt string   `json:"generated_at"`
+	Source      string   `json:"source"`
+	Zones       []string `json:"zones,omitempty"`
+	ZoneFilters []string `json:"zone_filters,omitempty"`
+	Include     []string `json:"include,omitempty"`
+	Exclude     []string `json:"exclude,omitempty"`
+	AssetCount  int      `json:"asset_count"`
+	Assets      []Asset  `json:"assets"`
+}
+
 type DiscoverOptions struct {
 	Zones    []string
 	Include  []string
@@ -252,6 +263,29 @@ func Hostnames(assets []Asset) []string {
 	return hostnames
 }
 
+func BuildInventorySnapshot(now time.Time, assets []Asset, opts DiscoverOptions) InventorySnapshot {
+	zones := uniqueSortedValues(func() []string {
+		values := make([]string, 0, len(assets))
+		for _, asset := range assets {
+			if zone := normalizeHost(asset.Zone); zone != "" {
+				values = append(values, zone)
+			}
+		}
+		return values
+	}())
+
+	return InventorySnapshot{
+		GeneratedAt: now.UTC().Format(time.RFC3339),
+		Source:      "cloudflare",
+		Zones:       zones,
+		ZoneFilters: uniqueSortedValues(opts.Zones),
+		Include:     uniqueSortedValues(opts.Include),
+		Exclude:     uniqueSortedValues(opts.Exclude),
+		AssetCount:  len(assets),
+		Assets:      append([]Asset(nil), assets...),
+	}
+}
+
 func (c *Client) get(ctx context.Context, endpoint string, query url.Values, dst any) error {
 	u, err := url.Parse(c.baseURL)
 	if err != nil {
@@ -407,4 +441,22 @@ func isPublicIP(value string) bool {
 		}
 	}
 	return true
+}
+
+func uniqueSortedValues(values []string) []string {
+	seen := make(map[string]struct{}, len(values))
+	normalized := make([]string, 0, len(values))
+	for _, value := range values {
+		value = normalizeHost(value)
+		if value == "" {
+			continue
+		}
+		if _, ok := seen[value]; ok {
+			continue
+		}
+		seen[value] = struct{}{}
+		normalized = append(normalized, value)
+	}
+	sort.Strings(normalized)
+	return normalized
 }

--- a/internal/providers/cloudflare/cloudflare.go
+++ b/internal/providers/cloudflare/cloudflare.go
@@ -57,6 +57,24 @@ type InventorySnapshot struct {
 	Assets      []Asset  `json:"assets"`
 }
 
+type InventoryDiff struct {
+	GeneratedAt         string        `json:"generated_at"`
+	Source              string        `json:"source"`
+	PreviousGeneratedAt string        `json:"previous_generated_at,omitempty"`
+	CurrentGeneratedAt  string        `json:"current_generated_at,omitempty"`
+	AddedCount          int           `json:"added_count"`
+	RemovedCount        int           `json:"removed_count"`
+	ChangedCount        int           `json:"changed_count"`
+	Added               []Asset       `json:"added,omitempty"`
+	Removed             []Asset       `json:"removed,omitempty"`
+	Changed             []AssetChange `json:"changed,omitempty"`
+}
+
+type AssetChange struct {
+	Before Asset `json:"before"`
+	After  Asset `json:"after"`
+}
+
 type DiscoverOptions struct {
 	Zones    []string
 	Include  []string
@@ -286,6 +304,58 @@ func BuildInventorySnapshot(now time.Time, assets []Asset, opts DiscoverOptions)
 	}
 }
 
+func DiffInventory(now time.Time, previous, current InventorySnapshot) InventoryDiff {
+	prevByIdentity := make(map[string]Asset, len(previous.Assets))
+	currByIdentity := make(map[string]Asset, len(current.Assets))
+
+	for _, asset := range previous.Assets {
+		prevByIdentity[assetIdentity(asset)] = asset
+	}
+	for _, asset := range current.Assets {
+		currByIdentity[assetIdentity(asset)] = asset
+	}
+
+	diff := InventoryDiff{
+		GeneratedAt:         now.UTC().Format(time.RFC3339),
+		Source:              "cloudflare",
+		PreviousGeneratedAt: previous.GeneratedAt,
+		CurrentGeneratedAt:  current.GeneratedAt,
+	}
+
+	for identity, currentAsset := range currByIdentity {
+		previousAsset, existed := prevByIdentity[identity]
+		if !existed {
+			diff.Added = append(diff.Added, currentAsset)
+			continue
+		}
+		if previousAsset.Proxied != currentAsset.Proxied || previousAsset.Source != currentAsset.Source {
+			diff.Changed = append(diff.Changed, AssetChange{Before: previousAsset, After: currentAsset})
+		}
+	}
+
+	for identity, previousAsset := range prevByIdentity {
+		if _, exists := currByIdentity[identity]; !exists {
+			diff.Removed = append(diff.Removed, previousAsset)
+		}
+	}
+
+	sort.Slice(diff.Added, func(i, j int) bool {
+		return assetKey(diff.Added[i]) < assetKey(diff.Added[j])
+	})
+	sort.Slice(diff.Removed, func(i, j int) bool {
+		return assetKey(diff.Removed[i]) < assetKey(diff.Removed[j])
+	})
+	sort.Slice(diff.Changed, func(i, j int) bool {
+		return assetIdentity(diff.Changed[i].After) < assetIdentity(diff.Changed[j].After)
+	})
+
+	diff.AddedCount = len(diff.Added)
+	diff.RemovedCount = len(diff.Removed)
+	diff.ChangedCount = len(diff.Changed)
+
+	return diff
+}
+
 func (c *Client) get(ctx context.Context, endpoint string, query url.Values, dst any) error {
 	u, err := url.Parse(c.baseURL)
 	if err != nil {
@@ -459,4 +529,12 @@ func uniqueSortedValues(values []string) []string {
 	}
 	sort.Strings(normalized)
 	return normalized
+}
+
+func assetIdentity(asset Asset) string {
+	return asset.Zone + "|" + asset.Hostname + "|" + asset.RecordType + "|" + asset.Value
+}
+
+func assetKey(asset Asset) string {
+	return assetIdentity(asset) + "|" + fmt.Sprintf("%t", asset.Proxied)
 }

--- a/internal/providers/cloudflare/cloudflare.go
+++ b/internal/providers/cloudflare/cloudflare.go
@@ -9,11 +9,13 @@ import (
 	"net/url"
 	"path"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 )
 
 const defaultBaseURL = "https://api.cloudflare.com/client/v4"
+const maxHTTPAttempts = 3
 
 type Client struct {
 	token      string
@@ -95,6 +97,19 @@ type apiEnvelope[T any] struct {
 		TotalPages int `json:"total_pages"`
 		TotalCount int `json:"total_count"`
 	} `json:"result_info"`
+}
+
+type apiEnvelopeChecker interface {
+	success() bool
+	errorMessage() string
+}
+
+func (e *apiEnvelope[T]) success() bool {
+	return e.Success
+}
+
+func (e *apiEnvelope[T]) errorMessage() string {
+	return joinErrors(e.Errors)
 }
 
 func NewClient(token string, timeout time.Duration) (*Client, error) {
@@ -367,38 +382,43 @@ func (c *Client) get(ctx context.Context, endpoint string, query url.Values, dst
 		u.RawQuery = query.Encode()
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
-	if err != nil {
-		return fmt.Errorf("build request: %w", err)
-	}
-	req.Header.Set("Authorization", "Bearer "+c.token)
-	req.Header.Set("Accept", "application/json")
-
-	resp, err := c.httpClient.Do(req)
-	if err != nil {
-		return fmt.Errorf("send request: %w", err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return fmt.Errorf("unexpected status: %s", resp.Status)
-	}
-	if err := json.NewDecoder(resp.Body).Decode(dst); err != nil {
-		return fmt.Errorf("decode response: %w", err)
-	}
-
-	switch v := dst.(type) {
-	case *apiEnvelope[Zone]:
-		if !v.Success {
-			return fmt.Errorf("cloudflare api error: %s", joinErrors(v.Errors))
+	for attempt := 0; attempt < maxHTTPAttempts; attempt++ {
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
+		if err != nil {
+			return fmt.Errorf("build request: %w", err)
 		}
-	case *apiEnvelope[DNSRecord]:
-		if !v.Success {
-			return fmt.Errorf("cloudflare api error: %s", joinErrors(v.Errors))
+		req.Header.Set("Authorization", "Bearer "+c.token)
+		req.Header.Set("Accept", "application/json")
+
+		resp, err := c.httpClient.Do(req)
+		if err != nil {
+			return fmt.Errorf("send request: %w", err)
 		}
+
+		if resp.StatusCode == http.StatusTooManyRequests && attempt+1 < maxHTTPAttempts {
+			delay := retryDelay(resp.Header.Get("Retry-After"), attempt)
+			resp.Body.Close()
+			if err := waitForRetry(ctx, delay); err != nil {
+				return err
+			}
+			continue
+		}
+		if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+			resp.Body.Close()
+			return fmt.Errorf("unexpected status: %s", resp.Status)
+		}
+		if err := json.NewDecoder(resp.Body).Decode(dst); err != nil {
+			resp.Body.Close()
+			return fmt.Errorf("decode response: %w", err)
+		}
+		resp.Body.Close()
+		if env, ok := dst.(apiEnvelopeChecker); ok && !env.success() {
+			return fmt.Errorf("cloudflare api error: %s", env.errorMessage())
+		}
+		return nil
 	}
 
-	return nil
+	return fmt.Errorf("cloudflare request failed after retries")
 }
 
 func joinErrors(errs []struct {
@@ -506,12 +526,36 @@ func isPublicIP(value string) bool {
 	if ip.IsUnspecified() || ip.IsLoopback() || ip.IsPrivate() || ip.IsMulticast() || ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast() {
 		return false
 	}
-	if ip4 := ip.To4(); ip4 != nil {
-		if ip4[0] == 0 || (ip4[0] == 169 && ip4[1] == 254) {
-			return false
-		}
+	if ip4 := ip.To4(); ip4 != nil && ip4[0] == 0 {
+		return false
 	}
 	return true
+}
+
+func retryDelay(value string, attempt int) time.Duration {
+	retryAfter := strings.TrimSpace(value)
+	if retryAfter != "" {
+		if seconds, err := strconv.Atoi(retryAfter); err == nil && seconds > 0 {
+			return time.Duration(seconds) * time.Second
+		}
+		if when, err := http.ParseTime(retryAfter); err == nil {
+			if delay := time.Until(when); delay > 0 {
+				return delay
+			}
+		}
+	}
+	return time.Duration(attempt+1) * time.Second
+}
+
+func waitForRetry(ctx context.Context, delay time.Duration) error {
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
 }
 
 func uniqueSortedValues(values []string) []string {

--- a/internal/providers/cloudflare/cloudflare_test.go
+++ b/internal/providers/cloudflare/cloudflare_test.go
@@ -1,0 +1,215 @@
+package cloudflare
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestDiscoverFiltersAndNormalizesAssets(t *testing.T) {
+	client, err := NewClientForTesting("token", "https://example.test", newMockHTTPClient(t, func(r *http.Request) (*http.Response, error) {
+		if got := r.Header.Get("Authorization"); got != "Bearer token" {
+			t.Fatalf("unexpected auth header: %q", got)
+		}
+		switch r.URL.Path {
+		case "/zones":
+			return jsonResponse(t, map[string]any{
+				"success": true,
+				"result": []map[string]any{
+					{"id": "zone-1", "name": "together.ai", "status": "active", "paused": false, "type": "full"},
+					{"id": "zone-2", "name": "openchatkit.ai", "status": "active", "paused": false, "type": "full"},
+				},
+				"result_info": map[string]any{"page": 1, "per_page": 50, "count": 2, "total_pages": 1, "total_count": 2},
+			}), nil
+		case "/zones/zone-1/dns_records":
+			return jsonResponse(t, map[string]any{
+				"success": true,
+				"result": []map[string]any{
+					{"id": "1", "name": "api.together.ai", "type": "CNAME", "content": "svc.example.net", "proxied": true},
+					{"id": "2", "name": "internal.together.ai", "type": "A", "content": "10.0.0.4", "proxied": false},
+					{"id": "3", "name": "_acme-challenge.together.ai", "type": "CNAME", "content": "validation.example.net", "proxied": false},
+					{"id": "4", "name": "*.together.ai", "type": "CNAME", "content": "wildcard.example.net", "proxied": false},
+					{"id": "5", "name": "mail.together.ai", "type": "MX", "content": "mx.example.net", "proxied": false},
+					{"id": "6", "name": "www.together.ai", "type": "A", "content": "8.8.8.8", "proxied": false},
+				},
+				"result_info": map[string]any{"page": 1, "per_page": 500, "count": 6, "total_pages": 1, "total_count": 6},
+			}), nil
+		case "/zones/zone-2/dns_records":
+			return jsonResponse(t, map[string]any{
+				"success": true,
+				"result": []map[string]any{
+					{"id": "7", "name": "openchatkit.ai", "type": "CNAME", "content": "api.together.xyz", "proxied": true},
+				},
+				"result_info": map[string]any{"page": 1, "per_page": 500, "count": 1, "total_pages": 1, "total_count": 1},
+			}), nil
+		default:
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+			return nil, nil
+		}
+	}))
+	if err != nil {
+		t.Fatalf("NewClientForTesting returned error: %v", err)
+	}
+
+	assets, err := client.Discover(context.Background(), DiscoverOptions{
+		Zones:   []string{"together.ai", "openchatkit.ai"},
+		Include: []string{"*.together.ai", "openchatkit.ai"},
+		Exclude: []string{"internal.together.ai"},
+	})
+	if err != nil {
+		t.Fatalf("Discover returned error: %v", err)
+	}
+
+	if len(assets) != 3 {
+		t.Fatalf("expected 3 assets, got %d: %#v", len(assets), assets)
+	}
+	if assets[0].Zone != "openchatkit.ai" || assets[0].Hostname != "openchatkit.ai" {
+		t.Fatalf("unexpected first asset ordering: %#v", assets[0])
+	}
+	if assets[1].Hostname != "api.together.ai" || !assets[1].Proxied {
+		t.Fatalf("expected proxied api.together.ai asset, got %#v", assets[1])
+	}
+	if assets[2].Hostname != "www.together.ai" {
+		t.Fatalf("expected www.together.ai asset, got %#v", assets[2])
+	}
+
+	hostnames := Hostnames(assets)
+	if strings.Join(hostnames, ",") != "api.together.ai,openchatkit.ai,www.together.ai" {
+		t.Fatalf("unexpected hostnames: %v", hostnames)
+	}
+}
+
+func TestListDNSRecordsPaginates(t *testing.T) {
+	client, err := NewClientForTesting("token", "https://example.test", newMockHTTPClient(t, func(r *http.Request) (*http.Response, error) {
+		if r.URL.Path != "/zones/zone-1/dns_records" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		switch r.URL.Query().Get("page") {
+		case "1":
+			return jsonResponse(t, map[string]any{
+				"success": true,
+				"result": []map[string]any{
+					{"id": "1", "name": "a.example.com", "type": "CNAME", "content": "one.example.net", "proxied": false},
+				},
+				"result_info": map[string]any{"page": 1, "per_page": 1, "count": 1, "total_pages": 2, "total_count": 2},
+			}), nil
+		case "2":
+			return jsonResponse(t, map[string]any{
+				"success": true,
+				"result": []map[string]any{
+					{"id": "2", "name": "b.example.com", "type": "CNAME", "content": "two.example.net", "proxied": false},
+				},
+				"result_info": map[string]any{"page": 2, "per_page": 1, "count": 1, "total_pages": 2, "total_count": 2},
+			}), nil
+		default:
+			t.Fatalf("unexpected page query: %q", r.URL.Query().Get("page"))
+			return nil, nil
+		}
+	}))
+	if err != nil {
+		t.Fatalf("NewClientForTesting returned error: %v", err)
+	}
+
+	records, err := client.ListDNSRecords(context.Background(), "zone-1", 1)
+	if err != nil {
+		t.Fatalf("ListDNSRecords returned error: %v", err)
+	}
+	if len(records) != 2 {
+		t.Fatalf("expected 2 records, got %d", len(records))
+	}
+}
+
+func TestPatternMatches(t *testing.T) {
+	tests := []struct {
+		host    string
+		pattern string
+		match   bool
+	}{
+		{host: "api.together.ai", pattern: "*.together.ai", match: true},
+		{host: "api.together.ai", pattern: "together.ai", match: true},
+		{host: "api.together.ai", pattern: "api.together.ai", match: true},
+		{host: "api.together.ai", pattern: "admin.together.ai", match: false},
+	}
+
+	for _, test := range tests {
+		if got := patternMatches(test.host, test.pattern); got != test.match {
+			t.Fatalf("patternMatches(%q, %q) = %v, want %v", test.host, test.pattern, got, test.match)
+		}
+	}
+}
+
+func TestIsPublicIP(t *testing.T) {
+	if isPublicIP("10.0.0.1") {
+		t.Fatal("expected private ip to be filtered")
+	}
+	if isPublicIP("127.0.0.1") {
+		t.Fatal("expected loopback ip to be filtered")
+	}
+	if !isPublicIP("8.8.8.8") {
+		t.Fatal("expected public ip to pass")
+	}
+}
+
+func TestNewClientRejectsEmptyToken(t *testing.T) {
+	if _, err := NewClient("", time.Second); err == nil {
+		t.Fatal("expected error for empty token")
+	}
+}
+
+func TestGetIncludesQuery(t *testing.T) {
+	client, err := NewClientForTesting("token", "https://example.test", newMockHTTPClient(t, func(r *http.Request) (*http.Response, error) {
+		if r.URL.Path != "/zones" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		values, err := url.ParseQuery(r.URL.RawQuery)
+		if err != nil {
+			t.Fatalf("parse query: %v", err)
+		}
+		if values.Get("page") != "1" || values.Get("per_page") != "5" {
+			t.Fatalf("unexpected query values: %v", values)
+		}
+		return jsonResponse(t, map[string]any{
+			"success":     true,
+			"result":      []map[string]any{},
+			"result_info": map[string]any{"page": 1, "per_page": 5, "count": 0, "total_pages": 1, "total_count": 0},
+		}), nil
+	}))
+	if err != nil {
+		t.Fatalf("NewClientForTesting returned error: %v", err)
+	}
+	_, err = client.ListZones(context.Background(), DiscoverOptions{PageSize: 5})
+	if err != nil {
+		t.Fatalf("ListZones returned error: %v", err)
+	}
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (fn roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return fn(req)
+}
+
+func newMockHTTPClient(t *testing.T, fn roundTripFunc) *http.Client {
+	t.Helper()
+	return &http.Client{Transport: fn}
+}
+
+func jsonResponse(t *testing.T, body map[string]any) *http.Response {
+	t.Helper()
+	buf := bytes.NewBuffer(nil)
+	if err := json.NewEncoder(buf).Encode(body); err != nil {
+		t.Fatalf("encode response: %v", err)
+	}
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Status:     "200 OK",
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Body:       io.NopCloser(buf),
+	}
+}

--- a/internal/providers/cloudflare/cloudflare_test.go
+++ b/internal/providers/cloudflare/cloudflare_test.go
@@ -162,6 +162,30 @@ func TestNewClientRejectsEmptyToken(t *testing.T) {
 	}
 }
 
+func TestBuildInventorySnapshot(t *testing.T) {
+	snapshot := BuildInventorySnapshot(time.Date(2026, 3, 7, 12, 0, 0, 0, time.UTC), []Asset{
+		{Zone: "together.ai", Hostname: "api.together.ai", RecordType: "CNAME", Value: "svc.example.net", Proxied: true, Source: "cloudflare"},
+		{Zone: "together.ai", Hostname: "www.together.ai", RecordType: "A", Value: "8.8.8.8", Proxied: false, Source: "cloudflare"},
+	}, DiscoverOptions{
+		Zones:   []string{"together.ai", "together.ai"},
+		Include: []string{"*.together.ai"},
+		Exclude: []string{"internal.together.ai"},
+	})
+
+	if snapshot.GeneratedAt != "2026-03-07T12:00:00Z" {
+		t.Fatalf("unexpected generated_at: %s", snapshot.GeneratedAt)
+	}
+	if snapshot.AssetCount != 2 {
+		t.Fatalf("unexpected asset_count: %d", snapshot.AssetCount)
+	}
+	if len(snapshot.Zones) != 1 || snapshot.Zones[0] != "together.ai" {
+		t.Fatalf("unexpected zones: %v", snapshot.Zones)
+	}
+	if len(snapshot.ZoneFilters) != 1 || snapshot.ZoneFilters[0] != "together.ai" {
+		t.Fatalf("unexpected zone filters: %v", snapshot.ZoneFilters)
+	}
+}
+
 func TestGetIncludesQuery(t *testing.T) {
 	client, err := NewClientForTesting("token", "https://example.test", newMockHTTPClient(t, func(r *http.Request) (*http.Response, error) {
 		if r.URL.Path != "/zones" {

--- a/internal/providers/cloudflare/cloudflare_test.go
+++ b/internal/providers/cloudflare/cloudflare_test.go
@@ -22,8 +22,8 @@ func TestDiscoverFiltersAndNormalizesAssets(t *testing.T) {
 			return jsonResponse(t, map[string]any{
 				"success": true,
 				"result": []map[string]any{
-					{"id": "zone-1", "name": "together.ai", "status": "active", "paused": false, "type": "full"},
-					{"id": "zone-2", "name": "openchatkit.ai", "status": "active", "paused": false, "type": "full"},
+					{"id": "zone-1", "name": "example.net", "status": "active", "paused": false, "type": "full"},
+					{"id": "zone-2", "name": "example.org", "status": "active", "paused": false, "type": "full"},
 				},
 				"result_info": map[string]any{"page": 1, "per_page": 50, "count": 2, "total_pages": 1, "total_count": 2},
 			}), nil
@@ -31,12 +31,12 @@ func TestDiscoverFiltersAndNormalizesAssets(t *testing.T) {
 			return jsonResponse(t, map[string]any{
 				"success": true,
 				"result": []map[string]any{
-					{"id": "1", "name": "api.together.ai", "type": "CNAME", "content": "svc.example.net", "proxied": true},
-					{"id": "2", "name": "internal.together.ai", "type": "A", "content": "10.0.0.4", "proxied": false},
-					{"id": "3", "name": "_acme-challenge.together.ai", "type": "CNAME", "content": "validation.example.net", "proxied": false},
-					{"id": "4", "name": "*.together.ai", "type": "CNAME", "content": "wildcard.example.net", "proxied": false},
-					{"id": "5", "name": "mail.together.ai", "type": "MX", "content": "mx.example.net", "proxied": false},
-					{"id": "6", "name": "www.together.ai", "type": "A", "content": "8.8.8.8", "proxied": false},
+					{"id": "1", "name": "api.example.net", "type": "CNAME", "content": "svc.example.net", "proxied": true},
+					{"id": "2", "name": "internal.example.net", "type": "A", "content": "10.0.0.4", "proxied": false},
+					{"id": "3", "name": "_acme-challenge.example.net", "type": "CNAME", "content": "validation.example.net", "proxied": false},
+					{"id": "4", "name": "*.example.net", "type": "CNAME", "content": "wildcard.example.net", "proxied": false},
+					{"id": "5", "name": "mail.example.net", "type": "MX", "content": "mx.example.net", "proxied": false},
+					{"id": "6", "name": "admin.example.net", "type": "A", "content": "8.8.8.8", "proxied": false},
 				},
 				"result_info": map[string]any{"page": 1, "per_page": 500, "count": 6, "total_pages": 1, "total_count": 6},
 			}), nil
@@ -44,7 +44,7 @@ func TestDiscoverFiltersAndNormalizesAssets(t *testing.T) {
 			return jsonResponse(t, map[string]any{
 				"success": true,
 				"result": []map[string]any{
-					{"id": "7", "name": "openchatkit.ai", "type": "CNAME", "content": "api.together.xyz", "proxied": true},
+					{"id": "7", "name": "example.org", "type": "CNAME", "content": "api.example.net", "proxied": true},
 				},
 				"result_info": map[string]any{"page": 1, "per_page": 500, "count": 1, "total_pages": 1, "total_count": 1},
 			}), nil
@@ -58,9 +58,9 @@ func TestDiscoverFiltersAndNormalizesAssets(t *testing.T) {
 	}
 
 	assets, err := client.Discover(context.Background(), DiscoverOptions{
-		Zones:   []string{"together.ai", "openchatkit.ai"},
-		Include: []string{"*.together.ai", "openchatkit.ai"},
-		Exclude: []string{"internal.together.ai"},
+		Zones:   []string{"example.net", "example.org"},
+		Include: []string{"*.example.net", "example.org"},
+		Exclude: []string{"internal.example.net"},
 	})
 	if err != nil {
 		t.Fatalf("Discover returned error: %v", err)
@@ -69,18 +69,18 @@ func TestDiscoverFiltersAndNormalizesAssets(t *testing.T) {
 	if len(assets) != 3 {
 		t.Fatalf("expected 3 assets, got %d: %#v", len(assets), assets)
 	}
-	if assets[0].Zone != "openchatkit.ai" || assets[0].Hostname != "openchatkit.ai" {
+	if assets[0].Zone != "example.net" || assets[0].Hostname != "admin.example.net" {
 		t.Fatalf("unexpected first asset ordering: %#v", assets[0])
 	}
-	if assets[1].Hostname != "api.together.ai" || !assets[1].Proxied {
-		t.Fatalf("expected proxied api.together.ai asset, got %#v", assets[1])
+	if assets[1].Hostname != "api.example.net" || !assets[1].Proxied {
+		t.Fatalf("expected proxied api.example.net asset, got %#v", assets[1])
 	}
-	if assets[2].Hostname != "www.together.ai" {
-		t.Fatalf("expected www.together.ai asset, got %#v", assets[2])
+	if assets[2].Zone != "example.org" || assets[2].Hostname != "example.org" {
+		t.Fatalf("expected example.org asset, got %#v", assets[2])
 	}
 
 	hostnames := Hostnames(assets)
-	if strings.Join(hostnames, ",") != "api.together.ai,openchatkit.ai,www.together.ai" {
+	if strings.Join(hostnames, ",") != "admin.example.net,api.example.net,example.org" {
 		t.Fatalf("unexpected hostnames: %v", hostnames)
 	}
 }
@@ -131,10 +131,10 @@ func TestPatternMatches(t *testing.T) {
 		pattern string
 		match   bool
 	}{
-		{host: "api.together.ai", pattern: "*.together.ai", match: true},
-		{host: "api.together.ai", pattern: "together.ai", match: true},
-		{host: "api.together.ai", pattern: "api.together.ai", match: true},
-		{host: "api.together.ai", pattern: "admin.together.ai", match: false},
+		{host: "api.example.net", pattern: "*.example.net", match: true},
+		{host: "api.example.net", pattern: "example.net", match: true},
+		{host: "api.example.net", pattern: "api.example.net", match: true},
+		{host: "api.example.net", pattern: "admin.example.net", match: false},
 	}
 
 	for _, test := range tests {
@@ -164,12 +164,12 @@ func TestNewClientRejectsEmptyToken(t *testing.T) {
 
 func TestBuildInventorySnapshot(t *testing.T) {
 	snapshot := BuildInventorySnapshot(time.Date(2026, 3, 7, 12, 0, 0, 0, time.UTC), []Asset{
-		{Zone: "together.ai", Hostname: "api.together.ai", RecordType: "CNAME", Value: "svc.example.net", Proxied: true, Source: "cloudflare"},
-		{Zone: "together.ai", Hostname: "www.together.ai", RecordType: "A", Value: "8.8.8.8", Proxied: false, Source: "cloudflare"},
+		{Zone: "example.net", Hostname: "api.example.net", RecordType: "CNAME", Value: "svc.example.net", Proxied: true, Source: "cloudflare"},
+		{Zone: "example.net", Hostname: "admin.example.net", RecordType: "A", Value: "8.8.8.8", Proxied: false, Source: "cloudflare"},
 	}, DiscoverOptions{
-		Zones:   []string{"together.ai", "together.ai"},
-		Include: []string{"*.together.ai"},
-		Exclude: []string{"internal.together.ai"},
+		Zones:   []string{"example.net", "example.net"},
+		Include: []string{"*.example.net"},
+		Exclude: []string{"internal.example.net"},
 	})
 
 	if snapshot.GeneratedAt != "2026-03-07T12:00:00Z" {
@@ -178,10 +178,10 @@ func TestBuildInventorySnapshot(t *testing.T) {
 	if snapshot.AssetCount != 2 {
 		t.Fatalf("unexpected asset_count: %d", snapshot.AssetCount)
 	}
-	if len(snapshot.Zones) != 1 || snapshot.Zones[0] != "together.ai" {
+	if len(snapshot.Zones) != 1 || snapshot.Zones[0] != "example.net" {
 		t.Fatalf("unexpected zones: %v", snapshot.Zones)
 	}
-	if len(snapshot.ZoneFilters) != 1 || snapshot.ZoneFilters[0] != "together.ai" {
+	if len(snapshot.ZoneFilters) != 1 || snapshot.ZoneFilters[0] != "example.net" {
 		t.Fatalf("unexpected zone filters: %v", snapshot.ZoneFilters)
 	}
 }
@@ -190,32 +190,32 @@ func TestDiffInventory(t *testing.T) {
 	previous := InventorySnapshot{
 		GeneratedAt: "2026-03-06T10:00:00Z",
 		Assets: []Asset{
-			{Zone: "together.ai", Hostname: "api.together.ai", RecordType: "CNAME", Value: "old.example.net", Proxied: true, Source: "cloudflare"},
-			{Zone: "together.ai", Hostname: "legacy.together.ai", RecordType: "A", Value: "8.8.8.8", Proxied: false, Source: "cloudflare"},
-			{Zone: "together.ai", Hostname: "app.together.ai", RecordType: "CNAME", Value: "svc.example.net", Proxied: false, Source: "cloudflare"},
+			{Zone: "example.net", Hostname: "api.example.net", RecordType: "CNAME", Value: "old.example.net", Proxied: true, Source: "cloudflare"},
+			{Zone: "example.net", Hostname: "legacy.example.net", RecordType: "A", Value: "8.8.8.8", Proxied: false, Source: "cloudflare"},
+			{Zone: "example.net", Hostname: "app.example.net", RecordType: "CNAME", Value: "svc.example.net", Proxied: false, Source: "cloudflare"},
 		},
 	}
 	current := InventorySnapshot{
 		GeneratedAt: "2026-03-07T10:00:00Z",
 		Assets: []Asset{
-			{Zone: "together.ai", Hostname: "api.together.ai", RecordType: "CNAME", Value: "new.example.net", Proxied: true, Source: "cloudflare"},
-			{Zone: "together.ai", Hostname: "app.together.ai", RecordType: "CNAME", Value: "svc.example.net", Proxied: true, Source: "cloudflare"},
-			{Zone: "together.ai", Hostname: "new.together.ai", RecordType: "A", Value: "1.1.1.1", Proxied: false, Source: "cloudflare"},
+			{Zone: "example.net", Hostname: "api.example.net", RecordType: "CNAME", Value: "new.example.net", Proxied: true, Source: "cloudflare"},
+			{Zone: "example.net", Hostname: "app.example.net", RecordType: "CNAME", Value: "svc.example.net", Proxied: true, Source: "cloudflare"},
+			{Zone: "example.net", Hostname: "new.example.net", RecordType: "A", Value: "1.1.1.1", Proxied: false, Source: "cloudflare"},
 		},
 	}
 
 	diff := DiffInventory(time.Date(2026, 3, 7, 12, 0, 0, 0, time.UTC), previous, current)
 
-	if diff.AddedCount != 2 {
+	if diff.AddedCount != 1 {
 		t.Fatalf("unexpected added count: %d", diff.AddedCount)
 	}
-	if diff.RemovedCount != 2 {
+	if diff.RemovedCount != 1 {
 		t.Fatalf("unexpected removed count: %d", diff.RemovedCount)
 	}
-	if diff.ChangedCount != 1 {
+	if diff.ChangedCount != 2 {
 		t.Fatalf("unexpected changed count: %d", diff.ChangedCount)
 	}
-	if len(diff.Changed) != 1 || diff.Changed[0].After.Hostname != "app.together.ai" {
+	if len(diff.Changed) != 2 || diff.Changed[0].After.Hostname != "api.example.net" || diff.Changed[1].After.Hostname != "app.example.net" {
 		t.Fatalf("unexpected changed assets: %#v", diff.Changed)
 	}
 }
@@ -223,19 +223,23 @@ func TestDiffInventory(t *testing.T) {
 func TestHostnamesFromDiff(t *testing.T) {
 	diff := InventoryDiff{
 		Added: []Asset{
-			{Zone: "together.ai", Hostname: "new.together.ai", RecordType: "A", Value: "1.1.1.1", Source: "cloudflare"},
-			{Zone: "together.ai", Hostname: "new.together.ai", RecordType: "AAAA", Value: "2606:4700::1111", Source: "cloudflare"},
+			{Zone: "example.net", Hostname: "new.example.net", RecordType: "A", Value: "1.1.1.1", Source: "cloudflare"},
+			{Zone: "example.net", Hostname: "new.example.net", RecordType: "AAAA", Value: "2606:4700::1111", Source: "cloudflare"},
 		},
 		Changed: []AssetChange{
 			{
-				Before: Asset{Zone: "together.ai", Hostname: "app.together.ai", RecordType: "CNAME", Value: "old.example.net", Source: "cloudflare"},
-				After:  Asset{Zone: "together.ai", Hostname: "app.together.ai", RecordType: "CNAME", Value: "new.example.net", Source: "cloudflare"},
+				Before: Asset{Zone: "example.net", Hostname: "api.example.net", RecordType: "CNAME", Value: "old.example.net", Source: "cloudflare"},
+				After:  Asset{Zone: "example.net", Hostname: "api.example.net", RecordType: "CNAME", Value: "new.example.net", Source: "cloudflare"},
+			},
+			{
+				Before: Asset{Zone: "example.net", Hostname: "app.example.net", RecordType: "CNAME", Value: "old.example.net", Source: "cloudflare"},
+				After:  Asset{Zone: "example.net", Hostname: "app.example.net", RecordType: "CNAME", Value: "new.example.net", Source: "cloudflare"},
 			},
 		},
 	}
 
 	got := HostnamesFromDiff(diff)
-	want := []string{"app.together.ai", "new.together.ai"}
+	want := []string{"api.example.net", "app.example.net", "new.example.net"}
 	if strings.Join(got, ",") != strings.Join(want, ",") {
 		t.Fatalf("unexpected diff hostnames: got %v want %v", got, want)
 	}

--- a/internal/providers/cloudflare/cloudflare_test.go
+++ b/internal/providers/cloudflare/cloudflare_test.go
@@ -272,6 +272,56 @@ func TestGetIncludesQuery(t *testing.T) {
 	}
 }
 
+func TestGetRetriesRateLimit(t *testing.T) {
+	attempts := 0
+	client, err := NewClientForTesting("token", "https://example.test", newMockHTTPClient(t, func(r *http.Request) (*http.Response, error) {
+		attempts++
+		if attempts == 1 {
+			return rateLimitedResponse("0"), nil
+		}
+		return jsonResponse(t, map[string]any{
+			"success":     true,
+			"result":      []map[string]any{},
+			"result_info": map[string]any{"page": 1, "per_page": 50, "count": 0, "total_pages": 1, "total_count": 0},
+		}), nil
+	}))
+	if err != nil {
+		t.Fatalf("NewClientForTesting returned error: %v", err)
+	}
+
+	_, err = client.ListZones(context.Background(), DiscoverOptions{})
+	if err != nil {
+		t.Fatalf("ListZones returned error: %v", err)
+	}
+	if attempts != 2 {
+		t.Fatalf("expected 2 attempts, got %d", attempts)
+	}
+}
+
+func TestGetReturnsAPIErrorOnSuccessFalse(t *testing.T) {
+	client, err := NewClientForTesting("token", "https://example.test", newMockHTTPClient(t, func(r *http.Request) (*http.Response, error) {
+		return jsonResponse(t, map[string]any{
+			"success": false,
+			"errors": []map[string]any{
+				{"message": "token is invalid"},
+			},
+			"result":      []map[string]any{},
+			"result_info": map[string]any{"page": 1, "per_page": 50, "count": 0, "total_pages": 1, "total_count": 0},
+		}), nil
+	}))
+	if err != nil {
+		t.Fatalf("NewClientForTesting returned error: %v", err)
+	}
+
+	_, err = client.ListZones(context.Background(), DiscoverOptions{})
+	if err == nil {
+		t.Fatal("expected ListZones to return an error")
+	}
+	if !strings.Contains(err.Error(), "token is invalid") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 type roundTripFunc func(*http.Request) (*http.Response, error)
 
 func (fn roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
@@ -294,5 +344,16 @@ func jsonResponse(t *testing.T, body map[string]any) *http.Response {
 		Status:     "200 OK",
 		Header:     http.Header{"Content-Type": []string{"application/json"}},
 		Body:       io.NopCloser(buf),
+	}
+}
+
+func rateLimitedResponse(retryAfter string) *http.Response {
+	return &http.Response{
+		StatusCode: http.StatusTooManyRequests,
+		Status:     "429 Too Many Requests",
+		Header: http.Header{
+			"Retry-After": []string{retryAfter},
+		},
+		Body: io.NopCloser(strings.NewReader("rate limited")),
 	}
 }

--- a/internal/providers/cloudflare/cloudflare_test.go
+++ b/internal/providers/cloudflare/cloudflare_test.go
@@ -220,6 +220,27 @@ func TestDiffInventory(t *testing.T) {
 	}
 }
 
+func TestHostnamesFromDiff(t *testing.T) {
+	diff := InventoryDiff{
+		Added: []Asset{
+			{Zone: "together.ai", Hostname: "new.together.ai", RecordType: "A", Value: "1.1.1.1", Source: "cloudflare"},
+			{Zone: "together.ai", Hostname: "new.together.ai", RecordType: "AAAA", Value: "2606:4700::1111", Source: "cloudflare"},
+		},
+		Changed: []AssetChange{
+			{
+				Before: Asset{Zone: "together.ai", Hostname: "app.together.ai", RecordType: "CNAME", Value: "old.example.net", Source: "cloudflare"},
+				After:  Asset{Zone: "together.ai", Hostname: "app.together.ai", RecordType: "CNAME", Value: "new.example.net", Source: "cloudflare"},
+			},
+		},
+	}
+
+	got := HostnamesFromDiff(diff)
+	want := []string{"app.together.ai", "new.together.ai"}
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Fatalf("unexpected diff hostnames: got %v want %v", got, want)
+	}
+}
+
 func TestGetIncludesQuery(t *testing.T) {
 	client, err := NewClientForTesting("token", "https://example.test", newMockHTTPClient(t, func(r *http.Request) (*http.Response, error) {
 		if r.URL.Path != "/zones" {

--- a/internal/providers/cloudflare/cloudflare_test.go
+++ b/internal/providers/cloudflare/cloudflare_test.go
@@ -186,6 +186,40 @@ func TestBuildInventorySnapshot(t *testing.T) {
 	}
 }
 
+func TestDiffInventory(t *testing.T) {
+	previous := InventorySnapshot{
+		GeneratedAt: "2026-03-06T10:00:00Z",
+		Assets: []Asset{
+			{Zone: "together.ai", Hostname: "api.together.ai", RecordType: "CNAME", Value: "old.example.net", Proxied: true, Source: "cloudflare"},
+			{Zone: "together.ai", Hostname: "legacy.together.ai", RecordType: "A", Value: "8.8.8.8", Proxied: false, Source: "cloudflare"},
+			{Zone: "together.ai", Hostname: "app.together.ai", RecordType: "CNAME", Value: "svc.example.net", Proxied: false, Source: "cloudflare"},
+		},
+	}
+	current := InventorySnapshot{
+		GeneratedAt: "2026-03-07T10:00:00Z",
+		Assets: []Asset{
+			{Zone: "together.ai", Hostname: "api.together.ai", RecordType: "CNAME", Value: "new.example.net", Proxied: true, Source: "cloudflare"},
+			{Zone: "together.ai", Hostname: "app.together.ai", RecordType: "CNAME", Value: "svc.example.net", Proxied: true, Source: "cloudflare"},
+			{Zone: "together.ai", Hostname: "new.together.ai", RecordType: "A", Value: "1.1.1.1", Proxied: false, Source: "cloudflare"},
+		},
+	}
+
+	diff := DiffInventory(time.Date(2026, 3, 7, 12, 0, 0, 0, time.UTC), previous, current)
+
+	if diff.AddedCount != 2 {
+		t.Fatalf("unexpected added count: %d", diff.AddedCount)
+	}
+	if diff.RemovedCount != 2 {
+		t.Fatalf("unexpected removed count: %d", diff.RemovedCount)
+	}
+	if diff.ChangedCount != 1 {
+		t.Fatalf("unexpected changed count: %d", diff.ChangedCount)
+	}
+	if len(diff.Changed) != 1 || diff.Changed[0].After.Hostname != "app.together.ai" {
+		t.Fatalf("unexpected changed assets: %#v", diff.Changed)
+	}
+}
+
 func TestGetIncludesQuery(t *testing.T) {
 	client, err := NewClientForTesting("token", "https://example.test", newMockHTTPClient(t, func(r *http.Request) (*http.Response, error) {
 		if r.URL.Path != "/zones" {

--- a/internal/scanner/context.go
+++ b/internal/scanner/context.go
@@ -58,6 +58,7 @@ func CheckPolicies(results []ScanResult, sc *ScanContext) []PolicyViolation {
 	}
 
 	var violations []PolicyViolation
+	seen := make(map[string]struct{})
 
 	for _, r := range results {
 		host := r.Host
@@ -65,7 +66,7 @@ func CheckPolicies(results []ScanResult, sc *ScanContext) []PolicyViolation {
 			host = r.Hostname
 		}
 		if len(sc.Policies.AllowedPorts) > 0 && !allowedSet[r.Port] {
-			violations = append(violations, PolicyViolation{
+			violations = appendUniqueViolation(violations, seen, PolicyViolation{
 				Host:     host,
 				Port:     r.Port,
 				Severity: "HIGH",
@@ -75,7 +76,7 @@ func CheckPolicies(results []ScanResult, sc *ScanContext) []PolicyViolation {
 
 		if r.TLS != nil && sc.Policies.TLSMinVersion != "" {
 			if v, ok := tlsOrder[r.TLS.Version]; ok && v < minRequired {
-				violations = append(violations, PolicyViolation{
+				violations = appendUniqueViolation(violations, seen, PolicyViolation{
 					Host:     host,
 					Port:     r.Port,
 					Severity: "HIGH",
@@ -87,7 +88,7 @@ func CheckPolicies(results []ScanResult, sc *ScanContext) []PolicyViolation {
 		if sc.Policies.SSHPasswordAuth != nil && !*sc.Policies.SSHPasswordAuth {
 			if strings.EqualFold(r.Service, "ssh") && r.Metadata != nil {
 				if strings.Contains(string(r.Metadata), `"passwordAuthEnabled":true`) {
-					violations = append(violations, PolicyViolation{
+					violations = appendUniqueViolation(violations, seen, PolicyViolation{
 						Host:     host,
 						Port:     r.Port,
 						Severity: "CRITICAL",
@@ -99,6 +100,15 @@ func CheckPolicies(results []ScanResult, sc *ScanContext) []PolicyViolation {
 	}
 
 	return violations
+}
+
+func appendUniqueViolation(violations []PolicyViolation, seen map[string]struct{}, violation PolicyViolation) []PolicyViolation {
+	key := fmt.Sprintf("%s|%d|%s|%s", violation.Host, violation.Port, violation.Severity, violation.Detail)
+	if _, exists := seen[key]; exists {
+		return violations
+	}
+	seen[key] = struct{}{}
+	return append(violations, violation)
 }
 
 func BuildContextSummary(sc *ScanContext) string {

--- a/internal/scanner/context_test.go
+++ b/internal/scanner/context_test.go
@@ -1,0 +1,38 @@
+package scanner
+
+import "testing"
+
+func TestCheckPoliciesDedupesViolations(t *testing.T) {
+	passwordsDisabled := false
+	sc := &ScanContext{}
+	sc.Policies.AllowedPorts = []int{80, 443}
+	sc.Policies.SSHPasswordAuth = &passwordsDisabled
+
+	results := []ScanResult{
+		{
+			Host:     "1.1.1.1",
+			Hostname: "api.together.ai",
+			Port:     22,
+			Service:  "ssh",
+			Metadata: []byte(`{"passwordAuthEnabled":true}`),
+		},
+		{
+			Host:     "1.1.1.2",
+			Hostname: "api.together.ai",
+			Port:     22,
+			Service:  "ssh",
+			Metadata: []byte(`{"passwordAuthEnabled":true}`),
+		},
+	}
+
+	violations := CheckPolicies(results, sc)
+	if len(violations) != 2 {
+		t.Fatalf("expected 2 unique violations, got %d: %#v", len(violations), violations)
+	}
+	if violations[0].Detail != "port 22 not in allowed_ports policy" {
+		t.Fatalf("unexpected first violation: %#v", violations[0])
+	}
+	if violations[1].Detail != "SSH password authentication enabled; policy requires key-based auth only" {
+		t.Fatalf("unexpected second violation: %#v", violations[1])
+	}
+}


### PR DESCRIPTION

- Integrated Cloudflare-backed continuous discovery and scan loop into Flan
- Add normalized inventory snapshots, diffs, delta scans, and scheduled baseline/delta workflows
- Integrated CF zone and DNS discovery directly into the existing Flan CLI and CI scan pipeline
- Move workflow scope configuration to manual inputs or secrets instead of plaintext repo settings
- Harden prod behavior with pinned GitHub Actions dependencies, safer artifact handling, and bounded Cloudflare API retry logic
- Reduced scan noise and added regression coverage for filtering, diffing, retries, and API error handling