### PR TITLE
Added additional optimizations

### DIFF
--- a/cmd/flan/main.go
+++ b/cmd/flan/main.go
@@ -547,6 +547,11 @@ func main() {
 		slog.Info("CDN hosts detected", "count", len(cdnHosts))
 	}
 
+	cdnSkipPorts := map[int]bool{
+		80:  true,
+		443: true,
+	}
+
 	progress := scanner.NewProgress(len(targets))
 	statsInterval := 5
 	if cfg.Scan.StatsInterval > 0 {
@@ -642,7 +647,7 @@ func main() {
 			if ctx.Err() != nil {
 				break
 			}
-			if cdn != "" && !*scanCDN && port != 80 && port != 443 {
+			if cdn != "" && !*scanCDN && !cdnSkipPorts[port] {
 				continue
 			}
 			if checkpoint.ShouldSkip(targetKey, port) {
@@ -664,6 +669,10 @@ func main() {
 		if len(hostPorts) > maxHostPorts {
 			maxHostPorts = len(hostPorts)
 		}
+	}
+
+	if storeResults {
+		results = make([]scanner.ScanResult, 0, portsScheduled/3)
 	}
 
 	for idx := 0; idx < maxHostPorts; idx++ {

--- a/internal/dns/cache.go
+++ b/internal/dns/cache.go
@@ -65,7 +65,7 @@ func (c *DNSCache) Lookup(host string) ([]net.IP, error) {
 	if exists && time.Now().Before(entry.expires) {
 		c.stats.CacheHits++
 		c.mu.Unlock()
-		return append([]net.IP(nil), entry.ips...), nil
+		return entry.ips, nil
 	}
 	if exists {
 		delete(c.entries, host)
@@ -114,7 +114,7 @@ func (c *DNSCache) Lookup(host string) ([]net.IP, error) {
 			expires: time.Now().Add(c.ttl),
 		}
 		c.mu.Unlock()
-		return append([]net.IP(nil), ips...), nil
+		return ips, nil
 	}
 
 	c.mu.Lock()

--- a/internal/scanner/cve.go
+++ b/internal/scanner/cve.go
@@ -32,7 +32,14 @@ type CVELookup struct {
 
 func NewCVELookup() *CVELookup {
 	return &CVELookup{
-		client:  &http.Client{Timeout: 15 * time.Second},
+		client: &http.Client{
+			Timeout: 15 * time.Second,
+			Transport: &http.Transport{
+				MaxIdleConns:        10,
+				MaxIdleConnsPerHost: 5,
+				IdleConnTimeout:     30 * time.Second,
+			},
+		},
 		cache:   make(map[string][]CVE),
 		limiter: rate.NewLimiter(rate.Every(6*time.Second), 1),
 	}


### PR DESCRIPTION
- DNS Cache - Reduced memory copies. Returns cached IPs directly instead of copying slices
- Port Lookups - Use map for CDN skip ports. Pre-computed cdnSkipPorts map for O(1) lookups instead of two boolean checks per port
- Pre-allocate Results Slice. Pre-allocates results slice with estimated capacity before scanning starts
- HTTP Client Connection Pooling. Added Transport with connection pooling: MaxIdleConns, MaxIdleConnsPerHost, and IdleConnTimeout