### PR TITLE
Refactor Qwen Ai analysis security prompt & readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,9 @@ Scan with detailed AI-powered analysis (requires `TOGETHER_API_KEY`):
 flan -t scanme.nmap.org --analyze
 ```
 
+> [!TIP]
+> Use `--analyze` when you want the full AI report saved alongside scan artifacts. The default pretty-mode AI summary is intended for quick triage, not detailed remediation tracking.
+
 Use a custom asset context file for policy-aware AI analysis:
 
 ```
@@ -225,17 +228,26 @@ flan -t api.example.com --context /path/to/context.yaml
 
 ## Runtime Behavior
 
-Context is loaded automatically from `config/context.yaml` when present. It defines asset criticality, data classification, and security policies such as TLS minimum version, SSH auth requirements, and allowed ports. Policy violations are flagged before AI analysis runs.
+> [!NOTE]
+> `config/context.yaml` is loaded automatically when present. It defines asset criticality, data classification, and security policies such as TLS minimum version, SSH auth requirements, and allowed ports. Policy violations are flagged before AI analysis runs.
 
-Security-header findings are generated for HTTP `2xx/3xx` responses. For `4xx/5xx` responses, which are common on load balancer and CDN default pages, Flan reports header checks as skipped.
+> [!TIP]
+> Security-header findings are generated only for HTTP `2xx/3xx` responses. On `4xx/5xx` responses, which are common on load balancer and CDN default pages, Flan reports header checks as skipped instead of treating them as header failures.
 
-Flan uses a deterministic resolver chain: custom resolver when provided, otherwise the system resolver, then configured fallbacks. Resolver and cache stats are recorded in scan metadata.
+> [!IMPORTANT]
+> Flan uses a deterministic resolver chain: custom resolver when provided, otherwise the system resolver, then configured fallbacks. Resolver and cache stats are recorded in scan metadata.
 
-Cloudflare discovery uses zones as the discovery boundary. It keeps `A`, `AAAA`, and `CNAME` scan candidates and skips validation, wildcard, and non-public-IP records by default. It can persist a normalized inventory snapshot, compare it against a prior snapshot, and optionally narrow scans to added or changed hosts for scheduled delta workflows. If `--cloudflare-diff-against` is omitted but `--cloudflare-inventory-out` is set, Flan reuses the inventory output path as the diff base.
+> [!NOTE]
+> Cloudflare discovery is zone-based. It keeps `A`, `AAAA`, and `CNAME` scan candidates and skips validation, wildcard, and non-public-IP records by default. It can persist normalized inventory snapshots, diff them across runs, and optionally narrow scans to added or changed hosts. If `--cloudflare-diff-against` is omitted but `--cloudflare-inventory-out` is set, Flan reuses the inventory output path as the diff base.
 
-AWS discovery is inventory-first. It collects public scan targets from `Route53`, `EC2`, `ELB/ELBv2`, `CloudFront`, `API Gateway`, `Lightsail`, `EKS`, `Lambda` function URLs, and S3 website endpoints. It can persist a normalized inventory snapshot, compare it against a prior snapshot, and optionally narrow scans to added or changed targets. If `--aws-diff-against` is omitted but `--aws-inventory-out` is set, Flan reuses the inventory output path as the diff base.
+> [!NOTE]
+> AWS discovery is inventory-first. It collects public scan targets from `Route53`, `EC2`, `ELB/ELBv2`, `CloudFront`, `API Gateway`, `Lightsail`, `EKS`, `Lambda` function URLs, and S3 website endpoints. It can persist normalized inventory snapshots, diff them across runs, and optionally narrow scans to added or changed targets. If `--aws-diff-against` is omitted but `--aws-inventory-out` is set, Flan reuses the inventory output path as the diff base.
 
-For GitHub Actions automation, set the repository secret `CLOUDFLARE_API_TOKEN`. To avoid putting Cloudflare scope in plaintext repo settings, pass zones, include, and exclude filters as manual workflow inputs or store them in secrets named `CLOUDFLARE_ZONES`, `CLOUDFLARE_INCLUDE`, `CLOUDFLARE_EXCLUDE`, and `CLOUDFLARE_TOP_PORTS`.
+> [!WARNING]
+> Keep provider credentials and API keys out of config files and committed shell scripts. Use environment variables such as `TOGETHER_API_KEY`, `CLOUDFLARE_API_TOKEN`, and `AWS_PROFILE`, or inject them through your CI secret store.
+
+> [!TIP]
+> For GitHub Actions automation, set the repository secret `CLOUDFLARE_API_TOKEN`. To avoid putting Cloudflare scope in plaintext repo settings, pass zones, include, and exclude filters as manual workflow inputs or store them in secrets named `CLOUDFLARE_ZONES`, `CLOUDFLARE_INCLUDE`, `CLOUDFLARE_EXCLUDE`, and `CLOUDFLARE_TOP_PORTS`.
 
 ## Config Defaults
 

--- a/internal/scanner/analyze.go
+++ b/internal/scanner/analyze.go
@@ -29,14 +29,20 @@ type AnalysisUsage struct {
 
 const TogetherModel = "Qwen/Qwen3.5-9B"
 
-const briefSystemPrompt = `You are a security expert. Summarize the scan results in 5-7 bullet points:
+const briefSystemPrompt = `You are a security expert. Return only the final report inside <report>...</report>.
+Do not include reasoning, hidden thoughts, step-by-step analysis, or headings such as "Thinking Process".
+
+Summarize the scan results in 5-7 bullet points:
 - Lead with critical/high severity findings; include a one-line remediation for each
 - Cover medium severity issues (missing headers, weak TLS, exposed admin interfaces, version disclosure)
 - Flag suspicious or non-standard ports by number -- apply known associations (31337 = Back Orifice, 4444 = Metasploit, 9929 = nping-echo, 6666 = IRC/malware)
 - Close with one sentence on overall risk posture
 Each bullet: what it is, why it matters, what to do. No preamble.`
 
-const systemPrompt = `You are a security expert analyzing network scan results. For each finding, provide:
+const systemPrompt = `You are a security expert analyzing network scan results. Return only the final report inside <report>...</report>.
+Do not include reasoning, hidden thoughts, scratch work, or headings such as "Thinking Process", "Analysis", or "Step-by-step".
+
+For each finding, provide:
 
 1. Severity (CRITICAL/HIGH/MEDIUM/LOW/INFO)
 2. What was found and why it matters
@@ -102,13 +108,20 @@ func Analyze(ctx context.Context, results []ScanResult, outputDir string, sc *Sc
 				OfChatCompletionNewsMessageChatCompletionUserMessageParam: &together.ChatCompletionNewParamsMessageChatCompletionUserMessageParam{
 					Role: "user",
 					Content: together.ChatCompletionNewParamsMessageChatCompletionUserMessageParamContentUnion{
-						OfString: together.String(fmt.Sprintf("Analyze these network scan results:\n\n%s", summary)),
+						OfString: together.String(fmt.Sprintf("Analyze these network scan results and return only the final report inside <report> tags:\n\n%s", summary)),
 					},
 				},
 			},
 		},
-		MaxTokens:   together.Int(2000),
-		Temperature: together.Float(0.3),
+		Reasoning: together.ChatCompletionNewParamsReasoning{
+			Enabled: together.Bool(false),
+		},
+		ReasoningEffort: together.ChatCompletionNewParamsReasoningEffortLow,
+		ResponseFormat: together.ChatCompletionNewParamsResponseFormatUnion{
+			OfText: &together.ChatCompletionNewParamsResponseFormatText{},
+		},
+		MaxTokens:   together.Int(1400),
+		Temperature: together.Float(0.2),
 	})
 	if err != nil {
 		return nil, fmt.Errorf("together API call failed: %w", err)
@@ -178,10 +191,17 @@ func AnalyzeBrief(ctx context.Context, results []ScanResult, sc *ScanContext) (s
 				OfChatCompletionNewsMessageChatCompletionUserMessageParam: &together.ChatCompletionNewParamsMessageChatCompletionUserMessageParam{
 					Role: "user",
 					Content: together.ChatCompletionNewParamsMessageChatCompletionUserMessageParamContentUnion{
-						OfString: together.String(fmt.Sprintf("Summarize:\n\n%s", summary)),
+						OfString: together.String(fmt.Sprintf("Summarize and return only the final report inside <report> tags:\n\n%s", summary)),
 					},
 				},
 			},
+		},
+		Reasoning: together.ChatCompletionNewParamsReasoning{
+			Enabled: together.Bool(false),
+		},
+		ReasoningEffort: together.ChatCompletionNewParamsReasoningEffortLow,
+		ResponseFormat: together.ChatCompletionNewParamsResponseFormatUnion{
+			OfText: &together.ChatCompletionNewParamsResponseFormatText{},
 		},
 		MaxTokens:   together.Int(400),
 		Temperature: together.Float(0.2),
@@ -201,16 +221,55 @@ func AnalyzeBrief(ctx context.Context, results []ScanResult, sc *ScanContext) (s
 }
 
 func choiceContent(choice together.ChatCompletionChoice) string {
-	if text := strings.TrimSpace(choice.Message.Content); text != "" {
+	if text := sanitizeModelOutput(choice.Message.Content); text != "" {
 		return text
 	}
-	if text := strings.TrimSpace(choice.Text); text != "" {
+	if text := sanitizeModelOutput(choice.Text); text != "" {
 		return text
 	}
-	if text := strings.TrimSpace(choice.Message.Reasoning); text != "" {
+	if text := sanitizeModelOutput(choice.Message.Reasoning); text != "" {
 		return text
 	}
 	return ""
+}
+
+func sanitizeModelOutput(raw string) string {
+	text := strings.TrimSpace(raw)
+	if text == "" {
+		return ""
+	}
+
+	if report := extractTaggedReport(text); report != "" {
+		return report
+	}
+
+	lower := strings.ToLower(text)
+	for _, marker := range []string{"final answer:", "report:"} {
+		if idx := strings.Index(lower, marker); idx >= 0 {
+			text = strings.TrimSpace(text[idx+len(marker):])
+			lower = strings.ToLower(text)
+			break
+		}
+	}
+
+	if strings.HasPrefix(lower, "thinking process:") ||
+		strings.HasPrefix(lower, "analysis:") ||
+		strings.HasPrefix(lower, "step-by-step:") {
+		return ""
+	}
+
+	return strings.TrimSpace(text)
+}
+
+func extractTaggedReport(text string) string {
+	lower := strings.ToLower(text)
+	start := strings.Index(lower, "<report>")
+	end := strings.Index(lower, "</report>")
+	if start < 0 || end < 0 || end <= start {
+		return ""
+	}
+	start += len("<report>")
+	return strings.TrimSpace(text[start:end])
 }
 
 func buildSummary(results []ScanResult) string {

--- a/internal/scanner/analyze_test.go
+++ b/internal/scanner/analyze_test.go
@@ -9,7 +9,7 @@ import (
 func TestChoiceContentPrefersMessageContent(t *testing.T) {
 	choice := together.ChatCompletionChoice{
 		Message: together.ChatCompletionChoiceMessage{
-			Content: "summary",
+			Content: "<report>summary</report>",
 		},
 		Text: "fallback",
 	}
@@ -22,7 +22,7 @@ func TestChoiceContentPrefersMessageContent(t *testing.T) {
 func TestChoiceContentFallsBackToText(t *testing.T) {
 	choice := together.ChatCompletionChoice{
 		Message: together.ChatCompletionChoiceMessage{},
-		Text:    "summary",
+		Text:    "<report>summary</report>",
 	}
 
 	if got := choiceContent(choice); got != "summary" {
@@ -33,11 +33,47 @@ func TestChoiceContentFallsBackToText(t *testing.T) {
 func TestChoiceContentFallsBackToReasoning(t *testing.T) {
 	choice := together.ChatCompletionChoice{
 		Message: together.ChatCompletionChoiceMessage{
-			Reasoning: "summary",
+			Reasoning: "<report>summary</report>",
 		},
 	}
 
 	if got := choiceContent(choice); got != "summary" {
+		t.Fatalf("unexpected content: %q", got)
+	}
+}
+
+func TestChoiceContentExtractsTaggedReport(t *testing.T) {
+	choice := together.ChatCompletionChoice{
+		Message: together.ChatCompletionChoiceMessage{
+			Content: "Thinking Process:\ninternal\n<report>final report</report>",
+		},
+	}
+
+	if got := choiceContent(choice); got != "final report" {
+		t.Fatalf("unexpected content: %q", got)
+	}
+}
+
+func TestChoiceContentDropsReasoningOnlyOutput(t *testing.T) {
+	choice := together.ChatCompletionChoice{
+		Message: together.ChatCompletionChoiceMessage{
+			Content: "Thinking Process:\n1. inspect\n2. reason\n3. answer later",
+		},
+	}
+
+	if got := choiceContent(choice); got != "" {
+		t.Fatalf("unexpected content: %q", got)
+	}
+}
+
+func TestChoiceContentUsesFinalAnswerFallback(t *testing.T) {
+	choice := together.ChatCompletionChoice{
+		Message: together.ChatCompletionChoiceMessage{
+			Content: "Analysis:\ninternal\nFinal Answer:\n- HIGH: fix this",
+		},
+	}
+
+	if got := choiceContent(choice); got != "- HIGH: fix this" {
 		t.Fatalf("unexpected content: %q", got)
 	}
 }


### PR DESCRIPTION

- Improve README usability in the `Runtime Behavior` section
- Tuned Together AI analysis for `Qwen/Qwen3.5-9B` so Flan requests final-report-only output instead of verbose reasoning dumps
- Add runtime sanitization and tests to strip leaked chain-of-thought and keep AI analysis concise, actionable, and scan-focused