### PR TITLE
Disable CF release and improve cli startup

### DIFF
--- a/.github/workflows/cloudflare-baseline-scan.yml
+++ b/.github/workflows/cloudflare-baseline-scan.yml
@@ -1,4 +1,4 @@
-name: Cloudflare Baseline Scan
+name: Cloudflare Baseline Scan (Disabled)
 
 on:
   workflow_dispatch:
@@ -19,8 +19,6 @@ on:
         description: Top port preset for scanning (100, 1000, 2000, 5000)
         required: false
         type: string
-  schedule:
-    - cron: "43 3 * * *"
 
 permissions:
   contents: read
@@ -31,6 +29,7 @@ concurrency:
 
 jobs:
   baseline-scan:
+    if: ${{ false }}
     runs-on: ubuntu-latest
     timeout-minutes: 90
     env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,7 @@
-name: Release
+name: Release (Disabled)
 
 on:
-  push:
-    tags:
-      - "v*"
+  workflow_dispatch:
 
 permissions:
   contents: write
@@ -14,6 +12,7 @@ concurrency:
 
 jobs:
   build:
+    if: ${{ false }}
     runs-on: ubuntu-latest
     timeout-minutes: 60
 

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -1,4 +1,4 @@
-name: Tag Release
+name: Tag Release (Disabled)
 
 on:
   workflow_dispatch:
@@ -18,6 +18,7 @@ permissions:
 
 jobs:
   tag:
+    if: ${{ false }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:

--- a/README.md
+++ b/README.md
@@ -231,27 +231,7 @@ flan -t api.example.com --context /path/to/context.yaml
 > [!NOTE]
 > `config/context.yaml` is loaded automatically when present. It defines asset criticality, data classification, and security policies such as TLS minimum version, SSH auth requirements, and allowed ports. Policy violations are flagged before AI analysis runs.
 
-> [!TIP]
-> Security-header findings are generated only for HTTP `2xx/3xx` responses. On `4xx/5xx` responses, which are common on load balancer and CDN default pages, Flan reports header checks as skipped instead of treating them as header failures.
-
-> [!IMPORTANT]
-> Flan uses a deterministic resolver chain: custom resolver when provided, otherwise the system resolver, then configured fallbacks. Resolver and cache stats are recorded in scan metadata.
-
-> [!NOTE]
-> Cloudflare discovery is zone-based. It keeps `A`, `AAAA`, and `CNAME` scan candidates and skips validation, wildcard, and non-public-IP records by default. It can persist normalized inventory snapshots, diff them across runs, and optionally narrow scans to added or changed hosts. If `--cloudflare-diff-against` is omitted but `--cloudflare-inventory-out` is set, Flan reuses the inventory output path as the diff base.
-
-> [!NOTE]
-> AWS discovery is inventory-first. It collects public scan targets from `Route53`, `EC2`, `ELB/ELBv2`, `CloudFront`, `API Gateway`, `Lightsail`, `EKS`, `Lambda` function URLs, and S3 website endpoints. It can persist normalized inventory snapshots, diff them across runs, and optionally narrow scans to added or changed targets. If `--aws-diff-against` is omitted but `--aws-inventory-out` is set, Flan reuses the inventory output path as the diff base.
-
-> [!WARNING]
-> Keep provider credentials and API keys out of config files and committed shell scripts. Use environment variables such as `TOGETHER_API_KEY`, `CLOUDFLARE_API_TOKEN`, and `AWS_PROFILE`, or inject them through your CI secret store.
-
-> [!TIP]
-> For GitHub Actions automation, set the repository secret `CLOUDFLARE_API_TOKEN`. To avoid putting Cloudflare scope in plaintext repo settings, pass zones, include, and exclude filters as manual workflow inputs or store them in secrets named `CLOUDFLARE_ZONES`, `CLOUDFLARE_INCLUDE`, `CLOUDFLARE_EXCLUDE`, and `CLOUDFLARE_TOP_PORTS`.
-
-## Config Defaults
-
-Guardrails, DNS policy, Cloudflare discovery, and AWS discovery settings are configurable in `config/config.yaml`:
+Flan uses a deterministic resolver chain: custom resolver when provided, otherwise the system resolver, then configured fallbacks. Resolver and cache stats are recorded in scan metadata.
 
 ```yaml
 scan:
@@ -262,6 +242,19 @@ dns:
   resolver: ""
   fallback_resolvers: ["1.1.1.1:53", "8.8.8.8:53"]
   lookup_timeout: 3s
+```
+
+> [!TIP]
+Security-header findings are generated only for HTTP `2xx/3xx` responses. On `4xx/5xx` responses, which are common on load balancer and CDN default pages, Flan reports header checks as skipped instead of treating them as header failures.
+
+> [!WARNING]
+Keep provider credentials and API keys out of config files and committed shell scripts. Use environment variables such as `TOGETHER_API_KEY`, `CLOUDFLARE_API_TOKEN`, and `AWS_PROFILE`, or inject them through your CI secret store.
+
+### Cloudflare Discovery
+
+Cloudflare discovery is zone-based. It keeps `A`, `AAAA`, and `CNAME` scan candidates and skips validation, wildcard, and non-public-IP records by default. It can persist normalized inventory snapshots, diff them across runs, and optionally narrow scans to added or changed hosts. If `--cloudflare-diff-against` is omitted but `--cloudflare-inventory-out` is set, Flan reuses the inventory output path as the diff base.
+
+```yaml
 cloudflare:
   enabled: false
   zones: []
@@ -272,6 +265,18 @@ cloudflare:
   inventory_out: ""
   diff_against: ""
   delta_only: false
+```
+
+```text
+GitHub Actions: set CLOUDFLARE_API_TOKEN as a repository secret.
+Optional scope inputs: CLOUDFLARE_ZONES, CLOUDFLARE_INCLUDE, CLOUDFLARE_EXCLUDE, CLOUDFLARE_TOP_PORTS.
+```
+
+### AWS Discovery
+
+AWS discovery is inventory-first. It collects public scan targets from `Route53`, `EC2`, `ELB/ELBv2`, `CloudFront`, `API Gateway`, `Lightsail`, `EKS`, `Lambda` function URLs, and S3 website endpoints. It can persist normalized inventory snapshots, diff them across runs, and optionally narrow scans to added or changed targets. If `--aws-diff-against` is omitted but `--aws-inventory-out` is set, Flan reuses the inventory output path as the diff base.
+
+```yaml
 aws:
   enabled: false
   profile: ""
@@ -282,6 +287,11 @@ aws:
   inventory_out: ""
   diff_against: ""
   delta_only: false
+```
+
+```text
+Authentication uses the standard AWS SDK credential chain.
+Common options: AWS_PROFILE=<profile>, aws sso login, or environment credentials.
 ```
 
 ## Flags

--- a/cmd/flan/main.go
+++ b/cmd/flan/main.go
@@ -28,22 +28,42 @@ import (
 
 var version = "dev"
 
-const banner = `
-  __ _
- / _| | __ _ _ __    ___  ___ __ _ _ __
-| |_| |/ _' | '_ \  / __|/ __/ _' | '_ \
-|  _| | (_| | | | | \__ \ (_| (_| | | | |
-|_| |_|\__,_|_| |_| |___/\___\__,_|_| |_| %s
-
-`
-
 func printBanner() {
-	fmt.Fprintf(os.Stderr, "\033[36m"+banner+"\033[0m", version)
+	logo := []string{
+		"███████╗██╗      █████╗ ███╗   ██╗",
+		"██╔════╝██║     ██╔══██╗████╗  ██║",
+		"█████╗  ██║     ███████║██╔██╗ ██║",
+		"██╔══╝  ██║     ██╔══██║██║╚██╗██║",
+		"██║     ███████╗██║  ██║██║ ╚████║",
+		"╚═╝     ╚══════╝╚═╝  ╚═╝╚═╝  ╚═══╝",
+	}
+	side := []string{
+		"",
+		"swiss army knife network scanner",
+		fmt.Sprintf("powered by Together AI (%s)", scanner.TogetherModel),
+		"",
+		fmt.Sprintf("[%s]", version),
+		"",
+	}
+
+	fmt.Fprintln(os.Stderr)
+	for i := range logo {
+		fmt.Fprintf(os.Stderr, "\033[1;35m%s\033[0m", logo[i])
+		if side[i] != "" {
+			fmt.Fprintf(os.Stderr, "  \033[1;96m%s\033[0m", side[i])
+		}
+		fmt.Fprintln(os.Stderr)
+	}
+	fmt.Fprintln(os.Stderr)
 }
 
 func usage() {
 	fmt.Fprintf(os.Stderr, `Usage:
   flan [flags]
+
+GENERAL:
+  -h, --help              show help
+  -v, --version           show version
 
 TARGET:
   -t, -target string       target host/IP to scan
@@ -220,7 +240,6 @@ func readHosts(filename string) ([]string, error) {
 
 func main() {
 	flag.Usage = usage
-	printBanner()
 
 	configPath := flag.String("config", "config/config.yaml", "")
 	configShort := flag.String("c", "config/config.yaml", "")
@@ -275,7 +294,22 @@ func main() {
 	jsonFlag := flag.Bool("json", false, "")
 	jsonlFlag := flag.Bool("jsonl", false, "")
 	csvFlag := flag.Bool("csv", false, "")
+	helpFlag := flag.Bool("help", false, "")
+	helpShort := flag.Bool("h", false, "")
+	versionFlag := flag.Bool("version", false, "")
+	versionShort := flag.Bool("v", false, "")
 	flag.Parse()
+
+	if *helpFlag || *helpShort {
+		usage()
+		return
+	}
+	if *versionFlag || *versionShort {
+		fmt.Println(version)
+		return
+	}
+
+	printBanner()
 
 	set := make(map[string]bool)
 	flag.Visit(func(f *flag.Flag) { set[f.Name] = true })

--- a/go.mod
+++ b/go.mod
@@ -131,7 +131,7 @@ require (
 	github.com/sagikazarmark/slog-shim v0.1.0 // indirect
 	github.com/saintfish/chardet v0.0.0-20230101081208-5e3ef4b5456d // indirect
 	github.com/shirou/gopsutil/v3 v3.23.7 // indirect
-	github.com/shoenig/go-m1cpu v0.1.6 // indirect
+	github.com/shoenig/go-m1cpu v0.2.0 // indirect
 	github.com/sorairolake/lzip-go v0.3.5 // indirect
 	github.com/sourcegraph/conc v0.3.0 // indirect
 	github.com/spf13/afero v1.10.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -472,8 +472,11 @@ github.com/shirou/gopsutil/v3 v3.23.7 h1:C+fHO8hfIppoJ1WdsVm1RoI0RwXoNdfTK7yWXV0
 github.com/shirou/gopsutil/v3 v3.23.7/go.mod h1:c4gnmoRC0hQuaLqvxnx1//VXQ0Ms/X9UnJF8pddY5z4=
 github.com/shoenig/go-m1cpu v0.1.6 h1:nxdKQNcEB6vzgA2E2bvzKIYRuNj7XNJ4S/aRSwKzFtM=
 github.com/shoenig/go-m1cpu v0.1.6/go.mod h1:1JJMcUBvfNwpq05QDQVAnx3gUHr9IYF7GNg9SUEw2VQ=
+github.com/shoenig/go-m1cpu v0.2.0 h1:t4GNqvPZ84Vjtpboo/kT3pIkbaK3vc+JIlD/Wz1zSFY=
+github.com/shoenig/go-m1cpu v0.2.0/go.mod h1:KkDOw6m3ZJQAPHbrzkZki4hnx+pDRR1Lo+ldA56wD5w=
 github.com/shoenig/test v0.6.4 h1:kVTaSd7WLz5WZ2IaoM0RSzRsUD+m8wRR+5qvntpn4LU=
 github.com/shoenig/test v0.6.4/go.mod h1:byHiCGXqrVaflBLAMq/srcZIHynQPQgeyvkvXnjqq0k=
+github.com/shoenig/test v1.7.0 h1:eWcHtTXa6QLnBvm0jgEabMRN/uJ4DMV3M8xUGgRkZmk=
 github.com/sirupsen/logrus v1.3.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.7.0/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
 github.com/sirupsen/logrus v1.9.0/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=

--- a/ips.txt
+++ b/ips.txt
@@ -1,3 +1,1 @@
 scanme.nmap.org
-healthybyte.net
-randomsecurity.dev


### PR DESCRIPTION

- CF workflow disabled
- -h / -v flags with clean output behavior
- Upgraded the transitive `go-m1cpu` dependency
- Banner redesigned