### PR TITLE
Fix cancellation, ipv6 fingerprinting and nvd caching

### DIFF
--- a/cmd/flan/main.go
+++ b/cmd/flan/main.go
@@ -1446,14 +1446,15 @@ func splitCSV(input string) []string {
 	out := make([]string, 0, len(parts))
 	seen := make(map[string]struct{}, len(parts))
 	for _, part := range parts {
-		value := strings.ToLower(strings.TrimSpace(part))
+		value := strings.TrimSpace(part)
 		if value == "" {
 			continue
 		}
-		if _, exists := seen[value]; exists {
+		key := strings.ToLower(value)
+		if _, exists := seen[key]; exists {
 			continue
 		}
-		seen[value] = struct{}{}
+		seen[key] = struct{}{}
 		out = append(out, value)
 	}
 	return out
@@ -1602,7 +1603,7 @@ func resolveTargets(
 				if host == "" {
 					continue
 				}
-				resolvedIPs, err := dnsCache.Lookup(host)
+				resolvedIPs, err := dnsCache.LookupContext(ctx, host)
 				if err != nil {
 					slog.Warn("DNS lookup failed", "host", host, "err", err)
 					continue
@@ -1828,7 +1829,7 @@ func scanTCPPort(
 	}
 
 	if service == "" || service == "unknown" {
-		svc := scanner.DetectService(ip, port, cfg.Scan.Timeout)
+		svc := scanner.DetectServiceContext(ctx, ip, port, cfg.Scan.Timeout)
 		if svc.Name == "closed" {
 			return nil
 		}

--- a/cmd/flan/main_test.go
+++ b/cmd/flan/main_test.go
@@ -61,7 +61,7 @@ func TestPickHonorsExplicitFlags(t *testing.T) {
 
 func TestSplitCSV(t *testing.T) {
 	values := splitCSV(" crtsh,ANUBIS,crtsh , ,digitorus ")
-	want := []string{"crtsh", "anubis", "digitorus"}
+	want := []string{"crtsh", "ANUBIS", "digitorus"}
 	if !reflect.DeepEqual(values, want) {
 		t.Fatalf("unexpected parsed CSV values: got %v want %v", values, want)
 	}

--- a/internal/dns/cache.go
+++ b/internal/dns/cache.go
@@ -54,6 +54,10 @@ func NewDNSCache(ttl, lookupTimeout time.Duration, primaryResolver string, fallb
 }
 
 func (c *DNSCache) Lookup(host string) ([]net.IP, error) {
+	return c.LookupContext(context.Background(), host)
+}
+
+func (c *DNSCache) LookupContext(ctx context.Context, host string) ([]net.IP, error) {
 	host = strings.TrimSpace(host)
 	if host == "" {
 		return nil, &net.DNSError{Err: "empty host"}
@@ -83,7 +87,7 @@ func (c *DNSCache) Lookup(host string) ([]net.IP, error) {
 			c.mu.Unlock()
 		}
 
-		lookupCtx, cancel := context.WithTimeout(context.Background(), lookupTimeout)
+		lookupCtx, cancel := context.WithTimeout(ctx, lookupTimeout)
 		addrs, err := resolver.resolver.LookupIPAddr(lookupCtx, host)
 		cancel()
 		if err != nil {

--- a/internal/dns/cache_test.go
+++ b/internal/dns/cache_test.go
@@ -1,6 +1,7 @@
 package dns
 
 import (
+	"context"
 	"net"
 	"testing"
 	"time"
@@ -57,5 +58,30 @@ func TestShouldFallback(t *testing.T) {
 	}
 	if !shouldFallback(&net.DNSError{IsTimeout: true}) {
 		t.Fatal("expected timeout DNS errors to use fallback")
+	}
+}
+
+func TestLookupContextRespectsCancellation(t *testing.T) {
+	cache := &DNSCache{
+		entries:       make(map[string]cacheEntry),
+		lookupTimeout: time.Second,
+		resolvers: []resolverEndpoint{
+			{
+				name: "test",
+				resolver: &net.Resolver{
+					PreferGo: true,
+					Dial: func(ctx context.Context, network, address string) (net.Conn, error) {
+						<-ctx.Done()
+						return nil, ctx.Err()
+					},
+				},
+			},
+		},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if _, err := cache.LookupContext(ctx, "example.com"); err == nil {
+		t.Fatal("expected cancellation error")
 	}
 }

--- a/internal/scanner/analyze.go
+++ b/internal/scanner/analyze.go
@@ -227,9 +227,6 @@ func choiceContent(choice together.ChatCompletionChoice) string {
 	if text := sanitizeModelOutput(choice.Text); text != "" {
 		return text
 	}
-	if text := sanitizeModelOutput(choice.Message.Reasoning); text != "" {
-		return text
-	}
 	return ""
 }
 

--- a/internal/scanner/analyze_test.go
+++ b/internal/scanner/analyze_test.go
@@ -30,14 +30,14 @@ func TestChoiceContentFallsBackToText(t *testing.T) {
 	}
 }
 
-func TestChoiceContentFallsBackToReasoning(t *testing.T) {
+func TestChoiceContentDoesNotFallbackToReasoning(t *testing.T) {
 	choice := together.ChatCompletionChoice{
 		Message: together.ChatCompletionChoiceMessage{
 			Reasoning: "<report>summary</report>",
 		},
 	}
 
-	if got := choiceContent(choice); got != "summary" {
+	if got := choiceContent(choice); got != "" {
 		t.Fatalf("unexpected content: %q", got)
 	}
 }

--- a/internal/scanner/crawl.go
+++ b/internal/scanner/crawl.go
@@ -11,7 +11,6 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
-	"sync"
 	"time"
 
 	"golang.org/x/net/html"
@@ -187,12 +186,6 @@ var pathTech = map[string]string{
 	"/nagios/":               "Nagios",
 }
 
-var httpClientPool = sync.Pool{
-	New: func() interface{} {
-		return &http.Client{}
-	},
-}
-
 var cookieTech = map[string]string{
 	"wordpress_":   "WordPress",
 	"wp-settings":  "WordPress",
@@ -292,15 +285,17 @@ func crawlHTTP(ctx context.Context, scheme, ip, hostname string, port int, maxDe
 	if hostname != "" && net.ParseIP(hostname) == nil {
 		tlsCfg.ServerName = hostname
 	}
-	client := httpClientPool.Get().(*http.Client)
-	client.Timeout = crawlTimeout
-	client.Transport = &http.Transport{
+	transport := &http.Transport{
 		TLSClientConfig: tlsCfg,
 	}
-	client.CheckRedirect = func(req *http.Request, via []*http.Request) error {
-		return http.ErrUseLastResponse
+	defer transport.CloseIdleConnections()
+	client := &http.Client{
+		Timeout:   crawlTimeout,
+		Transport: transport,
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
 	}
-	defer httpClientPool.Put(client)
 
 	type entry struct {
 		path  string

--- a/internal/scanner/cve.go
+++ b/internal/scanner/cve.go
@@ -30,6 +30,19 @@ type CVELookup struct {
 	limiter *rate.Limiter
 }
 
+type cvssMetric struct {
+	CvssData struct {
+		BaseScore    float64 `json:"baseScore"`
+		BaseSeverity string  `json:"baseSeverity"`
+	} `json:"cvssData"`
+}
+
+type cveMetrics struct {
+	CvssV31 []cvssMetric `json:"cvssMetricV31"`
+	CvssV30 []cvssMetric `json:"cvssMetricV30"`
+	CvssV2  []cvssMetric `json:"cvssMetricV2"`
+}
+
 func NewCVELookup() *CVELookup {
 	return &CVELookup{
 		client: &http.Client{
@@ -61,7 +74,10 @@ func (c *CVELookup) Lookup(ctx context.Context, cpe string) []CVE {
 		if err := c.limiter.Wait(ctx); err != nil {
 			return nil, err
 		}
-		cves := c.queryNVD(ctx, cpe)
+		cves, err := c.queryNVD(ctx, cpe)
+		if err != nil {
+			return nil, err
+		}
 
 		c.mu.Lock()
 		c.cache[cpe] = cves
@@ -79,62 +95,69 @@ func (c *CVELookup) Lookup(ctx context.Context, cpe string) []CVE {
 	return nil
 }
 
-func (c *CVELookup) queryNVD(ctx context.Context, cpe string) []CVE {
+func (c *CVELookup) queryNVD(ctx context.Context, cpe string) ([]CVE, error) {
 	u := fmt.Sprintf("https://services.nvd.nist.gov/rest/json/cves/2.0?cpeName=%s&resultsPerPage=20", url.QueryEscape(cpe))
 
 	req, err := http.NewRequestWithContext(ctx, "GET", u, nil)
 	if err != nil {
 		slog.Warn("NVD request build failed", "cpe", cpe, "err", err)
-		return nil
+		return nil, err
 	}
 	req.Header.Set("User-Agent", "flan/1.0")
 
 	resp, err := c.client.Do(req)
 	if err != nil {
 		slog.Warn("NVD query failed", "cpe", cpe, "err", err)
-		return nil
+		return nil, err
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != 200 {
 		slog.Warn("NVD returned non-200", "cpe", cpe, "status", resp.StatusCode)
-		return nil
+		return nil, fmt.Errorf("unexpected NVD status: %d", resp.StatusCode)
 	}
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return nil
+		return nil, err
 	}
 
 	var result struct {
 		Vulnerabilities []struct {
 			CVE struct {
-				ID      string `json:"id"`
-				Metrics struct {
-					CvssV31 []struct {
-						CvssData struct {
-							BaseScore    float64 `json:"baseScore"`
-							BaseSeverity string  `json:"baseSeverity"`
-						} `json:"cvssData"`
-					} `json:"cvssMetricV31"`
-				} `json:"metrics"`
+				ID      string     `json:"id"`
+				Metrics cveMetrics `json:"metrics"`
 			} `json:"cve"`
 		} `json:"vulnerabilities"`
 	}
 
 	if err := json.Unmarshal(body, &result); err != nil {
 		slog.Warn("NVD parse failed", "cpe", cpe, "err", err)
-		return nil
+		return nil, err
 	}
 
 	var cves []CVE
 	for _, v := range result.Vulnerabilities {
 		cve := CVE{ID: v.CVE.ID}
-		if len(v.CVE.Metrics.CvssV31) > 0 {
-			cve.Score = v.CVE.Metrics.CvssV31[0].CvssData.BaseScore
-			cve.Severity = v.CVE.Metrics.CvssV31[0].CvssData.BaseSeverity
+		score, severity := extractCVESeverity(v.CVE.Metrics)
+		if severity != "" {
+			cve.Score = score
+			cve.Severity = severity
 		}
 		cves = append(cves, cve)
 	}
-	return cves
+	return cves, nil
+}
+
+func extractCVESeverity(metrics cveMetrics) (float64, string) {
+	if len(metrics.CvssV31) > 0 {
+		return metrics.CvssV31[0].CvssData.BaseScore, metrics.CvssV31[0].CvssData.BaseSeverity
+	}
+	if len(metrics.CvssV30) > 0 {
+		return metrics.CvssV30[0].CvssData.BaseScore, metrics.CvssV30[0].CvssData.BaseSeverity
+	}
+	if len(metrics.CvssV2) > 0 {
+		return metrics.CvssV2[0].CvssData.BaseScore, metrics.CvssV2[0].CvssData.BaseSeverity
+	}
+	return 0, ""
 }

--- a/internal/scanner/cve_test.go
+++ b/internal/scanner/cve_test.go
@@ -2,7 +2,12 @@ package scanner
 
 import (
 	"context"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
 	"testing"
+	"time"
 )
 
 func TestCVELookupWildcardCPEIsSkipped(t *testing.T) {
@@ -21,4 +26,57 @@ func TestCVELookupRespectsCanceledContext(t *testing.T) {
 	if got != nil {
 		t.Fatalf("expected canceled lookup to return nil, got %+v", got)
 	}
+}
+
+func TestCVELookupDoesNotCacheFailures(t *testing.T) {
+	l := NewCVELookup()
+	cpe := "cpe:2.3:a:test:svc:1.0:-:-:-:-:-:-:-"
+	callCount := 0
+	l.client = &http.Client{
+		Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+			callCount++
+			return nil, errors.New("boom")
+		}),
+		Timeout: time.Second,
+	}
+
+	if got := l.Lookup(context.Background(), cpe); got != nil {
+		t.Fatalf("expected nil on failure, got %+v", got)
+	}
+	if got := l.Lookup(context.Background(), cpe); got != nil {
+		t.Fatalf("expected nil on repeated failure, got %+v", got)
+	}
+	if callCount != 2 {
+		t.Fatalf("expected failure lookups not to be cached, got %d calls", callCount)
+	}
+}
+
+func TestCVELookupFallsBackToOlderCVSSMetrics(t *testing.T) {
+	l := NewCVELookup()
+	cpe := "cpe:2.3:a:test:svc:1.0:-:-:-:-:-:-:-"
+	l.client = &http.Client{
+		Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+			body := `{"vulnerabilities":[{"cve":{"id":"CVE-2026-0001","metrics":{"cvssMetricV30":[{"cvssData":{"baseScore":8.1,"baseSeverity":"HIGH"}}]}}}]}`
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader(body)),
+				Header:     make(http.Header),
+			}, nil
+		}),
+		Timeout: time.Second,
+	}
+
+	got := l.Lookup(context.Background(), cpe)
+	if len(got) != 1 {
+		t.Fatalf("expected one CVE, got %+v", got)
+	}
+	if got[0].Severity != "HIGH" || got[0].Score != 8.1 {
+		t.Fatalf("unexpected CVE metadata: %+v", got[0])
+	}
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
 }

--- a/internal/scanner/fingerprint.go
+++ b/internal/scanner/fingerprint.go
@@ -2,7 +2,6 @@ package scanner
 
 import (
 	"encoding/json"
-	"fmt"
 	"net/netip"
 	"time"
 
@@ -27,7 +26,7 @@ func FingerprintUDP(host string, port int, timeout time.Duration) *FingerprintRe
 }
 
 func fingerprint(host string, port int, timeout time.Duration, udp bool) *FingerprintResult {
-	addr, err := netip.ParseAddrPort(fmt.Sprintf("%s:%d", host, port))
+	addr, err := fingerprintAddr(host, port)
 	if err != nil {
 		return nil
 	}
@@ -56,4 +55,12 @@ func fingerprint(host string, port int, timeout time.Duration, udp bool) *Finger
 		TLS:       result.TLS,
 		Metadata:  result.Raw,
 	}
+}
+
+func fingerprintAddr(host string, port int) (netip.AddrPort, error) {
+	ip, err := netip.ParseAddr(host)
+	if err != nil {
+		return netip.AddrPort{}, err
+	}
+	return netip.AddrPortFrom(ip, uint16(port)), nil
 }

--- a/internal/scanner/fingerprint_test.go
+++ b/internal/scanner/fingerprint_test.go
@@ -1,0 +1,13 @@
+package scanner
+
+import "testing"
+
+func TestFingerprintAddrSupportsIPv6(t *testing.T) {
+	addr, err := fingerprintAddr("2001:db8::1", 443)
+	if err != nil {
+		t.Fatalf("fingerprintAddr returned error: %v", err)
+	}
+	if got := addr.String(); got != "[2001:db8::1]:443" {
+		t.Fatalf("unexpected addr: %s", got)
+	}
+}

--- a/internal/scanner/service_detection.go
+++ b/internal/scanner/service_detection.go
@@ -32,8 +32,13 @@ func IsTCPPortOpen(ctx context.Context, host string, port int, timeout time.Dura
 }
 
 func DetectService(host string, port int, timeout time.Duration) ServiceResult {
+	return DetectServiceContext(context.Background(), host, port, timeout)
+}
+
+func DetectServiceContext(ctx context.Context, host string, port int, timeout time.Duration) ServiceResult {
 	addr := net.JoinHostPort(host, fmt.Sprintf("%d", port))
-	conn, err := net.DialTimeout("tcp", addr, timeout)
+	dialer := net.Dialer{Timeout: timeout}
+	conn, err := dialer.DialContext(ctx, "tcp", addr)
 	if err != nil {
 		return ServiceResult{Name: "closed"}
 	}

--- a/internal/scanner/service_detection_test.go
+++ b/internal/scanner/service_detection_test.go
@@ -70,6 +70,19 @@ func TestDetectServiceClosedPort(t *testing.T) {
 	}
 }
 
+func TestDetectServiceContextRespectsCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	start := time.Now()
+	result := DetectServiceContext(ctx, "192.0.2.1", 22, 5*time.Second)
+	if result.Name != "closed" {
+		t.Fatalf("expected closed, got %s", result.Name)
+	}
+	if time.Since(start) > 500*time.Millisecond {
+		t.Fatalf("expected canceled detect service to return quickly")
+	}
+}
+
 func TestIsTCPPortOpen(t *testing.T) {
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {

--- a/internal/scanner/targets.go
+++ b/internal/scanner/targets.go
@@ -10,6 +10,8 @@ import (
 	"strings"
 )
 
+const maxTargetScannerTokenSize = 1024 * 1024
+
 type EndpointTarget struct {
 	Host string
 	Port int
@@ -19,6 +21,7 @@ func ParseTargets(r io.Reader) ([]string, error) {
 	var targets []string
 	seen := make(map[string]bool)
 	s := bufio.NewScanner(r)
+	s.Buffer(make([]byte, 0, 64*1024), maxTargetScannerTokenSize)
 
 	for s.Scan() {
 		line := strings.TrimSpace(s.Text())
@@ -46,6 +49,7 @@ func ParseEndpointTargets(r io.Reader) ([]EndpointTarget, error) {
 	var targets []EndpointTarget
 	seen := make(map[string]bool)
 	s := bufio.NewScanner(r)
+	s.Buffer(make([]byte, 0, 64*1024), maxTargetScannerTokenSize)
 
 	for s.Scan() {
 		line := strings.TrimSpace(s.Text())

--- a/internal/scanner/targets_test.go
+++ b/internal/scanner/targets_test.go
@@ -123,3 +123,14 @@ func TestParseEndpointTargets(t *testing.T) {
 		})
 	}
 }
+
+func TestParseTargetsAllowsLargeLines(t *testing.T) {
+	longHost := strings.Repeat("a", 70*1024)
+	got, err := ParseTargets(strings.NewReader(longHost + "\n"))
+	if err != nil {
+		t.Fatalf("ParseTargets returned error: %v", err)
+	}
+	if len(got) != 1 || got[0] != longHost {
+		t.Fatalf("unexpected targets: %v", got)
+	}
+}


### PR DESCRIPTION

- Fixed IPv6 fingerprinting and cancellation handling across DNS and service detection
- Prevented failed NVD lookups from being cached as “no CVEs” and improve CVSS fallback parsing
- Removed AI reasoning fallback so only report content is surfaced
- Replaced the crawler’s transport-reuse pattern with a safer per-call HTTP client
- Improved input robustness with larger target-line support and safer CSV flag parsing