### PR TITLE
Add external kubernetes surface fingerprints

### DIFF
--- a/internal/scanner/crawl.go
+++ b/internal/scanner/crawl.go
@@ -43,7 +43,7 @@ var sensitivePaths = []string{
 	"/api", "/api/v1", "/api/v2", "/api/docs",
 	"/swagger", "/swagger-ui", "/swagger-ui.html", "/swagger.json", "/openapi.json",
 	"/graphql", "/graphiql",
-	"/version", "/readyz", "/livez", "/api", "/apis",
+	"/version", "/readyz", "/livez", "/healthz", "/api", "/apis", "/openapi/v2", "/openapi/v3",
 	"/debug/pprof", "/__debug__/",
 	"/wp-login.php", "/wp-admin/", "/wp-content/", "/wp-includes/", "/xmlrpc.php", "/wp-json/",
 	"/administrator/", "/components/", "/templates/",
@@ -211,6 +211,9 @@ var productProbePaths = []string{
 	"/apis",
 	"/readyz",
 	"/livez",
+	"/healthz",
+	"/openapi/v2",
+	"/openapi/v3",
 	"/v1/sys/health",
 	"/v1/agent/self",
 	"/-/healthy",
@@ -541,10 +544,19 @@ func detectDeeperProduct(path string, cr *CrawlResult, headers http.Header, body
 	case path == "/version" && strings.Contains(bodyLower, "etcdserver") || strings.Contains(bodyLower, "etcdcluster"):
 		addProduct(fp, productsFound, "etcd", "high")
 	case path == "/version" && strings.Contains(bodyLower, "\"major\"") && strings.Contains(bodyLower, "\"minor\""):
+		addProduct(fp, productsFound, "Kubernetes API Server", "high")
 		addProduct(fp, productsFound, "Kubernetes", "high")
 	case statusOK && (headers.Get("Audit-Id") != "" || headers.Get("X-Kubernetes-Pf-Flowschema-Uid") != "" || headers.Get("X-Kubernetes-Pf-Prioritylevel-Uid") != ""):
+		addProduct(fp, productsFound, "Kubernetes API Server", "high")
 		addProduct(fp, productsFound, "Kubernetes", "medium")
-	case statusOK && (path == "/api" || path == "/apis" || path == "/readyz" || path == "/livez") && strings.Contains(bodyLower, "kubernetes"):
+	case statusOK && (path == "/api" || path == "/apis" || path == "/readyz" || path == "/livez" || path == "/healthz" || path == "/openapi/v2" || path == "/openapi/v3") && strings.Contains(bodyLower, "kubernetes"):
+		addProduct(fp, productsFound, "Kubernetes API Server", "medium")
+		addProduct(fp, productsFound, "Kubernetes", "medium")
+	case strings.Contains(title, "kubernetes dashboard") || strings.Contains(bodyLower, "kubernetes dashboard"):
+		addProduct(fp, productsFound, "Kubernetes Dashboard", "high")
+		addProduct(fp, productsFound, "Kubernetes", "medium")
+	case (path == "/" || path == "/healthz") && (strings.Contains(bodyLower, "default backend - 404") || strings.Contains(bodyLower, "ingress-nginx")):
+		addProduct(fp, productsFound, "Kubernetes Ingress", "high")
 		addProduct(fp, productsFound, "Kubernetes", "medium")
 	case strings.Contains(generator, "grafana"):
 		addProduct(fp, productsFound, "Grafana", "medium")

--- a/internal/scanner/crawl_test.go
+++ b/internal/scanner/crawl_test.go
@@ -194,6 +194,74 @@ func TestDetectDeeperProduct(t *testing.T) {
 	}
 }
 
+func TestDetectDeeperProductKubernetesAPIServer(t *testing.T) {
+	fp := &AppFingerprint{}
+	products := make(map[string]string)
+
+	detectDeeperProduct(
+		"/version",
+		&CrawlResult{Path: "/version", StatusCode: http.StatusOK},
+		http.Header{"Audit-Id": []string{"1234"}},
+		`{"major":"1","minor":"31","gitVersion":"v1.31.0"}`,
+		fp,
+		products,
+	)
+
+	got := make(map[string]string, len(fp.Products))
+	for _, product := range fp.Products {
+		got[product.Name] = product.Confidence
+	}
+	if got["Kubernetes API Server"] != "high" {
+		t.Fatalf("expected Kubernetes API Server high confidence, got %+v", fp.Products)
+	}
+	if got["Kubernetes"] == "" {
+		t.Fatalf("expected Kubernetes umbrella product, got %+v", fp.Products)
+	}
+}
+
+func TestDetectDeeperProductKubernetesIngress(t *testing.T) {
+	fp := &AppFingerprint{}
+	products := make(map[string]string)
+
+	detectDeeperProduct(
+		"/",
+		&CrawlResult{Path: "/", StatusCode: http.StatusNotFound},
+		http.Header{},
+		`default backend - 404`,
+		fp,
+		products,
+	)
+
+	got := make(map[string]string, len(fp.Products))
+	for _, product := range fp.Products {
+		got[product.Name] = product.Confidence
+	}
+	if got["Kubernetes Ingress"] != "high" {
+		t.Fatalf("expected Kubernetes Ingress high confidence, got %+v", fp.Products)
+	}
+}
+
+func TestDetectDeeperProductKubernetesDashboard(t *testing.T) {
+	fp := &AppFingerprint{}
+	products := make(map[string]string)
+
+	detectDeeperProduct(
+		"/",
+		&CrawlResult{Path: "/", StatusCode: http.StatusOK, Title: "Kubernetes Dashboard"},
+		http.Header{},
+		`<html>Kubernetes Dashboard</html>`,
+		fp,
+		products,
+	)
+
+	for _, product := range fp.Products {
+		if product.Name == "Kubernetes Dashboard" {
+			return
+		}
+	}
+	t.Fatalf("expected Kubernetes Dashboard product, got %+v", fp.Products)
+}
+
 func TestDetectDeeperProductGraphQL(t *testing.T) {
 	fp := &AppFingerprint{}
 	products := make(map[string]string)


### PR DESCRIPTION

- Added Kubernetes-specific external surface fingerprints for API servers, ingresses, and dashboards
- Extended the lightweight HTTP probe set with Kubernetes-relevant endpoints like `/healthz` and `/openapi/*`
- Kept the implementation minimal by reusing the existing HTTP fingerprint path and adding focused regression tests