### PR TITLE
Add kubernetes snapshot diffing and delta scans

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,18 @@ Enumerate externally reachable Kubernetes resources from an authenticated cluste
 flan --kubeconfig ~/.kube/config --kube-context prod-cluster --kube-inventory
 ```
 
+Write a normalized Kubernetes inventory snapshot for later diffing:
+
+```bash
+flan --kubeconfig ~/.kube/config --kube-context prod-cluster --kube-inventory --kube-inventory-out reports/kubernetes-inventory.json
+```
+
+Scan only added or changed Kubernetes resources when a previous snapshot exists:
+
+```bash
+flan --kubeconfig ~/.kube/config --kube-context prod-cluster --kube-inventory --kube-inventory-out reports/kubernetes-inventory.json --kube-delta-only
+```
+
 Write a normalized Cloudflare inventory snapshot for later diffing:
 
 ```
@@ -351,12 +363,16 @@ kubernetes:
   kubeconfig: ""
   context: ""
   timeout: 10s
+  inventory_out: ""
+  diff_against: ""
+  delta_only: false
 ```
 
 ```text
 Path resolution order when Kubernetes mode is enabled: --kubeconfig, config file, KUBECONFIG, then ~/.kube/config.
 Use --kube-context when the kubeconfig contains multiple contexts.
 Use --kube-inventory to turn authenticated cluster access into scan targets.
+If --kube-diff-against is omitted but --kube-inventory-out is set, Flan reuses the inventory output path as the diff base.
 ```
 
 ## Flags
@@ -394,6 +410,9 @@ Use --kube-inventory to turn authenticated cluster access into scan targets.
 | `--kubeconfig` | Path to kubeconfig for Kubernetes validation |
 | `--kube-context` | Optional kubeconfig context to use |
 | `--kube-inventory` | Enumerate externally reachable Kubernetes resources from the selected cluster |
+| `--kube-inventory-out` | Write normalized Kubernetes inventory snapshot to this path |
+| `--kube-diff-against` | Compare the current Kubernetes inventory against a previous snapshot; defaults to `--kube-inventory-out` when omitted |
+| `--kube-delta-only` | Scan only added/changed Kubernetes resources when a previous snapshot is available |
 | `--passive-only` | Skip brute-force, use passive sources only |
 | `--subdomains-only` | Print discovered subdomains and exit (no port scan) |
 | `--subfinder-sources` | Comma-separated passive sources override |

--- a/cmd/flan/main.go
+++ b/cmd/flan/main.go
@@ -104,6 +104,9 @@ func usage() {
 		{"--kubeconfig string", "path to kubeconfig for Kubernetes validation"},
 		{"--kube-context string", "optional kubeconfig context to use"},
 		{"--kube-inventory", "enumerate externally reachable Kubernetes resources from the selected cluster"},
+		{"--kube-inventory-out string", "write normalized Kubernetes inventory snapshot to this path"},
+		{"--kube-diff-against string", "compare the current Kubernetes inventory against a previous snapshot (defaults to --kube-inventory-out when omitted)"},
+		{"--kube-delta-only", "scan only added/changed Kubernetes resources when a previous snapshot is available"},
 		{"--passive-only", "skip brute-force, use passive sources only"},
 		{"--subdomains-only", "print discovered subdomains and exit (subfinder-style)"},
 		{"--subfinder-sources string", "comma-separated passive sources override"},
@@ -306,6 +309,9 @@ func main() {
 	kubeconfigFlag := flag.String("kubeconfig", "", "")
 	kubeContextFlag := flag.String("kube-context", "", "")
 	kubeInventoryFlag := flag.Bool("kube-inventory", false, "")
+	kubeInventoryOut := flag.String("kube-inventory-out", "", "")
+	kubeDiffAgainst := flag.String("kube-diff-against", "", "")
+	kubeDeltaOnly := flag.Bool("kube-delta-only", false, "")
 	passiveOnly := flag.Bool("passive-only", false, "")
 	subdomainsOnly := flag.Bool("subdomains-only", false, "")
 	subfinderSources := flag.String("subfinder-sources", "", "")
@@ -401,7 +407,7 @@ func main() {
 	}
 	cloudflareEnabled := *cloudflareFlag || cfg.Cloudflare.Enabled
 	awsEnabled := *awsFlag || cfg.AWS.Enabled
-	kubeOpts, kubeEnabled := selectKubernetesOptions(set, cfg, *kubeconfigFlag, *kubeContextFlag, *kubeInventoryFlag)
+	kubeOpts, kubeEnabled := selectKubernetesOptions(set, cfg, *kubeconfigFlag, *kubeContextFlag, *kubeInventoryFlag, *kubeInventoryOut, *kubeDiffAgainst, *kubeDeltaOnly)
 	if *fingerprintOnly && (dom != "" || cloudflareEnabled || awsEnabled || *subdomainsOnly) {
 		slog.Error("--fingerprint-only only supports manual -t/-l host:port inputs")
 		os.Exit(1)
@@ -481,12 +487,51 @@ func main() {
 				os.Exit(1)
 			}
 			slog.Info("kubernetes cluster validated", "context", target.Context, "cluster", target.Cluster, "server", target.Server)
-			for _, item := range items {
+			selectedItems := items
+			snapshot := kubeprovider.BuildInventorySnapshot(scanStarted, target, items)
+			diffAgainst := kubeOpts.diffAgainst
+			if diffAgainst == "" && kubeOpts.inventoryOut != "" {
+				diffAgainst = kubeOpts.inventoryOut
+				slog.Info("kubernetes inventory diff base defaults to inventory output", "path", diffAgainst)
+			}
+			if diffAgainst != "" {
+				previous, err := output.ReadKubernetesInventory(diffAgainst)
+				if err == nil {
+					diff := kubeprovider.DiffInventory(scanStarted, previous, snapshot)
+					slog.Info("kubernetes inventory diff", "added", diff.AddedCount, "removed", diff.RemovedCount, "changed", diff.ChangedCount)
+					if kubeOpts.deltaOnly {
+						selectedItems = kubeprovider.ItemsFromDiff(diff)
+						noTargetsFromDelta = len(selectedItems) == 0
+						slog.Info("kubernetes delta scan selection", "resources", len(selectedItems))
+					}
+					if path, err := output.WriteKubernetesInventoryDiff(cfg.Output.Directory, kubeOpts.inventoryOut, diff); err != nil {
+						slog.Warn("failed to write kubernetes inventory diff", "err", err)
+					} else if path != "" {
+						slog.Info("kubernetes inventory diff written", "path", path)
+					}
+				} else if !os.IsNotExist(err) {
+					slog.Warn("failed to read previous kubernetes inventory", "path", diffAgainst, "err", err)
+				} else if kubeOpts.deltaOnly {
+					slog.Info("kubernetes delta scan fallback to full inventory; previous snapshot not found", "path", diffAgainst)
+				}
+			} else if kubeOpts.deltaOnly {
+				slog.Info("kubernetes delta scan fallback to full inventory; no previous snapshot configured")
+			}
+			if path, err := output.WriteKubernetesInventory(cfg.Output.Directory, kubeOpts.inventoryOut, snapshot); err != nil {
+				slog.Warn("failed to write kubernetes inventory", "err", err)
+			} else if path != "" {
+				slog.Info("kubernetes inventory written", "path", path)
+			}
+			for _, item := range selectedItems {
 				endpointTargets = append(endpointTargets, scanner.EndpointTarget{Host: item.Host, Port: item.Port})
 			}
 			slog.Info("kubernetes inventory complete", "resources", len(items), "scan_targets", len(endpointTargets))
-			if len(items) == 0 && tgt == "" && dom == "" && !cloudflareEnabled && !awsEnabled && !set["list"] && !set["l"] {
-				slog.Info("no externally reachable kubernetes resources found")
+			if len(selectedItems) == 0 && tgt == "" && dom == "" && !cloudflareEnabled && !awsEnabled && !set["list"] && !set["l"] {
+				if kubeOpts.deltaOnly {
+					slog.Info("no delta targets to scan")
+				} else {
+					slog.Info("no externally reachable kubernetes resources found")
+				}
 				return
 			}
 		} else {
@@ -835,7 +880,7 @@ func main() {
 			slog.Info("no delta targets to scan")
 			return
 		}
-		slog.Error("no hosts to scan, provide -t, -d, -l, --cloudflare, or --aws")
+		slog.Error("no hosts to scan, provide -t, -d, -l, --cloudflare, --aws, or --kube-inventory")
 		os.Exit(1)
 	}
 	inputTargets := len(hosts) + len(endpointTargets)
@@ -1517,16 +1562,22 @@ func splitCSV(input string) []string {
 }
 
 type kubernetesOptions struct {
-	kubeconfig string
-	context    string
-	inventory  bool
+	kubeconfig   string
+	context      string
+	inventory    bool
+	inventoryOut string
+	diffAgainst  string
+	deltaOnly    bool
 }
 
-func selectKubernetesOptions(set map[string]bool, cfg *config.Config, kubeconfigFlag string, kubeContextFlag string, kubeInventoryFlag bool) (kubernetesOptions, bool) {
+func selectKubernetesOptions(set map[string]bool, cfg *config.Config, kubeconfigFlag string, kubeContextFlag string, kubeInventoryFlag bool, kubeInventoryOut string, kubeDiffAgainst string, kubeDeltaOnly bool) (kubernetesOptions, bool) {
 	opts := kubernetesOptions{
-		kubeconfig: strings.TrimSpace(cfg.Kubernetes.Kubeconfig),
-		context:    strings.TrimSpace(cfg.Kubernetes.Context),
-		inventory:  cfg.Kubernetes.Inventory,
+		kubeconfig:   strings.TrimSpace(cfg.Kubernetes.Kubeconfig),
+		context:      strings.TrimSpace(cfg.Kubernetes.Context),
+		inventory:    cfg.Kubernetes.Inventory,
+		inventoryOut: strings.TrimSpace(cfg.Kubernetes.InventoryOut),
+		diffAgainst:  strings.TrimSpace(cfg.Kubernetes.DiffAgainst),
+		deltaOnly:    cfg.Kubernetes.DeltaOnly,
 	}
 	if set["kubeconfig"] {
 		opts.kubeconfig = strings.TrimSpace(kubeconfigFlag)
@@ -1537,13 +1588,31 @@ func selectKubernetesOptions(set map[string]bool, cfg *config.Config, kubeconfig
 	if set["kube-inventory"] {
 		opts.inventory = kubeInventoryFlag
 	}
+	if set["kube-inventory-out"] {
+		opts.inventoryOut = strings.TrimSpace(kubeInventoryOut)
+	}
+	if set["kube-diff-against"] {
+		opts.diffAgainst = strings.TrimSpace(kubeDiffAgainst)
+	}
+	if set["kube-delta-only"] {
+		opts.deltaOnly = kubeDeltaOnly
+	}
+	if opts.inventoryOut != "" || opts.diffAgainst != "" || opts.deltaOnly {
+		opts.inventory = true
+	}
 	enabled := cfg.Kubernetes.Enabled ||
 		opts.inventory ||
 		set["kubeconfig"] ||
 		set["kube-context"] ||
 		set["kube-inventory"] ||
+		set["kube-inventory-out"] ||
+		set["kube-diff-against"] ||
+		set["kube-delta-only"] ||
 		opts.kubeconfig != "" ||
-		opts.context != ""
+		opts.context != "" ||
+		opts.inventoryOut != "" ||
+		opts.diffAgainst != "" ||
+		opts.deltaOnly
 	return opts, enabled
 }
 

--- a/cmd/flan/main_test.go
+++ b/cmd/flan/main_test.go
@@ -71,11 +71,11 @@ func TestSplitCSV(t *testing.T) {
 func TestSelectKubernetesOptions(t *testing.T) {
 	cfg := &config.Config{}
 
-	opts, enabled := selectKubernetesOptions(map[string]bool{}, cfg, "", "", false)
+	opts, enabled := selectKubernetesOptions(map[string]bool{}, cfg, "", "", false, "", "", false)
 	if enabled {
 		t.Fatal("did not expect kubernetes mode enabled by default")
 	}
-	if opts.kubeconfig != "" || opts.context != "" || opts.inventory {
+	if opts.kubeconfig != "" || opts.context != "" || opts.inventory || opts.inventoryOut != "" || opts.diffAgainst != "" || opts.deltaOnly {
 		t.Fatalf("unexpected default kube opts: %+v", opts)
 	}
 
@@ -83,19 +83,25 @@ func TestSelectKubernetesOptions(t *testing.T) {
 	cfg.Kubernetes.Kubeconfig = "/tmp/config"
 	cfg.Kubernetes.Context = "prod"
 	cfg.Kubernetes.Inventory = true
-	opts, enabled = selectKubernetesOptions(map[string]bool{}, cfg, "", "", false)
+	cfg.Kubernetes.InventoryOut = "./reports/kube.json"
+	cfg.Kubernetes.DiffAgainst = "./reports/kube-prev.json"
+	cfg.Kubernetes.DeltaOnly = true
+	opts, enabled = selectKubernetesOptions(map[string]bool{}, cfg, "", "", false, "", "", false)
 	if !enabled {
 		t.Fatal("expected kubernetes mode enabled from config")
 	}
-	if opts.kubeconfig != "/tmp/config" || opts.context != "prod" || !opts.inventory {
+	if opts.kubeconfig != "/tmp/config" || opts.context != "prod" || !opts.inventory || opts.inventoryOut != "./reports/kube.json" || opts.diffAgainst != "./reports/kube-prev.json" || !opts.deltaOnly {
 		t.Fatalf("unexpected config kube opts: %+v", opts)
 	}
 
-	opts, enabled = selectKubernetesOptions(map[string]bool{"kubeconfig": true, "kube-context": true, "kube-inventory": true}, cfg, "/tmp/override", "staging", false)
+	opts, enabled = selectKubernetesOptions(map[string]bool{
+		"kubeconfig": true, "kube-context": true, "kube-inventory": true,
+		"kube-inventory-out": true, "kube-diff-against": true, "kube-delta-only": true,
+	}, cfg, "/tmp/override", "staging", false, "./reports/new.json", "./reports/old.json", false)
 	if !enabled {
 		t.Fatal("expected kubernetes mode enabled from flags")
 	}
-	if opts.kubeconfig != "/tmp/override" || opts.context != "staging" || opts.inventory {
+	if opts.kubeconfig != "/tmp/override" || opts.context != "staging" || !opts.inventory || opts.inventoryOut != "./reports/new.json" || opts.diffAgainst != "./reports/old.json" || opts.deltaOnly {
 		t.Fatalf("unexpected overridden kube opts: %+v", opts)
 	}
 }

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -60,3 +60,6 @@ kubernetes:
   kubeconfig: ""
   context: ""
   timeout: 10s
+  inventory_out: ""
+  diff_against: ""
+  delta_only: false

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -70,11 +70,14 @@ type Config struct {
 		DeltaOnly    bool          `mapstructure:"delta_only"`
 	} `mapstructure:"aws"`
 	Kubernetes struct {
-		Enabled    bool          `mapstructure:"enabled"`
-		Inventory  bool          `mapstructure:"inventory"`
-		Kubeconfig string        `mapstructure:"kubeconfig"`
-		Context    string        `mapstructure:"context"`
-		Timeout    time.Duration `mapstructure:"timeout"`
+		Enabled      bool          `mapstructure:"enabled"`
+		Inventory    bool          `mapstructure:"inventory"`
+		Kubeconfig   string        `mapstructure:"kubeconfig"`
+		Context      string        `mapstructure:"context"`
+		Timeout      time.Duration `mapstructure:"timeout"`
+		InventoryOut string        `mapstructure:"inventory_out"`
+		DiffAgainst  string        `mapstructure:"diff_against"`
+		DeltaOnly    bool          `mapstructure:"delta_only"`
 	} `mapstructure:"kubernetes"`
 }
 
@@ -126,6 +129,9 @@ func defaults() *Config {
 	cfg.Kubernetes.Kubeconfig = ""
 	cfg.Kubernetes.Context = ""
 	cfg.Kubernetes.Timeout = 10 * time.Second
+	cfg.Kubernetes.InventoryOut = ""
+	cfg.Kubernetes.DiffAgainst = ""
+	cfg.Kubernetes.DeltaOnly = false
 	return cfg
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -88,6 +88,15 @@ func TestLoadConfigMissingFileUsesDefaults(t *testing.T) {
 	if cfg.Kubernetes.Timeout != 10*time.Second {
 		t.Fatalf("unexpected default kubernetes timeout: %v", cfg.Kubernetes.Timeout)
 	}
+	if cfg.Kubernetes.InventoryOut != "" {
+		t.Fatalf("unexpected default kubernetes inventory out: %q", cfg.Kubernetes.InventoryOut)
+	}
+	if cfg.Kubernetes.DiffAgainst != "" {
+		t.Fatalf("unexpected default kubernetes diff_against: %q", cfg.Kubernetes.DiffAgainst)
+	}
+	if cfg.Kubernetes.DeltaOnly {
+		t.Fatal("unexpected default kubernetes delta_only to be true")
+	}
 }
 
 func TestLoadConfigFromFileOverridesDefaults(t *testing.T) {
@@ -145,6 +154,9 @@ kubernetes:
   kubeconfig: /tmp/test-kubeconfig
   context: prod-cluster
   timeout: 9s
+  inventory_out: ./reports/kubernetes.json
+  diff_against: ./reports/kubernetes-prev.json
+  delta_only: true
 `
 	if err := os.WriteFile(path, []byte(body), 0600); err != nil {
 		t.Fatalf("write config: %v", err)
@@ -267,5 +279,14 @@ kubernetes:
 	}
 	if cfg.Kubernetes.Timeout != 9*time.Second {
 		t.Fatalf("unexpected kubernetes timeout override: %v", cfg.Kubernetes.Timeout)
+	}
+	if cfg.Kubernetes.InventoryOut != "./reports/kubernetes.json" {
+		t.Fatalf("unexpected kubernetes inventory_out override: %s", cfg.Kubernetes.InventoryOut)
+	}
+	if cfg.Kubernetes.DiffAgainst != "./reports/kubernetes-prev.json" {
+		t.Fatalf("unexpected kubernetes diff_against override: %s", cfg.Kubernetes.DiffAgainst)
+	}
+	if !cfg.Kubernetes.DeltaOnly {
+		t.Fatal("expected kubernetes delta_only override to be true")
 	}
 }

--- a/internal/output/kubernetes_inventory.go
+++ b/internal/output/kubernetes_inventory.go
@@ -1,0 +1,85 @@
+package output
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	kubeprovider "github.com/therandomsecurityguy/flan-go-scan/internal/providers/kubernetes"
+)
+
+func WriteKubernetesInventory(outputDir string, explicitPath string, snapshot kubeprovider.InventorySnapshot) (string, error) {
+	path := strings.TrimSpace(explicitPath)
+	if path == "" {
+		if outputDir == "" || outputDir == "-" {
+			return "", nil
+		}
+		path = filepath.Join(outputDir, fmt.Sprintf("kubernetes-inventory-%s.json", time.Now().Format("20060102-150405")))
+	}
+	if err := writeKubernetesJSON(path, snapshot); err != nil {
+		return "", err
+	}
+	return path, nil
+}
+
+func ReadKubernetesInventory(path string) (kubeprovider.InventorySnapshot, error) {
+	var snapshot kubeprovider.InventorySnapshot
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return snapshot, fmt.Errorf("read kubernetes inventory: %w", err)
+	}
+	if err := json.Unmarshal(data, &snapshot); err != nil {
+		return snapshot, fmt.Errorf("parse kubernetes inventory: %w", err)
+	}
+	return snapshot, nil
+}
+
+func WriteKubernetesInventoryDiff(outputDir string, inventoryPath string, diff kubeprovider.InventoryDiff) (string, error) {
+	path := ""
+	if trimmed := strings.TrimSpace(inventoryPath); trimmed != "" {
+		ext := filepath.Ext(trimmed)
+		base := strings.TrimSuffix(trimmed, ext)
+		if ext == "" {
+			path = base + "-diff.json"
+		} else {
+			path = base + "-diff" + ext
+		}
+	} else if outputDir != "" && outputDir != "-" {
+		path = filepath.Join(outputDir, fmt.Sprintf("kubernetes-inventory-diff-%s.json", time.Now().Format("20060102-150405")))
+	}
+	if path == "" {
+		return "", nil
+	}
+	if err := writeKubernetesJSON(path, diff); err != nil {
+		return "", err
+	}
+	return path, nil
+}
+
+func writeKubernetesJSON(path string, value any) error {
+	if err := ensureKubernetesOutputDir(path); err != nil {
+		return err
+	}
+	data, err := json.MarshalIndent(value, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal kubernetes json: %w", err)
+	}
+	if err := os.WriteFile(path, data, 0600); err != nil {
+		return fmt.Errorf("write kubernetes json: %w", err)
+	}
+	return nil
+}
+
+func ensureKubernetesOutputDir(path string) error {
+	dir := filepath.Dir(path)
+	if dir == "" || dir == "." {
+		return nil
+	}
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return fmt.Errorf("create kubernetes output directory: %w", err)
+	}
+	return nil
+}

--- a/internal/output/report_writer_test.go
+++ b/internal/output/report_writer_test.go
@@ -9,6 +9,7 @@ import (
 
 	awsprovider "github.com/therandomsecurityguy/flan-go-scan/internal/providers/aws"
 	cfprovider "github.com/therandomsecurityguy/flan-go-scan/internal/providers/cloudflare"
+	kubeprovider "github.com/therandomsecurityguy/flan-go-scan/internal/providers/kubernetes"
 	"github.com/therandomsecurityguy/flan-go-scan/internal/scanner"
 )
 
@@ -274,5 +275,46 @@ func TestReadAWSInventoryAndDiff(t *testing.T) {
 	}
 	if _, err := os.Stat(diffPath); err != nil {
 		t.Fatalf("expected aws diff file: %v", err)
+	}
+}
+
+func TestReadKubernetesInventoryAndDiff(t *testing.T) {
+	dir := t.TempDir()
+	inventoryPath := filepath.Join(dir, "kubernetes.json")
+	expected := kubeprovider.InventorySnapshot{
+		GeneratedAt:   "2026-03-24T00:00:00Z",
+		Source:        "kubernetes",
+		Cluster:       "prod-cluster",
+		Context:       "prod",
+		Server:        "https://api.cluster.example.com:6443",
+		ResourceCount: 1,
+		Resources: []kubeprovider.InventoryItem{
+			{Cluster: "prod-cluster", Context: "prod", Namespace: "prod", Kind: "Ingress", Name: "web", Host: "app.example.com", Port: 443, Protocol: "https", Exposure: "ingress"},
+		},
+	}
+	if _, err := WriteKubernetesInventory("", inventoryPath, expected); err != nil {
+		t.Fatalf("WriteKubernetesInventory failed: %v", err)
+	}
+	got, err := ReadKubernetesInventory(inventoryPath)
+	if err != nil {
+		t.Fatalf("ReadKubernetesInventory failed: %v", err)
+	}
+	if got.ResourceCount != expected.ResourceCount || len(got.Resources) != len(expected.Resources) {
+		t.Fatalf("unexpected kubernetes inventory readback: %#v", got)
+	}
+
+	diffPath, err := WriteKubernetesInventoryDiff("", inventoryPath, kubeprovider.InventoryDiff{
+		GeneratedAt: "2026-03-24T01:00:00Z",
+		Source:      "kubernetes",
+		AddedCount:  1,
+	})
+	if err != nil {
+		t.Fatalf("WriteKubernetesInventoryDiff failed: %v", err)
+	}
+	if diffPath != filepath.Join(dir, "kubernetes-diff.json") {
+		t.Fatalf("unexpected kubernetes diff path: %s", diffPath)
+	}
+	if _, err := os.Stat(diffPath); err != nil {
+		t.Fatalf("expected kubernetes diff file: %v", err)
 	}
 }

--- a/internal/providers/kubernetes/kubernetes.go
+++ b/internal/providers/kubernetes/kubernetes.go
@@ -49,6 +49,34 @@ type InventoryItem struct {
 	Exposure  string
 }
 
+type InventorySnapshot struct {
+	GeneratedAt   string          `json:"generated_at"`
+	Source        string          `json:"source"`
+	Cluster       string          `json:"cluster"`
+	Context       string          `json:"context"`
+	Server        string          `json:"server"`
+	ResourceCount int             `json:"resource_count"`
+	Resources     []InventoryItem `json:"resources"`
+}
+
+type InventoryDiff struct {
+	GeneratedAt         string                `json:"generated_at"`
+	Source              string                `json:"source"`
+	PreviousGeneratedAt string                `json:"previous_generated_at,omitempty"`
+	CurrentGeneratedAt  string                `json:"current_generated_at,omitempty"`
+	AddedCount          int                   `json:"added_count"`
+	RemovedCount        int                   `json:"removed_count"`
+	ChangedCount        int                   `json:"changed_count"`
+	Added               []InventoryItem       `json:"added,omitempty"`
+	Removed             []InventoryItem       `json:"removed,omitempty"`
+	Changed             []InventoryItemChange `json:"changed,omitempty"`
+}
+
+type InventoryItemChange struct {
+	Before InventoryItem `json:"before"`
+	After  InventoryItem `json:"after"`
+}
+
 func NewClient(timeout time.Duration) *Client {
 	if timeout <= 0 {
 		timeout = 10 * time.Second
@@ -84,6 +112,74 @@ func (c *Client) Inventory(ctx context.Context, opts ValidateOptions) (Target, [
 		return Target{}, nil, err
 	}
 	return target, items, nil
+}
+
+func BuildInventorySnapshot(now time.Time, target Target, items []InventoryItem) InventorySnapshot {
+	resources := append([]InventoryItem(nil), items...)
+	sortInventoryItems(resources)
+	return InventorySnapshot{
+		GeneratedAt:   now.UTC().Format(time.RFC3339),
+		Source:        "kubernetes",
+		Cluster:       target.Cluster,
+		Context:       target.Context,
+		Server:        target.Server,
+		ResourceCount: len(resources),
+		Resources:     resources,
+	}
+}
+
+func DiffInventory(now time.Time, previous, current InventorySnapshot) InventoryDiff {
+	prevByKey := make(map[string]InventoryItem, len(previous.Resources))
+	currByKey := make(map[string]InventoryItem, len(current.Resources))
+	for _, item := range previous.Resources {
+		prevByKey[itemChangeKey(item)] = item
+	}
+	for _, item := range current.Resources {
+		currByKey[itemChangeKey(item)] = item
+	}
+
+	diff := InventoryDiff{
+		GeneratedAt:         now.UTC().Format(time.RFC3339),
+		Source:              "kubernetes",
+		PreviousGeneratedAt: previous.GeneratedAt,
+		CurrentGeneratedAt:  current.GeneratedAt,
+	}
+
+	for key, currentItem := range currByKey {
+		previousItem, ok := prevByKey[key]
+		if !ok {
+			diff.Added = append(diff.Added, currentItem)
+			continue
+		}
+		if itemIdentity(previousItem) != itemIdentity(currentItem) {
+			diff.Changed = append(diff.Changed, InventoryItemChange{Before: previousItem, After: currentItem})
+		}
+	}
+
+	for key, previousItem := range prevByKey {
+		if _, ok := currByKey[key]; !ok {
+			diff.Removed = append(diff.Removed, previousItem)
+		}
+	}
+
+	sortInventoryItems(diff.Added)
+	sortInventoryItems(diff.Removed)
+	slices.SortFunc(diff.Changed, func(a, b InventoryItemChange) int {
+		return strings.Compare(itemKey(a.After), itemKey(b.After))
+	})
+
+	diff.AddedCount = len(diff.Added)
+	diff.RemovedCount = len(diff.Removed)
+	diff.ChangedCount = len(diff.Changed)
+	return diff
+}
+
+func ItemsFromDiff(diff InventoryDiff) []InventoryItem {
+	items := append([]InventoryItem(nil), diff.Added...)
+	for _, change := range diff.Changed {
+		items = append(items, change.After)
+	}
+	return dedupeInventoryItems(items)
 }
 
 func validateTarget(ctx context.Context, target Target, cfg *rest.Config, timeout time.Duration) error {
@@ -448,41 +544,14 @@ func dedupeInventoryItems(items []InventoryItem) []InventoryItem {
 		if item.Host == "" || item.Port <= 0 {
 			continue
 		}
-		key := strings.Join([]string{
-			item.Cluster,
-			item.Context,
-			item.Namespace,
-			item.Kind,
-			item.Name,
-			item.Host,
-			fmt.Sprintf("%d", item.Port),
-			item.Protocol,
-			item.Exposure,
-		}, "|")
+		key := itemIdentity(item)
 		if _, ok := seen[key]; ok {
 			continue
 		}
 		seen[key] = struct{}{}
 		out = append(out, item)
 	}
-	slices.SortFunc(out, func(a, b InventoryItem) int {
-		if a.Host != b.Host {
-			return strings.Compare(a.Host, b.Host)
-		}
-		if a.Port != b.Port {
-			if a.Port < b.Port {
-				return -1
-			}
-			return 1
-		}
-		if a.Namespace != b.Namespace {
-			return strings.Compare(a.Namespace, b.Namespace)
-		}
-		if a.Kind != b.Kind {
-			return strings.Compare(a.Kind, b.Kind)
-		}
-		return strings.Compare(a.Name, b.Name)
-	})
+	sortInventoryItems(out)
 	return out
 }
 
@@ -513,4 +582,30 @@ func resolvedKubeconfigPath(explicitPath string) string {
 		return envPath
 	}
 	return filepath.Join(clientcmd.RecommendedHomeDir, clientcmd.RecommendedFileName)
+}
+
+func sortInventoryItems(items []InventoryItem) {
+	slices.SortFunc(items, func(a, b InventoryItem) int {
+		return strings.Compare(itemKey(a), itemKey(b))
+	})
+}
+
+func itemChangeKey(item InventoryItem) string {
+	return strings.Join([]string{
+		item.Cluster,
+		item.Context,
+		item.Namespace,
+		item.Kind,
+		item.Name,
+		item.Host,
+		fmt.Sprintf("%d", item.Port),
+	}, "|")
+}
+
+func itemIdentity(item InventoryItem) string {
+	return itemChangeKey(item) + "|" + item.Protocol + "|" + item.Exposure
+}
+
+func itemKey(item InventoryItem) string {
+	return itemIdentity(item)
 }

--- a/internal/providers/kubernetes/kubernetes_test.go
+++ b/internal/providers/kubernetes/kubernetes_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strconv"
 	"strings"
 	"testing"
@@ -174,6 +175,78 @@ func TestInventoryFromClient(t *testing.T) {
 		if _, ok := got[key]; !ok {
 			t.Fatalf("missing inventory item %s in %v", key, got)
 		}
+	}
+}
+
+func TestBuildInventorySnapshot(t *testing.T) {
+	target := Target{
+		Context: "prod",
+		Cluster: "prod-cluster",
+		Server:  "https://api.cluster.example.com:6443",
+	}
+	snapshot := BuildInventorySnapshot(time.Date(2026, 3, 24, 12, 0, 0, 0, time.UTC), target, []InventoryItem{
+		{Cluster: "prod-cluster", Context: "prod", Namespace: "prod", Kind: "Ingress", Name: "web", Host: "app.example.com", Port: 443, Protocol: "https", Exposure: "ingress"},
+	})
+
+	if snapshot.Source != "kubernetes" {
+		t.Fatalf("unexpected source: %s", snapshot.Source)
+	}
+	if snapshot.Cluster != target.Cluster || snapshot.Context != target.Context || snapshot.Server != target.Server {
+		t.Fatalf("unexpected target data in snapshot: %#v", snapshot)
+	}
+	if snapshot.ResourceCount != 1 || len(snapshot.Resources) != 1 {
+		t.Fatalf("unexpected snapshot resources: %#v", snapshot)
+	}
+}
+
+func TestDiffInventory(t *testing.T) {
+	previous := InventorySnapshot{
+		GeneratedAt: "2026-03-24T10:00:00Z",
+		Resources: []InventoryItem{
+			{Cluster: "prod-cluster", Context: "prod", Namespace: "prod", Kind: "Ingress", Name: "web", Host: "old.example.com", Port: 443, Protocol: "https", Exposure: "ingress"},
+			{Cluster: "prod-cluster", Context: "prod", Namespace: "prod", Kind: "Service", Name: "legacy", Host: "legacy.example.com", Port: 443, Protocol: "tcp", Exposure: "loadbalancer"},
+			{Cluster: "prod-cluster", Context: "prod", Namespace: "prod", Kind: "Service", Name: "node-app", Host: "34.1.2.3", Port: 32080, Protocol: "tcp", Exposure: "nodeport"},
+		},
+	}
+	current := InventorySnapshot{
+		GeneratedAt: "2026-03-24T11:00:00Z",
+		Resources: []InventoryItem{
+			{Cluster: "prod-cluster", Context: "prod", Namespace: "prod", Kind: "Ingress", Name: "web", Host: "new.example.com", Port: 443, Protocol: "https", Exposure: "ingress"},
+			{Cluster: "prod-cluster", Context: "prod", Namespace: "prod", Kind: "Service", Name: "node-app", Host: "34.1.2.3", Port: 32080, Protocol: "tcp", Exposure: "cluster-node"},
+			{Cluster: "prod-cluster", Context: "prod", Namespace: "prod", Kind: "APIServer", Name: "kubernetes", Host: "api.cluster.example.com", Port: 6443, Protocol: "https", Exposure: "cluster"},
+		},
+	}
+
+	diff := DiffInventory(time.Date(2026, 3, 24, 12, 0, 0, 0, time.UTC), previous, current)
+	if diff.AddedCount != 2 {
+		t.Fatalf("unexpected added count: %d", diff.AddedCount)
+	}
+	if diff.RemovedCount != 2 {
+		t.Fatalf("unexpected removed count: %d", diff.RemovedCount)
+	}
+	if diff.ChangedCount != 1 {
+		t.Fatalf("unexpected changed count: %d", diff.ChangedCount)
+	}
+}
+
+func TestItemsFromDiff(t *testing.T) {
+	diff := InventoryDiff{
+		Added: []InventoryItem{
+			{Host: "api.cluster.example.com", Port: 6443, Protocol: "https", Exposure: "cluster"},
+			{Host: "api.cluster.example.com", Port: 6443, Protocol: "https", Exposure: "cluster"},
+		},
+		Changed: []InventoryItemChange{
+			{After: InventoryItem{Host: "app.example.com", Port: 443, Protocol: "https", Exposure: "ingress"}},
+		},
+	}
+
+	got := ItemsFromDiff(diff)
+	want := []InventoryItem{
+		{Host: "api.cluster.example.com", Port: 6443, Protocol: "https", Exposure: "cluster"},
+		{Host: "app.example.com", Port: 443, Protocol: "https", Exposure: "ingress"},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("unexpected diff items: got %#v want %#v", got, want)
 	}
 }
 


### PR DESCRIPTION

- Added Kubernetes inventory snapshots and diffing on top of kubeconfig-backed cluster access
- Added `--kube-inventory-out`, `--kube-diff-against`, and `--kube-delta-only` with the same flow as AWS and Cloudflare inventory modes
- Normalized Kubernetes API server, `Ingress`, `LoadBalancer`, and externally reachable `NodePort` resources into a stable inventory model
- Scan only added or changed Kubernetes resources when delta mode is enabled
- Add focused tests and real kubeconfig smoke validation for snapshot writing, diff generation, and delta-only behavior