### PR TITLE
Add canonical verification models

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,6 @@
 name: CI
 
 on:
-  pull_request:
-    branches:
-      - main
   push:
     branches:
       - main

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -1,24 +1,15 @@
-name: Tag Release (Disabled)
+name: Auto Tag
 
 on:
-  workflow_dispatch:
-    inputs:
-      version:
-        description: Semver tag to create (for example v0.12.0)
-        required: true
-        type: string
-      target_ref:
-        description: Branch or commit to tag
-        required: false
-        default: main
-        type: string
+  push:
+    branches:
+      - main
 
 permissions:
   contents: write
 
 jobs:
   tag:
-    if: ${{ false }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -26,25 +17,42 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
-          ref: ${{ inputs.target_ref }}
 
-      - name: Validate version
-        env:
-          VERSION: ${{ inputs.version }}
+      - name: Fetch tags
+        run: git fetch --tags --force
+
+      - name: Compute next patch tag
+        id: version
         run: |
-          if [[ ! "${VERSION}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "version must match vMAJOR.MINOR.PATCH" >&2
-            exit 1
+          set -euo pipefail
+
+          if git tag --points-at HEAD | grep -Eq '^v[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "create=false" >> "${GITHUB_OUTPUT}"
+            exit 0
           fi
-          if git rev-parse "refs/tags/${VERSION}" >/dev/null 2>&1; then
-            echo "tag ${VERSION} already exists" >&2
-            exit 1
+
+          latest="$(git tag -l 'v*.*.*' --sort=-v:refname | head -n1)"
+          if [[ -z "${latest}" ]]; then
+            next="v0.0.1"
+          else
+            version="${latest#v}"
+            IFS='.' read -r major minor patch <<<"${version}"
+            if (( patch >= 10 )); then
+              next="v${major}.$((minor + 1)).0"
+            else
+              next="v${major}.${minor}.$((patch + 1))"
+            fi
           fi
+
+          echo "create=true" >> "${GITHUB_OUTPUT}"
+          echo "version=${next}" >> "${GITHUB_OUTPUT}"
 
       - name: Create annotated tag
+        if: steps.version.outputs.create == 'true'
         env:
-          VERSION: ${{ inputs.version }}
+          VERSION: ${{ steps.version.outputs.version }}
         run: |
+          set -euo pipefail
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git tag -a "${VERSION}" -m "Release ${VERSION}"

--- a/internal/verify/models.go
+++ b/internal/verify/models.go
@@ -1,0 +1,315 @@
+package verify
+
+import (
+	"encoding/json"
+	"net/url"
+	"slices"
+	"strconv"
+	"strings"
+
+	"github.com/therandomsecurityguy/flan-go-scan/internal/scanner"
+)
+
+type Asset struct {
+	Host       string                       `json:"host"`
+	Hostname   string                       `json:"hostname,omitempty"`
+	Port       int                          `json:"port"`
+	Protocol   string                       `json:"protocol"`
+	Service    string                       `json:"service,omitempty"`
+	Version    string                       `json:"version,omitempty"`
+	Banner     string                       `json:"banner,omitempty"`
+	CDN        string                       `json:"cdn,omitempty"`
+	PTR        string                       `json:"ptr,omitempty"`
+	ASN        string                       `json:"asn,omitempty"`
+	Org        string                       `json:"org,omitempty"`
+	TLS        *scanner.TLSResult           `json:"tls,omitempty"`
+	Metadata   json.RawMessage              `json:"metadata,omitempty"`
+	App        *scanner.AppFingerprint      `json:"app,omitempty"`
+	Products   []scanner.ProductFingerprint `json:"products,omitempty"`
+	Kubernetes []scanner.KubernetesOrigin   `json:"kubernetes,omitempty"`
+}
+
+type Surface struct {
+	Source      string   `json:"source"`
+	Path        string   `json:"path"`
+	MethodHints []string `json:"method_hints,omitempty"`
+	Params      []string `json:"params,omitempty"`
+	StatusCode  int      `json:"status_code,omitempty"`
+	ContentType string   `json:"content_type,omitempty"`
+	Title       string   `json:"title,omitempty"`
+	RedirectTo  string   `json:"redirect_to,omitempty"`
+}
+
+type SelectorContext struct {
+	Asset           Asset                   `json:"asset"`
+	Surfaces        []Surface               `json:"surfaces,omitempty"`
+	ProductHints    []string                `json:"product_hints,omitempty"`
+	AppHints        []string                `json:"app_hints,omitempty"`
+	PathHints       []string                `json:"path_hints,omitempty"`
+	TitleHints      []string                `json:"title_hints,omitempty"`
+	HeaderHints     []string                `json:"header_hints,omitempty"`
+	Vulnerabilities []string                `json:"vulnerabilities,omitempty"`
+	SecurityHeaders []scanner.HeaderFinding `json:"security_headers,omitempty"`
+}
+
+type CandidateCheck struct {
+	CheckID string   `json:"check_id"`
+	Family  string   `json:"family"`
+	Adapter string   `json:"adapter,omitempty"`
+	Asset   Asset    `json:"asset"`
+	Surface *Surface `json:"surface,omitempty"`
+	Reasons []string `json:"reasons,omitempty"`
+}
+
+type HTTPRequestEvidence struct {
+	Method  string            `json:"method"`
+	URL     string            `json:"url"`
+	Headers map[string]string `json:"headers,omitempty"`
+	Body    string            `json:"body,omitempty"`
+}
+
+type HTTPResponseEvidence struct {
+	StatusCode int                 `json:"status_code"`
+	Headers    map[string][]string `json:"headers,omitempty"`
+	Body       string              `json:"body,omitempty"`
+}
+
+type Evidence struct {
+	Matcher  string                `json:"matcher,omitempty"`
+	Detail   string                `json:"detail,omitempty"`
+	Curl     string                `json:"curl,omitempty"`
+	Request  *HTTPRequestEvidence  `json:"request,omitempty"`
+	Response *HTTPResponseEvidence `json:"response,omitempty"`
+}
+
+type Finding struct {
+	ID          string   `json:"id"`
+	CheckID     string   `json:"check_id"`
+	Family      string   `json:"family"`
+	Adapter     string   `json:"adapter,omitempty"`
+	Severity    string   `json:"severity,omitempty"`
+	Confidence  string   `json:"confidence,omitempty"`
+	Asset       Asset    `json:"asset"`
+	Surface     *Surface `json:"surface,omitempty"`
+	Reasons     []string `json:"reasons,omitempty"`
+	References  []string `json:"references,omitempty"`
+	Remediation string   `json:"remediation,omitempty"`
+	Evidence    Evidence `json:"evidence"`
+}
+
+func AssetFromScanResult(result scanner.ScanResult) Asset {
+	return Asset{
+		Host:       result.Host,
+		Hostname:   result.Hostname,
+		Port:       result.Port,
+		Protocol:   result.Protocol,
+		Service:    result.Service,
+		Version:    result.Version,
+		Banner:     result.Banner,
+		CDN:        result.CDN,
+		PTR:        result.PTR,
+		ASN:        result.ASN,
+		Org:        result.Org,
+		TLS:        result.TLS,
+		Metadata:   result.Metadata,
+		App:        result.App,
+		Products:   scanner.MergeProductFingerprints(result.Products, appProducts(result.App)),
+		Kubernetes: slices.Clone(result.Kubernetes),
+	}
+}
+
+func SurfacesFromScanResult(result scanner.ScanResult) []Surface {
+	if len(result.Endpoints) == 0 {
+		return nil
+	}
+
+	seen := make(map[string]struct{}, len(result.Endpoints))
+	surfaces := make([]Surface, 0, len(result.Endpoints))
+	for _, endpoint := range result.Endpoints {
+		surface := SurfaceFromCrawlResult(endpoint)
+		key := strings.Join([]string{
+			surface.Source,
+			surface.Path,
+			strings.Join(surface.Params, ","),
+			strconv.Itoa(surface.StatusCode),
+			surface.ContentType,
+			surface.Title,
+			surface.RedirectTo,
+		}, "\x00")
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		surfaces = append(surfaces, surface)
+	}
+
+	return surfaces
+}
+
+func SurfaceFromCrawlResult(result scanner.CrawlResult) Surface {
+	return Surface{
+		Source:      "crawl",
+		Path:        normalizeSurfacePath(result.Path),
+		MethodHints: []string{"GET"},
+		Params:      pathParamNames(result.Path),
+		StatusCode:  result.StatusCode,
+		ContentType: result.ContentType,
+		Title:       strings.TrimSpace(result.Title),
+		RedirectTo:  strings.TrimSpace(result.RedirectTo),
+	}
+}
+
+func SelectorContextFromScanResult(result scanner.ScanResult) SelectorContext {
+	asset := AssetFromScanResult(result)
+	surfaces := SurfacesFromScanResult(result)
+
+	return SelectorContext{
+		Asset:           asset,
+		Surfaces:        surfaces,
+		ProductHints:    productHints(asset.Products),
+		AppHints:        appHints(result.App),
+		PathHints:       surfacePaths(surfaces),
+		TitleHints:      surfaceTitles(surfaces),
+		HeaderHints:     headerHints(result.SecurityHeaders),
+		Vulnerabilities: dedupeStrings(result.Vulnerabilities),
+		SecurityHeaders: slices.Clone(result.SecurityHeaders),
+	}
+}
+
+func normalizeSurfacePath(raw string) string {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return "/"
+	}
+	if parsed, err := url.Parse(trimmed); err == nil {
+		if parsed.Path != "" || parsed.RawQuery != "" {
+			path := parsed.Path
+			if path == "" {
+				path = "/"
+			} else if !strings.HasPrefix(path, "/") {
+				path = "/" + path
+			}
+			if parsed.RawQuery == "" {
+				return path
+			}
+			return path + "?" + parsed.RawQuery
+		}
+	}
+	if strings.HasPrefix(trimmed, "/") {
+		return trimmed
+	}
+	return "/" + trimmed
+}
+
+func pathParamNames(raw string) []string {
+	parsed, err := url.Parse(normalizeSurfacePath(raw))
+	if err != nil {
+		return nil
+	}
+	keys := make([]string, 0, len(parsed.Query()))
+	for key := range parsed.Query() {
+		if key == "" {
+			continue
+		}
+		keys = append(keys, strings.ToLower(key))
+	}
+	slices.Sort(keys)
+	return dedupeStrings(keys)
+}
+
+func appProducts(app *scanner.AppFingerprint) []scanner.ProductFingerprint {
+	if app == nil {
+		return nil
+	}
+	return app.Products
+}
+
+func productHints(products []scanner.ProductFingerprint) []string {
+	hints := make([]string, 0, len(products))
+	for _, product := range products {
+		if product.Name == "" {
+			continue
+		}
+		hints = append(hints, strings.ToLower(product.Name))
+	}
+	return dedupeStrings(hints)
+}
+
+func appHints(app *scanner.AppFingerprint) []string {
+	if app == nil {
+		return nil
+	}
+	hints := append([]string{}, app.Apps...)
+	for _, value := range []string{app.Server, app.PoweredBy, app.Generator} {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			continue
+		}
+		hints = append(hints, value)
+	}
+	for _, product := range app.Products {
+		if product.Name == "" {
+			continue
+		}
+		hints = append(hints, product.Name)
+	}
+	for i := range hints {
+		hints[i] = strings.ToLower(strings.TrimSpace(hints[i]))
+	}
+	return dedupeStrings(hints)
+}
+
+func surfacePaths(surfaces []Surface) []string {
+	paths := make([]string, 0, len(surfaces))
+	for _, surface := range surfaces {
+		if surface.Path == "" {
+			continue
+		}
+		paths = append(paths, surface.Path)
+	}
+	return dedupeStrings(paths)
+}
+
+func surfaceTitles(surfaces []Surface) []string {
+	titles := make([]string, 0, len(surfaces))
+	for _, surface := range surfaces {
+		if surface.Title == "" {
+			continue
+		}
+		titles = append(titles, strings.ToLower(surface.Title))
+	}
+	return dedupeStrings(titles)
+}
+
+func headerHints(findings []scanner.HeaderFinding) []string {
+	hints := make([]string, 0, len(findings))
+	for _, finding := range findings {
+		header := strings.ToLower(strings.TrimSpace(finding.Header))
+		if header == "" {
+			continue
+		}
+		hints = append(hints, header)
+	}
+	return dedupeStrings(hints)
+}
+
+func dedupeStrings(values []string) []string {
+	if len(values) == 0 {
+		return nil
+	}
+	seen := make(map[string]struct{}, len(values))
+	out := make([]string, 0, len(values))
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			continue
+		}
+		if _, ok := seen[value]; ok {
+			continue
+		}
+		seen[value] = struct{}{}
+		out = append(out, value)
+	}
+	slices.Sort(out)
+	return out
+}

--- a/internal/verify/models_test.go
+++ b/internal/verify/models_test.go
@@ -1,0 +1,123 @@
+package verify
+
+import (
+	"testing"
+
+	"github.com/therandomsecurityguy/flan-go-scan/internal/scanner"
+)
+
+func TestAssetFromScanResultMergesProducts(t *testing.T) {
+	result := scanner.ScanResult{
+		Host:     "10.0.0.1",
+		Hostname: "grafana.example.com",
+		Port:     443,
+		Protocol: "tcp",
+		Service:  "https",
+		Products: []scanner.ProductFingerprint{
+			{Name: "Grafana", Confidence: "low"},
+		},
+		App: &scanner.AppFingerprint{
+			Products: []scanner.ProductFingerprint{
+				{Name: "Grafana", Confidence: "high"},
+				{Name: "Vault", Confidence: "medium"},
+			},
+		},
+	}
+
+	asset := AssetFromScanResult(result)
+
+	if got, want := len(asset.Products), 2; got != want {
+		t.Fatalf("len(asset.Products) = %d, want %d", got, want)
+	}
+	if got, want := asset.Products[0].Name, "Grafana"; got != want {
+		t.Fatalf("asset.Products[0].Name = %q, want %q", got, want)
+	}
+	if got, want := asset.Products[0].Confidence, "high"; got != want {
+		t.Fatalf("asset.Products[0].Confidence = %q, want %q", got, want)
+	}
+	if got, want := asset.Products[1].Name, "Vault"; got != want {
+		t.Fatalf("asset.Products[1].Name = %q, want %q", got, want)
+	}
+}
+
+func TestSurfaceFromCrawlResultNormalizesPathAndParams(t *testing.T) {
+	surface := SurfaceFromCrawlResult(scanner.CrawlResult{
+		Path:        "login?Next=%2Fdashboard&redirect=https://evil.example&next=/foo",
+		StatusCode:  302,
+		ContentType: "text/html",
+		Title:       "  Login  ",
+		RedirectTo:  "https://evil.example",
+	})
+
+	if got, want := surface.Path, "/login?Next=%2Fdashboard&redirect=https://evil.example&next=/foo"; got != want {
+		t.Fatalf("surface.Path = %q, want %q", got, want)
+	}
+	if got, want := surface.MethodHints, []string{"GET"}; len(got) != len(want) || got[0] != want[0] {
+		t.Fatalf("surface.MethodHints = %v, want %v", got, want)
+	}
+	wantParams := []string{"next", "redirect"}
+	if len(surface.Params) != len(wantParams) {
+		t.Fatalf("len(surface.Params) = %d, want %d", len(surface.Params), len(wantParams))
+	}
+	for i := range wantParams {
+		if surface.Params[i] != wantParams[i] {
+			t.Fatalf("surface.Params[%d] = %q, want %q", i, surface.Params[i], wantParams[i])
+		}
+	}
+	if got, want := surface.Title, "Login"; got != want {
+		t.Fatalf("surface.Title = %q, want %q", got, want)
+	}
+}
+
+func TestSelectorContextFromScanResultBuildsHints(t *testing.T) {
+	result := scanner.ScanResult{
+		Host:     "192.0.2.10",
+		Hostname: "app.example.com",
+		Port:     443,
+		Protocol: "tcp",
+		Service:  "https",
+		Products: []scanner.ProductFingerprint{
+			{Name: "Grafana", Confidence: "high"},
+		},
+		App: &scanner.AppFingerprint{
+			Server:    "nginx/1.27.0",
+			PoweredBy: "Grafana",
+			Apps:      []string{"Grafana", "Grafana"},
+		},
+		Endpoints: []scanner.CrawlResult{
+			{Path: "/login?redirect=/", Title: "Login"},
+			{Path: "/login?redirect=/", Title: "Login"},
+			{Path: "/api/health", Title: "Health"},
+		},
+		SecurityHeaders: []scanner.HeaderFinding{
+			{Header: "Content-Security-Policy"},
+			{Header: "Content-Security-Policy"},
+			{Header: "Server"},
+		},
+		Vulnerabilities: []string{"CVE-2025-1234", "CVE-2025-1234", "CWE-601"},
+	}
+
+	ctx := SelectorContextFromScanResult(result)
+
+	if got, want := len(ctx.Surfaces), 2; got != want {
+		t.Fatalf("len(ctx.Surfaces) = %d, want %d", got, want)
+	}
+	assertStrings(t, "ProductHints", ctx.ProductHints, []string{"grafana"})
+	assertStrings(t, "AppHints", ctx.AppHints, []string{"grafana", "nginx/1.27.0"})
+	assertStrings(t, "PathHints", ctx.PathHints, []string{"/api/health", "/login?redirect=/"})
+	assertStrings(t, "TitleHints", ctx.TitleHints, []string{"health", "login"})
+	assertStrings(t, "HeaderHints", ctx.HeaderHints, []string{"content-security-policy", "server"})
+	assertStrings(t, "Vulnerabilities", ctx.Vulnerabilities, []string{"CVE-2025-1234", "CWE-601"})
+}
+
+func assertStrings(t *testing.T, name string, got, want []string) {
+	t.Helper()
+	if len(got) != len(want) {
+		t.Fatalf("%s length = %d, want %d (%v)", name, len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("%s[%d] = %q, want %q", name, i, got[i], want[i])
+		}
+	}
+}


### PR DESCRIPTION
Testing Engine: 

- Added minimal `internal/verify` model layer for `Asset`, `Surface`, `SelectorContext`, `CandidateCheck`, `Evidence`, and `Finding`
- Derived verification models directly from existing `ScanResult` and crawl output instead of introducing a parallel schema
- Normalized surface paths, extract query parameter hints, merge product fingerprints, and build selector-context hints
