### PR TITLE
Add `verify` CLI command and scan artifact loading

### DIFF
--- a/cmd/flan/main.go
+++ b/cmd/flan/main.go
@@ -62,6 +62,7 @@ func printBanner() {
 func usage() {
 	fmt.Fprintln(os.Stderr, "Usage:")
 	fmt.Fprintln(os.Stderr, "  flan [flags]")
+	fmt.Fprintln(os.Stderr, "  flan verify [flags]")
 	fmt.Fprintln(os.Stderr)
 
 	printUsageSection("GENERAL", [][2]string{
@@ -136,6 +137,7 @@ func usage() {
 	fmt.Fprintln(os.Stderr, "EXAMPLES:")
 	examples := []string{
 		"flan -t scanme.nmap.org",
+		"flan verify --input reports/scan-20260406-120000.json",
 		"flan -l targets.txt --top-ports 1000",
 		"flan -d example.net",
 		"flan --cloudflare --cloudflare-zones example.net --cloudflare-include api.example.net",
@@ -269,6 +271,15 @@ func readHosts(filename string) ([]string, error) {
 }
 
 func main() {
+	handled, err := dispatchSubcommand(os.Args[1:], os.Stdout, os.Stderr)
+	if handled {
+		if err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
+		}
+		return
+	}
+
 	flag.Usage = usage
 
 	configPath := flag.String("config", "config/config.yaml", "")

--- a/cmd/flan/verify.go
+++ b/cmd/flan/verify.go
@@ -1,0 +1,111 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"text/tabwriter"
+
+	"github.com/therandomsecurityguy/flan-go-scan/internal/output"
+	verifymodel "github.com/therandomsecurityguy/flan-go-scan/internal/verify"
+)
+
+var stdinHasDataFunc = stdinHasData
+
+type verifySummary struct {
+	InputPath string `json:"input_path"`
+	Results   int    `json:"results"`
+	Assets    int    `json:"assets"`
+	Surfaces  int    `json:"surfaces"`
+}
+
+func dispatchSubcommand(args []string, stdout, stderr io.Writer) (bool, error) {
+	if len(args) == 0 {
+		return false, nil
+	}
+	switch args[0] {
+	case "verify":
+		return true, runVerifyCommand(args[1:], stdout, stderr)
+	default:
+		return false, nil
+	}
+}
+
+func runVerifyCommand(args []string, stdout, stderr io.Writer) error {
+	fs := flag.NewFlagSet("verify", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	inputPath := fs.String("input", "", "")
+	inputShort := fs.String("i", "", "")
+	jsonFlag := fs.Bool("json", false, "")
+	fs.Usage = func() {
+		fmt.Fprintln(stderr, "Usage:")
+		fmt.Fprintln(stderr, "  flan verify [flags]")
+		fmt.Fprintln(stderr)
+		w := tabwriter.NewWriter(stderr, 0, 0, 2, ' ', 0)
+		fmt.Fprintf(w, "  --input, -i string\tpath to scan results in JSON or JSONL format; use - for stdin\n")
+		fmt.Fprintf(w, "  --json\toutput summary as JSON\n")
+		_ = w.Flush()
+		fmt.Fprintln(stderr)
+		fmt.Fprintln(stderr, "Examples:")
+		fmt.Fprintln(stderr, "  flan verify --input reports/scan-20260406-120000.json")
+		fmt.Fprintln(stderr, "  flan --jsonl -t scanme.nmap.org | flan verify --input -")
+	}
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if len(fs.Args()) > 1 {
+		return fmt.Errorf("verify accepts at most one positional input path")
+	}
+
+	path := *inputPath
+	if path == "" {
+		path = *inputShort
+	}
+	if path == "" && len(fs.Args()) == 1 {
+		path = fs.Args()[0]
+	}
+	if path == "" {
+		if stdinHasDataFunc() {
+			path = "-"
+		} else {
+			return errors.New("verify requires --input path or piped scan results")
+		}
+	}
+
+	results, err := output.ReadScanResults(path)
+	if err != nil {
+		return err
+	}
+
+	summary := verifySummary{
+		InputPath: path,
+		Results:   len(results),
+		Assets:    len(results),
+	}
+	for _, result := range results {
+		ctx := verifymodel.SelectorContextFromScanResult(result)
+		summary.Surfaces += len(ctx.Surfaces)
+	}
+
+	if *jsonFlag {
+		enc := json.NewEncoder(stdout)
+		enc.SetIndent("", "  ")
+		return enc.Encode(summary)
+	}
+
+	fmt.Fprintf(stdout, "Loaded %d scan results for verification\n", summary.Results)
+	fmt.Fprintf(stdout, "Assets: %d\n", summary.Assets)
+	fmt.Fprintf(stdout, "Surfaces: %d\n", summary.Surfaces)
+	return nil
+}
+
+func stdinHasData() bool {
+	fi, err := os.Stdin.Stat()
+	if err != nil {
+		return false
+	}
+	return fi.Mode()&os.ModeCharDevice == 0
+}

--- a/cmd/flan/verify_test.go
+++ b/cmd/flan/verify_test.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestDispatchSubcommandVerify(t *testing.T) {
+	path := writeVerifyInput(t, `[{"host":"1.1.1.1","port":80,"protocol":"tcp","service":"http"}]`)
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	handled, err := dispatchSubcommand([]string{"verify", "--input", path}, &stdout, &stderr)
+	if err != nil {
+		t.Fatalf("dispatchSubcommand returned error: %v", err)
+	}
+	if !handled {
+		t.Fatal("expected verify subcommand to be handled")
+	}
+	if got := stdout.String(); !strings.Contains(got, "Loaded 1 scan results for verification") {
+		t.Fatalf("unexpected stdout: %q", got)
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("expected empty stderr, got %q", stderr.String())
+	}
+}
+
+func TestRunVerifyCommandJSONSummary(t *testing.T) {
+	path := writeVerifyInput(t, `[{"host":"1.1.1.1","port":80,"protocol":"tcp","service":"http","endpoints":[{"path":"/login?redirect=/","status_code":302}]}]`)
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	if err := runVerifyCommand([]string{"--input", path, "--json"}, &stdout, &stderr); err != nil {
+		t.Fatalf("runVerifyCommand returned error: %v", err)
+	}
+	got := stdout.String()
+	if !strings.Contains(got, `"results": 1`) {
+		t.Fatalf("expected json summary to include results count, got %q", got)
+	}
+	if !strings.Contains(got, `"surfaces": 1`) {
+		t.Fatalf("expected json summary to include surface count, got %q", got)
+	}
+}
+
+func TestRunVerifyCommandRequiresInputWithoutPipe(t *testing.T) {
+	old := stdinHasDataFunc
+	stdinHasDataFunc = func() bool { return false }
+	defer func() { stdinHasDataFunc = old }()
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	err := runVerifyCommand(nil, &stdout, &stderr)
+	if err == nil {
+		t.Fatal("expected missing input error")
+	}
+	if !strings.Contains(err.Error(), "requires --input path or piped scan results") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func writeVerifyInput(t *testing.T, content string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "scan.json")
+	if err := os.WriteFile(path, []byte(content), 0600); err != nil {
+		t.Fatalf("write verify input: %v", err)
+	}
+	return path
+}

--- a/internal/output/scan_results.go
+++ b/internal/output/scan_results.go
@@ -1,0 +1,65 @@
+package output
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/therandomsecurityguy/flan-go-scan/internal/scanner"
+)
+
+func ReadScanResults(path string) ([]scanner.ScanResult, error) {
+	reader, closeFn, err := openScanResults(path)
+	if err != nil {
+		return nil, err
+	}
+	defer closeFn()
+
+	data, err := io.ReadAll(reader)
+	if err != nil {
+		return nil, fmt.Errorf("read scan results: %w", err)
+	}
+
+	trimmed := bytes.TrimSpace(data)
+	if len(trimmed) == 0 {
+		return nil, fmt.Errorf("read scan results: empty input")
+	}
+
+	if trimmed[0] == '[' {
+		var results []scanner.ScanResult
+		if err := json.Unmarshal(trimmed, &results); err != nil {
+			return nil, fmt.Errorf("parse scan results json: %w", err)
+		}
+		return results, nil
+	}
+
+	dec := json.NewDecoder(bytes.NewReader(trimmed))
+	results := make([]scanner.ScanResult, 0, 16)
+	for {
+		var result scanner.ScanResult
+		if err := dec.Decode(&result); err != nil {
+			if err == io.EOF {
+				break
+			}
+			return nil, fmt.Errorf("parse scan results stream: %w", err)
+		}
+		results = append(results, result)
+	}
+	if len(results) == 0 {
+		return nil, fmt.Errorf("parse scan results stream: no results decoded")
+	}
+	return results, nil
+}
+
+func openScanResults(path string) (io.Reader, func() error, error) {
+	if path == "-" {
+		return os.Stdin, func() error { return nil }, nil
+	}
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, nil, fmt.Errorf("open scan results: %w", err)
+	}
+	return file, file.Close, nil
+}

--- a/internal/output/scan_results_test.go
+++ b/internal/output/scan_results_test.go
@@ -1,0 +1,59 @@
+package output
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestReadScanResultsJSON(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "scan.json")
+	if err := os.WriteFile(path, []byte(`[
+  {"host":"1.1.1.1","port":80,"protocol":"tcp","service":"http"},
+  {"host":"2.2.2.2","port":443,"protocol":"tcp","service":"https"}
+]`), 0600); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+
+	results, err := ReadScanResults(path)
+	if err != nil {
+		t.Fatalf("ReadScanResults returned error: %v", err)
+	}
+	if got, want := len(results), 2; got != want {
+		t.Fatalf("len(results) = %d, want %d", got, want)
+	}
+	if got, want := results[1].Host, "2.2.2.2"; got != want {
+		t.Fatalf("results[1].Host = %q, want %q", got, want)
+	}
+}
+
+func TestReadScanResultsJSONL(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "scan.jsonl")
+	if err := os.WriteFile(path, []byte(`{"host":"1.1.1.1","port":80,"protocol":"tcp","service":"http"}
+{"host":"2.2.2.2","port":443,"protocol":"tcp","service":"https"}
+`), 0600); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+
+	results, err := ReadScanResults(path)
+	if err != nil {
+		t.Fatalf("ReadScanResults returned error: %v", err)
+	}
+	if got, want := len(results), 2; got != want {
+		t.Fatalf("len(results) = %d, want %d", got, want)
+	}
+	if got, want := results[0].Service, "http"; got != want {
+		t.Fatalf("results[0].Service = %q, want %q", got, want)
+	}
+}
+
+func TestReadScanResultsEmptyInput(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "empty.json")
+	if err := os.WriteFile(path, nil, 0600); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+
+	if _, err := ReadScanResults(path); err == nil {
+		t.Fatal("expected error for empty input")
+	}
+}


### PR DESCRIPTION

- Added flan verify command with dry-run verification summary output
- Added JSON and JSONL scan artifact loading for verification input
- Reused existing scan-result and verification models instead of creating a parallel command path