### PR TITLE
Add fallback and inferred verification surfaces

### DIFF
--- a/internal/verify/models.go
+++ b/internal/verify/models.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"net/url"
 	"slices"
-	"strconv"
 	"strings"
 
 	"github.com/therandomsecurityguy/flan-go-scan/internal/scanner"
@@ -34,6 +33,7 @@ type Surface struct {
 	Path        string   `json:"path"`
 	MethodHints []string `json:"method_hints,omitempty"`
 	Params      []string `json:"params,omitempty"`
+	AuthHints   []string `json:"auth_hints,omitempty"`
 	StatusCode  int      `json:"status_code,omitempty"`
 	ContentType string   `json:"content_type,omitempty"`
 	Title       string   `json:"title,omitempty"`
@@ -46,6 +46,7 @@ type SelectorContext struct {
 	ProductHints    []string                `json:"product_hints,omitempty"`
 	AppHints        []string                `json:"app_hints,omitempty"`
 	PathHints       []string                `json:"path_hints,omitempty"`
+	AuthHints       []string                `json:"auth_hints,omitempty"`
 	TitleHints      []string                `json:"title_hints,omitempty"`
 	HeaderHints     []string                `json:"header_hints,omitempty"`
 	Vulnerabilities []string                `json:"vulnerabilities,omitempty"`
@@ -119,35 +120,32 @@ func AssetFromScanResult(result scanner.ScanResult) Asset {
 }
 
 func SurfacesFromScanResult(result scanner.ScanResult) []Surface {
-	if len(result.Endpoints) == 0 {
-		return nil
-	}
-
-	seen := make(map[string]struct{}, len(result.Endpoints))
-	surfaces := make([]Surface, 0, len(result.Endpoints))
-	for _, endpoint := range result.Endpoints {
-		surface := SurfaceFromCrawlResult(endpoint)
-		key := strings.Join([]string{
-			surface.Source,
-			surface.Path,
-			strings.Join(surface.Params, ","),
-			strconv.Itoa(surface.StatusCode),
-			surface.ContentType,
-			surface.Title,
-			surface.RedirectTo,
-		}, "\x00")
+	seen := make(map[string]struct{}, len(result.Endpoints)+4)
+	surfaces := make([]Surface, 0, len(result.Endpoints)+4)
+	addSurface := func(surface Surface) {
+		key := surfaceKey(surface)
 		if _, ok := seen[key]; ok {
-			continue
+			return
 		}
 		seen[key] = struct{}{}
 		surfaces = append(surfaces, surface)
 	}
 
+	for _, endpoint := range result.Endpoints {
+		addSurface(SurfaceFromCrawlResult(endpoint))
+	}
+	for _, surface := range inferredSurfacesFromScanResult(result, surfaces) {
+		addSurface(surface)
+	}
+
+	if len(surfaces) == 0 {
+		return nil
+	}
 	return surfaces
 }
 
 func SurfaceFromCrawlResult(result scanner.CrawlResult) Surface {
-	return Surface{
+	surface := Surface{
 		Source:      "crawl",
 		Path:        normalizeSurfacePath(result.Path),
 		MethodHints: []string{"GET"},
@@ -157,6 +155,8 @@ func SurfaceFromCrawlResult(result scanner.CrawlResult) Surface {
 		Title:       strings.TrimSpace(result.Title),
 		RedirectTo:  strings.TrimSpace(result.RedirectTo),
 	}
+	surface.AuthHints = authHintsForSurface(surface)
+	return surface
 }
 
 func SelectorContextFromScanResult(result scanner.ScanResult) SelectorContext {
@@ -169,6 +169,7 @@ func SelectorContextFromScanResult(result scanner.ScanResult) SelectorContext {
 		ProductHints:    productHints(asset.Products),
 		AppHints:        appHints(result.App),
 		PathHints:       surfacePaths(surfaces),
+		AuthHints:       surfaceAuthHints(surfaces),
 		TitleHints:      surfaceTitles(surfaces),
 		HeaderHints:     headerHints(result.SecurityHeaders),
 		Vulnerabilities: dedupeStrings(result.Vulnerabilities),
@@ -284,11 +285,23 @@ func surfaceTitles(surfaces []Surface) []string {
 func headerHints(findings []scanner.HeaderFinding) []string {
 	hints := make([]string, 0, len(findings))
 	for _, finding := range findings {
+		detail := strings.ToLower(strings.TrimSpace(finding.Detail))
+		if strings.HasPrefix(detail, "missing ") {
+			continue
+		}
 		header := strings.ToLower(strings.TrimSpace(finding.Header))
-		if header == "" {
+		if header == "" || header == "http probe" {
 			continue
 		}
 		hints = append(hints, header)
+	}
+	return dedupeStrings(hints)
+}
+
+func surfaceAuthHints(surfaces []Surface) []string {
+	hints := make([]string, 0, len(surfaces))
+	for _, surface := range surfaces {
+		hints = append(hints, surface.AuthHints...)
 	}
 	return dedupeStrings(hints)
 }

--- a/internal/verify/models_test.go
+++ b/internal/verify/models_test.go
@@ -99,15 +99,81 @@ func TestSelectorContextFromScanResultBuildsHints(t *testing.T) {
 
 	ctx := SelectorContextFromScanResult(result)
 
-	if got, want := len(ctx.Surfaces), 2; got != want {
+	if got, want := len(ctx.Surfaces), 3; got != want {
 		t.Fatalf("len(ctx.Surfaces) = %d, want %d", got, want)
 	}
 	assertStrings(t, "ProductHints", ctx.ProductHints, []string{"grafana"})
 	assertStrings(t, "AppHints", ctx.AppHints, []string{"grafana", "nginx/1.27.0"})
-	assertStrings(t, "PathHints", ctx.PathHints, []string{"/api/health", "/login?redirect=/"})
+	assertStrings(t, "AuthHints", ctx.AuthHints, []string{"login"})
+	assertStrings(t, "PathHints", ctx.PathHints, []string{"/", "/api/health", "/login?redirect=/"})
 	assertStrings(t, "TitleHints", ctx.TitleHints, []string{"health", "login"})
 	assertStrings(t, "HeaderHints", ctx.HeaderHints, []string{"content-security-policy", "server"})
 	assertStrings(t, "Vulnerabilities", ctx.Vulnerabilities, []string{"CVE-2025-1234", "CWE-601"})
+}
+
+func TestSurfacesFromScanResultAddsFallbackRootForHTTPService(t *testing.T) {
+	result := scanner.ScanResult{
+		Host:     "192.0.2.20",
+		Port:     443,
+		Protocol: "tcp",
+		Service:  "https",
+		TLS:      &scanner.TLSResult{Version: "TLS 1.3"},
+	}
+
+	surfaces := SurfacesFromScanResult(result)
+
+	if got, want := len(surfaces), 1; got != want {
+		t.Fatalf("len(surfaces) = %d, want %d", got, want)
+	}
+	if got, want := surfaces[0].Source, "service"; got != want {
+		t.Fatalf("surfaces[0].Source = %q, want %q", got, want)
+	}
+	if got, want := surfaces[0].Path, "/"; got != want {
+		t.Fatalf("surfaces[0].Path = %q, want %q", got, want)
+	}
+}
+
+func TestSurfacesFromScanResultAddsInferredProductPaths(t *testing.T) {
+	result := scanner.ScanResult{
+		Host:     "192.0.2.21",
+		Port:     8200,
+		Protocol: "tcp",
+		Service:  "http",
+		Products: []scanner.ProductFingerprint{
+			{Name: "HashiCorp Vault", Confidence: "high"},
+		},
+	}
+
+	surfaces := SurfacesFromScanResult(result)
+
+	assertSurfacePaths(t, surfaces, []string{"/", "/v1/sys/health"})
+}
+
+func TestSurfacesFromScanResultAddsKubernetesPaths(t *testing.T) {
+	result := scanner.ScanResult{
+		Host:     "192.0.2.22",
+		Port:     6443,
+		Protocol: "tcp",
+		Service:  "https",
+		TLS:      &scanner.TLSResult{Version: "TLS 1.3"},
+		Kubernetes: []scanner.KubernetesOrigin{{
+			Cluster: "prod",
+		}},
+	}
+
+	surfaces := SurfacesFromScanResult(result)
+
+	assertSurfacePaths(t, surfaces, []string{"/", "/api", "/apis", "/version"})
+}
+
+func TestHeaderHintsSkipsMissingHeaders(t *testing.T) {
+	hints := headerHints([]scanner.HeaderFinding{
+		{Header: "Content-Security-Policy", Detail: "missing CSP; XSS and injection attacks not mitigated"},
+		{Header: "Server", Detail: "version disclosed: nginx/1.27.0"},
+		{Header: "HTTP Probe", Detail: "header inspection failed"},
+	})
+
+	assertStrings(t, "HeaderHints", hints, []string{"server"})
 }
 
 func assertStrings(t *testing.T, name string, got, want []string) {
@@ -120,4 +186,13 @@ func assertStrings(t *testing.T, name string, got, want []string) {
 			t.Fatalf("%s[%d] = %q, want %q", name, i, got[i], want[i])
 		}
 	}
+}
+
+func assertSurfacePaths(t *testing.T, surfaces []Surface, want []string) {
+	t.Helper()
+	got := make([]string, 0, len(surfaces))
+	for _, surface := range surfaces {
+		got = append(got, surface.Path)
+	}
+	assertStrings(t, "SurfacePaths", got, want)
 }

--- a/internal/verify/surfaces.go
+++ b/internal/verify/surfaces.go
@@ -1,0 +1,128 @@
+package verify
+
+import (
+	"strconv"
+	"strings"
+
+	"github.com/therandomsecurityguy/flan-go-scan/internal/scanner"
+)
+
+var inferredProductSurfacePaths = map[string][]string{
+	"graphql":          {"/graphql"},
+	"kubernetes":       {"/version", "/api", "/apis"},
+	"hashicorp vault":  {"/v1/sys/health"},
+	"vault":            {"/v1/sys/health"},
+	"hashicorp consul": {"/v1/agent/self"},
+	"consul":           {"/v1/agent/self"},
+}
+
+func inferredSurfacesFromScanResult(result scanner.ScanResult, existing []Surface) []Surface {
+	if !scanner.IsHTTPService(result.Service, result.Port, result.TLS != nil) {
+		return nil
+	}
+
+	pathsSeen := make(map[string]struct{}, len(existing))
+	for _, surface := range existing {
+		pathsSeen[normalizeSurfacePath(surface.Path)] = struct{}{}
+	}
+
+	inferred := make([]Surface, 0, 4)
+	if _, ok := pathsSeen["/"]; !ok {
+		inferred = append(inferred, newSurface("service", "/"))
+		pathsSeen["/"] = struct{}{}
+	}
+
+	for _, path := range inferredProductPaths(result) {
+		normalized := normalizeSurfacePath(path)
+		if _, ok := pathsSeen[normalized]; ok {
+			continue
+		}
+		inferred = append(inferred, newSurface("inferred", normalized))
+		pathsSeen[normalized] = struct{}{}
+	}
+
+	return inferred
+}
+
+func inferredProductPaths(result scanner.ScanResult) []string {
+	keys := make([]string, 0, len(result.Products)+len(result.Kubernetes)+1)
+	for _, product := range result.Products {
+		if product.Name == "" {
+			continue
+		}
+		keys = append(keys, strings.ToLower(strings.TrimSpace(product.Name)))
+	}
+	if result.App != nil {
+		for _, product := range result.App.Products {
+			if product.Name == "" {
+				continue
+			}
+			keys = append(keys, strings.ToLower(strings.TrimSpace(product.Name)))
+		}
+	}
+	if len(result.Kubernetes) > 0 {
+		keys = append(keys, "kubernetes")
+	}
+
+	paths := make([]string, 0, 4)
+	for _, key := range dedupeStrings(keys) {
+		paths = append(paths, inferredProductSurfacePaths[key]...)
+	}
+	return dedupeStrings(paths)
+}
+
+func newSurface(source, path string) Surface {
+	surface := Surface{
+		Source:      source,
+		Path:        normalizeSurfacePath(path),
+		MethodHints: []string{"GET"},
+		Params:      pathParamNames(path),
+	}
+	surface.AuthHints = authHintsForSurface(surface)
+	return surface
+}
+
+func authHintsForSurface(surface Surface) []string {
+	textParts := []string{
+		strings.ToLower(surface.Path),
+		strings.ToLower(surface.Title),
+		strings.ToLower(surface.RedirectTo),
+	}
+	textParts = append(textParts, surface.Params...)
+	text := strings.Join(textParts, " ")
+
+	hints := make([]string, 0, 3)
+	if containsAnyHint(text, []string{"login", "signin", "sign-in", "auth", "logout"}) {
+		hints = append(hints, "login")
+	}
+	if containsAnyHint(text, []string{"admin", "dashboard", "console", "backoffice"}) {
+		hints = append(hints, "admin")
+	}
+	if containsAnyHint(text, []string{"redirect_uri", "client_id", "response_type", "scope", "state", "oauth"}) {
+		hints = append(hints, "oauth")
+	}
+	return dedupeStrings(hints)
+}
+
+func containsAnyHint(text string, patterns []string) bool {
+	for _, pattern := range patterns {
+		if strings.Contains(text, pattern) {
+			return true
+		}
+	}
+	return false
+}
+
+func surfaceKey(surface Surface) string {
+	return strings.Join([]string{
+		surface.Source,
+		normalizeSurfacePath(surface.Path),
+		strings.Join(surface.MethodHints, ","),
+		strings.Join(surface.Params, ","),
+		strings.Join(surface.AuthHints, ","),
+		strconv.Itoa(surface.StatusCode),
+		surface.ContentType,
+		surface.Title,
+		surface.RedirectTo,
+	}, "\x00")
+}


### PR DESCRIPTION

- Added fallback HTTP root surfaces so verification has usable targets even when crawl is disabled
- Infer high-signal product surfaces for Kubernetes, Vault, Consul, and GraphQL from scan fingerprints
- Added auth hints to normalized surfaces and selector context for later family selection
- Filtered misleading header hints so missing-header findings do not become positive verification signals