### PR TITLE
Add source-driven candidate selection and explainable verify output

### DIFF
--- a/cmd/flan/verify.go
+++ b/cmd/flan/verify.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strings"
 	"text/tabwriter"
 
 	"github.com/therandomsecurityguy/flan-go-scan/internal/output"
@@ -16,10 +17,22 @@ import (
 var stdinHasDataFunc = stdinHasData
 
 type verifySummary struct {
-	InputPath string `json:"input_path"`
-	Results   int    `json:"results"`
-	Assets    int    `json:"assets"`
-	Surfaces  int    `json:"surfaces"`
+	InputPath        string                   `json:"input_path"`
+	Results          int                      `json:"results"`
+	Assets           int                      `json:"assets"`
+	Surfaces         int                      `json:"surfaces"`
+	Candidates       int                      `json:"candidates"`
+	CandidateDetails []verifyCandidateSummary `json:"candidate_details,omitempty"`
+}
+
+type verifyCandidateSummary struct {
+	CheckID string   `json:"check_id"`
+	Family  string   `json:"family"`
+	Adapter string   `json:"adapter,omitempty"`
+	Host    string   `json:"host"`
+	Port    int      `json:"port"`
+	Path    string   `json:"path,omitempty"`
+	Reasons []string `json:"reasons,omitempty"`
 }
 
 func dispatchSubcommand(args []string, stdout, stderr io.Writer) (bool, error) {
@@ -88,6 +101,22 @@ func runVerifyCommand(args []string, stdout, stderr io.Writer) error {
 	for _, result := range results {
 		ctx := verifymodel.SelectorContextFromScanResult(result)
 		summary.Surfaces += len(ctx.Surfaces)
+		candidates := verifymodel.SelectCandidateChecks(ctx)
+		summary.Candidates += len(candidates)
+		for _, candidate := range candidates {
+			detail := verifyCandidateSummary{
+				CheckID: candidate.CheckID,
+				Family:  candidate.Family,
+				Adapter: candidate.Adapter,
+				Host:    candidate.Asset.Host,
+				Port:    candidate.Asset.Port,
+				Reasons: candidate.Reasons,
+			}
+			if candidate.Surface != nil {
+				detail.Path = candidate.Surface.Path
+			}
+			summary.CandidateDetails = append(summary.CandidateDetails, detail)
+		}
 	}
 
 	if *jsonFlag {
@@ -99,6 +128,17 @@ func runVerifyCommand(args []string, stdout, stderr io.Writer) error {
 	fmt.Fprintf(stdout, "Loaded %d scan results for verification\n", summary.Results)
 	fmt.Fprintf(stdout, "Assets: %d\n", summary.Assets)
 	fmt.Fprintf(stdout, "Surfaces: %d\n", summary.Surfaces)
+	fmt.Fprintf(stdout, "Candidates: %d\n", summary.Candidates)
+	for _, candidate := range summary.CandidateDetails {
+		if candidate.Path != "" {
+			fmt.Fprintf(stdout, "- %s (%s) %s:%d%s\n", candidate.CheckID, candidate.Family, candidate.Host, candidate.Port, candidate.Path)
+		} else {
+			fmt.Fprintf(stdout, "- %s (%s) %s:%d\n", candidate.CheckID, candidate.Family, candidate.Host, candidate.Port)
+		}
+		if len(candidate.Reasons) > 0 {
+			fmt.Fprintf(stdout, "  reasons: %s\n", strings.Join(candidate.Reasons, ", "))
+		}
+	}
 	return nil
 }
 

--- a/cmd/flan/verify_test.go
+++ b/cmd/flan/verify_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
@@ -37,11 +38,30 @@ func TestRunVerifyCommandJSONSummary(t *testing.T) {
 		t.Fatalf("runVerifyCommand returned error: %v", err)
 	}
 	got := stdout.String()
-	if !strings.Contains(got, `"results": 1`) {
-		t.Fatalf("expected json summary to include results count, got %q", got)
+	var summary verifySummary
+	if err := json.Unmarshal([]byte(got), &summary); err != nil {
+		t.Fatalf("unmarshal verify summary: %v; body=%q", err, got)
 	}
-	if !strings.Contains(got, `"surfaces": 1`) {
-		t.Fatalf("expected json summary to include surface count, got %q", got)
+	if got, want := summary.Results, 1; got != want {
+		t.Fatalf("summary.Results = %d, want %d", got, want)
+	}
+	if got, want := summary.Surfaces, 2; got != want {
+		t.Fatalf("summary.Surfaces = %d, want %d", got, want)
+	}
+	if got, want := summary.Candidates, 1; got != want {
+		t.Fatalf("summary.Candidates = %d, want %d", got, want)
+	}
+	if got, want := len(summary.CandidateDetails), 1; got != want {
+		t.Fatalf("len(summary.CandidateDetails) = %d, want %d", got, want)
+	}
+	if got, want := summary.CandidateDetails[0].CheckID, "generic-web/open-redirect"; got != want {
+		t.Fatalf("summary.CandidateDetails[0].CheckID = %q, want %q", got, want)
+	}
+	if got, want := summary.CandidateDetails[0].Path, "/login?redirect=/"; got != want {
+		t.Fatalf("summary.CandidateDetails[0].Path = %q, want %q", got, want)
+	}
+	if len(summary.CandidateDetails[0].Reasons) == 0 {
+		t.Fatal("expected candidate reasons in summary")
 	}
 }
 
@@ -58,6 +78,26 @@ func TestRunVerifyCommandRequiresInputWithoutPipe(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "requires --input path or piped scan results") {
 		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestRunVerifyCommandPlainSummaryIncludesCandidateReasons(t *testing.T) {
+	path := writeVerifyInput(t, `[{"host":"1.1.1.1","port":80,"protocol":"tcp","service":"http","endpoints":[{"path":"/login?redirect=/","status_code":302}]}]`)
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	if err := runVerifyCommand([]string{"--input", path}, &stdout, &stderr); err != nil {
+		t.Fatalf("runVerifyCommand returned error: %v", err)
+	}
+	got := stdout.String()
+	if !strings.Contains(got, "Candidates: 1") {
+		t.Fatalf("expected candidate count in output, got %q", got)
+	}
+	if !strings.Contains(got, "generic-web/open-redirect") {
+		t.Fatalf("expected candidate detail in output, got %q", got)
+	}
+	if !strings.Contains(got, "reasons:") {
+		t.Fatalf("expected candidate reasons in output, got %q", got)
 	}
 }
 

--- a/internal/verify/models.go
+++ b/internal/verify/models.go
@@ -166,7 +166,7 @@ func SelectorContextFromScanResult(result scanner.ScanResult) SelectorContext {
 	return SelectorContext{
 		Asset:           asset,
 		Surfaces:        surfaces,
-		ProductHints:    productHints(asset.Products),
+		ProductHints:    selectorProductHints(asset),
 		AppHints:        appHints(result.App),
 		PathHints:       surfacePaths(surfaces),
 		AuthHints:       surfaceAuthHints(surfaces),
@@ -175,6 +175,14 @@ func SelectorContextFromScanResult(result scanner.ScanResult) SelectorContext {
 		Vulnerabilities: dedupeStrings(result.Vulnerabilities),
 		SecurityHeaders: slices.Clone(result.SecurityHeaders),
 	}
+}
+
+func selectorProductHints(asset Asset) []string {
+	hints := productHints(asset.Products)
+	if len(asset.Kubernetes) > 0 {
+		hints = append(hints, "kubernetes")
+	}
+	return dedupeStrings(hints)
 }
 
 func normalizeSurfacePath(raw string) string {

--- a/internal/verify/models_test.go
+++ b/internal/verify/models_test.go
@@ -166,6 +166,23 @@ func TestSurfacesFromScanResultAddsKubernetesPaths(t *testing.T) {
 	assertSurfacePaths(t, surfaces, []string{"/", "/api", "/apis", "/version"})
 }
 
+func TestSelectorContextFromScanResultAddsKubernetesProductHint(t *testing.T) {
+	result := scanner.ScanResult{
+		Host:     "192.0.2.23",
+		Port:     6443,
+		Protocol: "tcp",
+		Service:  "https",
+		TLS:      &scanner.TLSResult{Version: "TLS 1.3"},
+		Kubernetes: []scanner.KubernetesOrigin{{
+			Cluster: "prod",
+		}},
+	}
+
+	ctx := SelectorContextFromScanResult(result)
+
+	assertStrings(t, "ProductHints", ctx.ProductHints, []string{"kubernetes"})
+}
+
 func TestHeaderHintsSkipsMissingHeaders(t *testing.T) {
 	hints := headerHints([]scanner.HeaderFinding{
 		{Header: "Content-Security-Policy", Detail: "missing CSP; XSS and injection attacks not mitigated"},

--- a/internal/verify/selectors.go
+++ b/internal/verify/selectors.go
@@ -1,0 +1,201 @@
+package verify
+
+import (
+	"fmt"
+	"slices"
+	"strconv"
+	"strings"
+)
+
+var redirectParams = map[string]struct{}{
+	"callback":     {},
+	"continue":     {},
+	"dest":         {},
+	"destination":  {},
+	"next":         {},
+	"redirect":     {},
+	"redirect_uri": {},
+	"return":       {},
+	"returnto":     {},
+	"target":       {},
+	"url":          {},
+}
+
+var fileParams = map[string]struct{}{
+	"dir":       {},
+	"directory": {},
+	"doc":       {},
+	"document":  {},
+	"download":  {},
+	"file":      {},
+	"filename":  {},
+	"filepath":  {},
+	"folder":    {},
+	"page":      {},
+	"path":      {},
+	"template":  {},
+	"view":      {},
+}
+
+func SelectCandidateChecks(ctx SelectorContext) []CandidateCheck {
+	if len(ctx.Surfaces) == 0 {
+		return nil
+	}
+
+	candidates := make([]CandidateCheck, 0, len(ctx.Surfaces))
+	seen := make(map[string]struct{}, len(ctx.Surfaces)*2)
+	addCandidate := func(candidate CandidateCheck) {
+		key := candidateKey(candidate)
+		if _, ok := seen[key]; ok {
+			return
+		}
+		seen[key] = struct{}{}
+		candidate.Reasons = dedupeStrings(candidate.Reasons)
+		candidates = append(candidates, candidate)
+	}
+
+	for i := range ctx.Surfaces {
+		surface := &ctx.Surfaces[i]
+		if candidate, ok := selectOpenRedirectCandidate(ctx, surface); ok {
+			addCandidate(candidate)
+		}
+		if candidate, ok := selectTraversalCandidate(ctx, surface); ok {
+			addCandidate(candidate)
+		}
+		if candidate, ok := selectUnauthAPICandidate(ctx, surface); ok {
+			addCandidate(candidate)
+		}
+	}
+
+	return candidates
+}
+
+func selectOpenRedirectCandidate(ctx SelectorContext, surface *Surface) (CandidateCheck, bool) {
+	reasons := make([]string, 0, 4)
+	for _, param := range surface.Params {
+		if _, ok := redirectParams[param]; ok {
+			reasons = append(reasons, "redirect parameter: "+param)
+		}
+	}
+	if surface.StatusCode >= 300 && surface.StatusCode < 400 {
+		reasons = append(reasons, "redirect status: "+strconv.Itoa(surface.StatusCode))
+	}
+	if surface.RedirectTo != "" {
+		reasons = append(reasons, "redirect target observed")
+	}
+	if pathHasAny(surface.Path, []string{"/redirect", "/continue", "/callback", "/return", "/logout", "/out", "/jump"}) {
+		reasons = append(reasons, "redirect path anchor")
+	}
+	if slices.Contains(surface.AuthHints, "oauth") {
+		reasons = append(reasons, "oauth auth hint")
+	}
+	if len(reasons) == 0 {
+		return CandidateCheck{}, false
+	}
+
+	return CandidateCheck{
+		CheckID: "generic-web/open-redirect",
+		Family:  "open-redirect",
+		Adapter: "generic-web",
+		Asset:   ctx.Asset,
+		Surface: surface,
+		Reasons: reasons,
+	}, true
+}
+
+func selectTraversalCandidate(ctx SelectorContext, surface *Surface) (CandidateCheck, bool) {
+	reasons := make([]string, 0, 4)
+	adapter := "generic-web"
+
+	for _, param := range surface.Params {
+		if _, ok := fileParams[param]; ok {
+			reasons = append(reasons, "file parameter: "+param)
+		}
+	}
+	if pathHasAny(surface.Path, []string{"/download", "/export", "/file", "/files", "/render", "/template", "/view"}) {
+		reasons = append(reasons, "file path anchor")
+	}
+	if hasHint(ctx.ProductHints, "grafana") && pathHasAny(surface.Path, []string{"/public/", "/public/plugins/"}) {
+		adapter = "grafana"
+		reasons = append(reasons, "product hint: grafana")
+		reasons = append(reasons, "grafana public path anchor")
+	}
+	if len(reasons) == 0 {
+		return CandidateCheck{}, false
+	}
+
+	return CandidateCheck{
+		CheckID: adapter + "/traversal-read",
+		Family:  "traversal-read",
+		Adapter: adapter,
+		Asset:   ctx.Asset,
+		Surface: surface,
+		Reasons: reasons,
+	}, true
+}
+
+func selectUnauthAPICandidate(ctx SelectorContext, surface *Surface) (CandidateCheck, bool) {
+	type platformRule struct {
+		product string
+		adapter string
+		paths   []string
+	}
+
+	rules := []platformRule{
+		{product: "kubernetes", adapter: "kubernetes", paths: []string{"/api", "/apis", "/version"}},
+		{product: "hashicorp vault", adapter: "vault", paths: []string{"/v1/"}},
+		{product: "vault", adapter: "vault", paths: []string{"/v1/"}},
+		{product: "hashicorp consul", adapter: "consul", paths: []string{"/v1/"}},
+		{product: "consul", adapter: "consul", paths: []string{"/v1/"}},
+	}
+
+	for _, rule := range rules {
+		if !hasHint(ctx.ProductHints, rule.product) {
+			continue
+		}
+		if !pathHasAny(surface.Path, rule.paths) {
+			continue
+		}
+		return CandidateCheck{
+			CheckID: rule.adapter + "/unauth-api",
+			Family:  "unauth-api",
+			Adapter: rule.adapter,
+			Asset:   ctx.Asset,
+			Surface: surface,
+			Reasons: []string{
+				"product hint: " + rule.product,
+				"path anchor: " + normalizeSurfacePath(surface.Path),
+			},
+		}, true
+	}
+
+	return CandidateCheck{}, false
+}
+
+func hasHint(values []string, want string) bool {
+	want = strings.ToLower(strings.TrimSpace(want))
+	for _, value := range values {
+		if strings.ToLower(strings.TrimSpace(value)) == want {
+			return true
+		}
+	}
+	return false
+}
+
+func pathHasAny(path string, patterns []string) bool {
+	normalized := strings.ToLower(normalizeSurfacePath(path))
+	for _, pattern := range patterns {
+		if strings.Contains(normalized, strings.ToLower(pattern)) {
+			return true
+		}
+	}
+	return false
+}
+
+func candidateKey(candidate CandidateCheck) string {
+	path := ""
+	if candidate.Surface != nil {
+		path = normalizeSurfacePath(candidate.Surface.Path)
+	}
+	return fmt.Sprintf("%s\x00%s\x00%d\x00%s\x00%s", candidate.Family, candidate.Adapter, candidate.Asset.Port, candidate.Asset.Host, path)
+}

--- a/internal/verify/selectors_test.go
+++ b/internal/verify/selectors_test.go
@@ -1,0 +1,86 @@
+package verify
+
+import "testing"
+
+func TestSelectCandidateChecksOpenRedirect(t *testing.T) {
+	ctx := SelectorContext{
+		Asset: Asset{Host: "192.0.2.10", Port: 443, Service: "https"},
+		Surfaces: []Surface{{
+			Source:      "crawl",
+			Path:        "/login?redirect=/",
+			Params:      []string{"redirect"},
+			StatusCode:  302,
+			RedirectTo:  "https://example.com",
+			MethodHints: []string{"GET"},
+		}},
+	}
+
+	candidates := SelectCandidateChecks(ctx)
+
+	if got, want := len(candidates), 1; got != want {
+		t.Fatalf("len(candidates) = %d, want %d", got, want)
+	}
+	if got, want := candidates[0].Family, "open-redirect"; got != want {
+		t.Fatalf("candidates[0].Family = %q, want %q", got, want)
+	}
+	if got, want := candidates[0].Adapter, "generic-web"; got != want {
+		t.Fatalf("candidates[0].Adapter = %q, want %q", got, want)
+	}
+	assertStrings(t, "Reasons", candidates[0].Reasons, []string{
+		"redirect parameter: redirect",
+		"redirect status: 302",
+		"redirect target observed",
+	})
+}
+
+func TestSelectCandidateChecksGrafanaTraversal(t *testing.T) {
+	ctx := SelectorContext{
+		Asset:        Asset{Host: "192.0.2.11", Port: 3000, Service: "http"},
+		ProductHints: []string{"grafana"},
+		Surfaces: []Surface{{
+			Source:      "crawl",
+			Path:        "/public/plugins/alertlist/",
+			MethodHints: []string{"GET"},
+		}},
+	}
+
+	candidates := SelectCandidateChecks(ctx)
+
+	if got, want := len(candidates), 1; got != want {
+		t.Fatalf("len(candidates) = %d, want %d", got, want)
+	}
+	if got, want := candidates[0].Family, "traversal-read"; got != want {
+		t.Fatalf("candidates[0].Family = %q, want %q", got, want)
+	}
+	if got, want := candidates[0].Adapter, "grafana"; got != want {
+		t.Fatalf("candidates[0].Adapter = %q, want %q", got, want)
+	}
+}
+
+func TestSelectCandidateChecksKubernetesUnauthAPI(t *testing.T) {
+	ctx := SelectorContext{
+		Asset:        Asset{Host: "192.0.2.12", Port: 6443, Service: "https"},
+		ProductHints: []string{"kubernetes"},
+		Surfaces: []Surface{{
+			Source:      "inferred",
+			Path:        "/api",
+			MethodHints: []string{"GET"},
+		}},
+	}
+
+	candidates := SelectCandidateChecks(ctx)
+
+	if got, want := len(candidates), 1; got != want {
+		t.Fatalf("len(candidates) = %d, want %d", got, want)
+	}
+	if got, want := candidates[0].Family, "unauth-api"; got != want {
+		t.Fatalf("candidates[0].Family = %q, want %q", got, want)
+	}
+	if got, want := candidates[0].Adapter, "kubernetes"; got != want {
+		t.Fatalf("candidates[0].Adapter = %q, want %q", got, want)
+	}
+	assertStrings(t, "Reasons", candidates[0].Reasons, []string{
+		"path anchor: /api",
+		"product hint: kubernetes",
+	})
+}


### PR DESCRIPTION

- Added the first selector-engine slice for open-redirect, traversal-read, and unauth-api
- Made selector decisions explainable by surfacing candidate details and reasons in flan verify
