### PR TITLE
Add bounded candidate execution and match plumbing

### DIFF
--- a/cmd/flan/verify.go
+++ b/cmd/flan/verify.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"flag"
@@ -9,6 +10,7 @@ import (
 	"os"
 	"strings"
 	"text/tabwriter"
+	"time"
 
 	"github.com/therandomsecurityguy/flan-go-scan/internal/output"
 	verifymodel "github.com/therandomsecurityguy/flan-go-scan/internal/verify"
@@ -23,6 +25,10 @@ type verifySummary struct {
 	Surfaces         int                      `json:"surfaces"`
 	Candidates       int                      `json:"candidates"`
 	CandidateDetails []verifyCandidateSummary `json:"candidate_details,omitempty"`
+	Executed         int                      `json:"executed,omitempty"`
+	Failures         int                      `json:"failures,omitempty"`
+	Matched          int                      `json:"matched,omitempty"`
+	ExecutionDetails []verifyExecutionSummary `json:"execution_details,omitempty"`
 }
 
 type verifyCandidateSummary struct {
@@ -33,6 +39,27 @@ type verifyCandidateSummary struct {
 	Port    int      `json:"port"`
 	Path    string   `json:"path,omitempty"`
 	Reasons []string `json:"reasons,omitempty"`
+}
+
+type verifyExecutionSummary struct {
+	CheckID    string               `json:"check_id"`
+	Family     string               `json:"family"`
+	Adapter    string               `json:"adapter,omitempty"`
+	Host       string               `json:"host"`
+	Port       int                  `json:"port"`
+	Path       string               `json:"path,omitempty"`
+	Executed   bool                 `json:"executed"`
+	StatusCode int                  `json:"status_code,omitempty"`
+	DurationMS int64                `json:"duration_ms,omitempty"`
+	Error      string               `json:"error,omitempty"`
+	Detail     string               `json:"detail,omitempty"`
+	Reasons    []string             `json:"reasons,omitempty"`
+	Matches    []verifyMatchSummary `json:"matches,omitempty"`
+}
+
+type verifyMatchSummary struct {
+	Name   string `json:"name"`
+	Detail string `json:"detail,omitempty"`
 }
 
 func dispatchSubcommand(args []string, stdout, stderr io.Writer) (bool, error) {
@@ -53,6 +80,12 @@ func runVerifyCommand(args []string, stdout, stderr io.Writer) error {
 	inputPath := fs.String("input", "", "")
 	inputShort := fs.String("i", "", "")
 	jsonFlag := fs.Bool("json", false, "")
+	runFlag := fs.Bool("run", false, "")
+	timeoutFlag := fs.Duration("timeout", 5*time.Second, "")
+	workersFlag := fs.Int("workers", 4, "")
+	maxBodyBytesFlag := fs.Int64("max-body-bytes", 8192, "")
+	maxRedirectsFlag := fs.Int("max-redirects", 0, "")
+	verifyTLSFlag := fs.Bool("tls-verify", false, "")
 	fs.Usage = func() {
 		fmt.Fprintln(stderr, "Usage:")
 		fmt.Fprintln(stderr, "  flan verify [flags]")
@@ -60,6 +93,12 @@ func runVerifyCommand(args []string, stdout, stderr io.Writer) error {
 		w := tabwriter.NewWriter(stderr, 0, 0, 2, ' ', 0)
 		fmt.Fprintf(w, "  --input, -i string\tpath to scan results in JSON or JSONL format; use - for stdin\n")
 		fmt.Fprintf(w, "  --json\toutput summary as JSON\n")
+		fmt.Fprintf(w, "  --run\texecute selected HTTP candidates and capture baseline evidence\n")
+		fmt.Fprintf(w, "  --timeout duration\trequest timeout for executed candidates\n")
+		fmt.Fprintf(w, "  --workers int\tmax concurrent candidate executions\n")
+		fmt.Fprintf(w, "  --max-body-bytes int\tmaximum response body bytes to capture per execution\n")
+		fmt.Fprintf(w, "  --max-redirects int\tmaximum redirects to follow when executing candidates (0 = do not follow)\n")
+		fmt.Fprintf(w, "  --tls-verify\tverify TLS certificates when executing HTTPS candidates\n")
 		_ = w.Flush()
 		fmt.Fprintln(stderr)
 		fmt.Fprintln(stderr, "Examples:")
@@ -117,6 +156,49 @@ func runVerifyCommand(args []string, stdout, stderr io.Writer) error {
 			}
 			summary.CandidateDetails = append(summary.CandidateDetails, detail)
 		}
+		if *runFlag && len(candidates) > 0 {
+			executions := verifymodel.ExecuteCandidateChecks(context.Background(), candidates, verifymodel.RuntimeConfig{
+				Timeout:      *timeoutFlag,
+				Workers:      *workersFlag,
+				MaxBodyBytes: *maxBodyBytesFlag,
+				MaxRedirects: *maxRedirectsFlag,
+				VerifyTLS:    *verifyTLSFlag,
+			})
+			for _, execution := range executions {
+				if execution.Executed {
+					summary.Executed++
+				}
+				if execution.Error != "" {
+					summary.Failures++
+				}
+				summary.Matched += len(execution.Evidence.Matches)
+				detail := verifyExecutionSummary{
+					CheckID:    execution.Candidate.CheckID,
+					Family:     execution.Candidate.Family,
+					Adapter:    execution.Candidate.Adapter,
+					Host:       execution.Candidate.Asset.Host,
+					Port:       execution.Candidate.Asset.Port,
+					Executed:   execution.Executed,
+					DurationMS: execution.DurationMS,
+					Error:      execution.Error,
+					Reasons:    execution.Candidate.Reasons,
+				}
+				if execution.Candidate.Surface != nil {
+					detail.Path = execution.Candidate.Surface.Path
+				}
+				if execution.Evidence.Response != nil {
+					detail.StatusCode = execution.Evidence.Response.StatusCode
+				}
+				detail.Detail = execution.Evidence.Detail
+				for _, match := range execution.Evidence.Matches {
+					detail.Matches = append(detail.Matches, verifyMatchSummary{
+						Name:   match.Name,
+						Detail: match.Detail,
+					})
+				}
+				summary.ExecutionDetails = append(summary.ExecutionDetails, detail)
+			}
+		}
 	}
 
 	if *jsonFlag {
@@ -137,6 +219,34 @@ func runVerifyCommand(args []string, stdout, stderr io.Writer) error {
 		}
 		if len(candidate.Reasons) > 0 {
 			fmt.Fprintf(stdout, "  reasons: %s\n", strings.Join(candidate.Reasons, ", "))
+		}
+	}
+	if *runFlag {
+		fmt.Fprintf(stdout, "Executed: %d\n", summary.Executed)
+		fmt.Fprintf(stdout, "Failures: %d\n", summary.Failures)
+		fmt.Fprintf(stdout, "Matched: %d\n", summary.Matched)
+		for _, execution := range summary.ExecutionDetails {
+			line := fmt.Sprintf("- %s (%s) %s:%d", execution.CheckID, execution.Family, execution.Host, execution.Port)
+			if execution.Path != "" {
+				line += execution.Path
+			}
+			if execution.Executed && execution.StatusCode > 0 {
+				line += fmt.Sprintf(" status=%d", execution.StatusCode)
+			}
+			if execution.Error != "" {
+				line += " error=" + execution.Error
+			}
+			fmt.Fprintln(stdout, line)
+			if execution.Detail != "" {
+				fmt.Fprintf(stdout, "  detail: %s\n", execution.Detail)
+			}
+			for _, match := range execution.Matches {
+				fmt.Fprintf(stdout, "  match: %s", match.Name)
+				if match.Detail != "" {
+					fmt.Fprintf(stdout, " - %s", match.Detail)
+				}
+				fmt.Fprintln(stdout)
+			}
 		}
 	}
 	return nil

--- a/cmd/flan/verify_test.go
+++ b/cmd/flan/verify_test.go
@@ -3,31 +3,15 @@ package main
 import (
 	"bytes"
 	"encoding/json"
+	"net"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 )
-
-func TestDispatchSubcommandVerify(t *testing.T) {
-	path := writeVerifyInput(t, `[{"host":"1.1.1.1","port":80,"protocol":"tcp","service":"http"}]`)
-
-	var stdout bytes.Buffer
-	var stderr bytes.Buffer
-	handled, err := dispatchSubcommand([]string{"verify", "--input", path}, &stdout, &stderr)
-	if err != nil {
-		t.Fatalf("dispatchSubcommand returned error: %v", err)
-	}
-	if !handled {
-		t.Fatal("expected verify subcommand to be handled")
-	}
-	if got := stdout.String(); !strings.Contains(got, "Loaded 1 scan results for verification") {
-		t.Fatalf("unexpected stdout: %q", got)
-	}
-	if stderr.Len() != 0 {
-		t.Fatalf("expected empty stderr, got %q", stderr.String())
-	}
-}
 
 func TestRunVerifyCommandJSONSummary(t *testing.T) {
 	path := writeVerifyInput(t, `[{"host":"1.1.1.1","port":80,"protocol":"tcp","service":"http","endpoints":[{"path":"/login?redirect=/","status_code":302}]}]`)
@@ -101,6 +85,48 @@ func TestRunVerifyCommandPlainSummaryIncludesCandidateReasons(t *testing.T) {
 	}
 }
 
+func TestRunVerifyCommandJSONRunIncludesExecutionDetails(t *testing.T) {
+	server := newIPv4VerifyServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Location", "https://example.com")
+		w.WriteHeader(http.StatusFound)
+	}))
+	defer server.Close()
+
+	host, port := verifyServerHostPort(t, server)
+	path := writeVerifyInput(t, `[{"host":"`+host+`","hostname":"app.example.test","port":`+strconv.Itoa(port)+`,"protocol":"tcp","service":"http","endpoints":[{"path":"/login?redirect=/","status_code":302}]}]`)
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	if err := runVerifyCommand([]string{"--input", path, "--json", "--run", "--workers", "1"}, &stdout, &stderr); err != nil {
+		t.Fatalf("runVerifyCommand returned error: %v", err)
+	}
+	var summary verifySummary
+	if err := json.Unmarshal(stdout.Bytes(), &summary); err != nil {
+		t.Fatalf("unmarshal verify summary: %v; body=%q", err, stdout.String())
+	}
+	if got, want := summary.Executed, 1; got != want {
+		t.Fatalf("summary.Executed = %d, want %d", got, want)
+	}
+	if got, want := len(summary.ExecutionDetails), 1; got != want {
+		t.Fatalf("len(summary.ExecutionDetails) = %d, want %d", got, want)
+	}
+	if got, want := summary.ExecutionDetails[0].StatusCode, http.StatusFound; got != want {
+		t.Fatalf("summary.ExecutionDetails[0].StatusCode = %d, want %d", got, want)
+	}
+	if summary.ExecutionDetails[0].Error != "" {
+		t.Fatalf("summary.ExecutionDetails[0].Error = %q, want empty", summary.ExecutionDetails[0].Error)
+	}
+	if got, want := summary.Matched, 1; got != want {
+		t.Fatalf("summary.Matched = %d, want %d", got, want)
+	}
+	if got, want := len(summary.ExecutionDetails[0].Matches), 1; got != want {
+		t.Fatalf("len(summary.ExecutionDetails[0].Matches) = %d, want %d", got, want)
+	}
+	if got, want := summary.ExecutionDetails[0].Matches[0].Name, "redirect-location"; got != want {
+		t.Fatalf("summary.ExecutionDetails[0].Matches[0].Name = %q, want %q", got, want)
+	}
+}
+
 func writeVerifyInput(t *testing.T, content string) string {
 	t.Helper()
 	path := filepath.Join(t.TempDir(), "scan.json")
@@ -108,4 +134,29 @@ func writeVerifyInput(t *testing.T, content string) string {
 		t.Fatalf("write verify input: %v", err)
 	}
 	return path
+}
+
+func newIPv4VerifyServer(t *testing.T, handler http.Handler) *httptest.Server {
+	t.Helper()
+	server := httptest.NewUnstartedServer(handler)
+	listener, err := net.Listen("tcp4", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen tcp4: %v", err)
+	}
+	server.Listener = listener
+	server.Start()
+	return server
+}
+
+func verifyServerHostPort(t *testing.T, server *httptest.Server) (string, int) {
+	t.Helper()
+	host, port, err := net.SplitHostPort(server.Listener.Addr().String())
+	if err != nil {
+		t.Fatalf("split host port: %v", err)
+	}
+	portNum, err := strconv.Atoi(port)
+	if err != nil {
+		t.Fatalf("parse port: %v", err)
+	}
+	return host, portNum
 }

--- a/internal/verify/models.go
+++ b/internal/verify/models.go
@@ -75,12 +75,18 @@ type HTTPResponseEvidence struct {
 	Body       string              `json:"body,omitempty"`
 }
 
+type MatchResult struct {
+	Name   string `json:"name"`
+	Detail string `json:"detail,omitempty"`
+}
+
 type Evidence struct {
 	Matcher  string                `json:"matcher,omitempty"`
 	Detail   string                `json:"detail,omitempty"`
 	Curl     string                `json:"curl,omitempty"`
 	Request  *HTTPRequestEvidence  `json:"request,omitempty"`
 	Response *HTTPResponseEvidence `json:"response,omitempty"`
+	Matches  []MatchResult         `json:"matches,omitempty"`
 }
 
 type Finding struct {

--- a/internal/verify/runtime.go
+++ b/internal/verify/runtime.go
@@ -1,0 +1,340 @@
+package verify
+
+import (
+	"context"
+	"crypto/tls"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/therandomsecurityguy/flan-go-scan/internal/scanner"
+)
+
+const defaultMaxBodyBytes int64 = 8192
+
+type RuntimeConfig struct {
+	Timeout      time.Duration
+	Workers      int
+	MaxBodyBytes int64
+	MaxRedirects int
+	VerifyTLS    bool
+}
+
+type ExecutionResult struct {
+	Candidate  CandidateCheck `json:"candidate"`
+	Executed   bool           `json:"executed"`
+	DurationMS int64          `json:"duration_ms,omitempty"`
+	Error      string         `json:"error,omitempty"`
+	Evidence   Evidence       `json:"evidence,omitempty"`
+}
+
+func DefaultRuntimeConfig() RuntimeConfig {
+	return RuntimeConfig{
+		Timeout:      5 * time.Second,
+		Workers:      4,
+		MaxBodyBytes: defaultMaxBodyBytes,
+		MaxRedirects: 0,
+	}
+}
+
+func ExecuteCandidateChecks(ctx context.Context, candidates []CandidateCheck, cfg RuntimeConfig) []ExecutionResult {
+	if len(candidates) == 0 {
+		return nil
+	}
+	cfg = normalizeRuntimeConfig(cfg)
+
+	type job struct {
+		index     int
+		candidate CandidateCheck
+	}
+
+	results := make([]ExecutionResult, len(candidates))
+	jobs := make(chan job)
+	var wg sync.WaitGroup
+
+	for range cfg.Workers {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for job := range jobs {
+				results[job.index] = executeCandidateCheck(ctx, job.candidate, cfg)
+			}
+		}()
+	}
+
+	for i, candidate := range candidates {
+		select {
+		case <-ctx.Done():
+			close(jobs)
+			wg.Wait()
+			for j := i; j < len(candidates); j++ {
+				results[j] = ExecutionResult{
+					Candidate: candidates[j],
+					Error:     ctx.Err().Error(),
+				}
+			}
+			return results
+		case jobs <- job{index: i, candidate: candidate}:
+		}
+	}
+	close(jobs)
+	wg.Wait()
+	return results
+}
+
+func normalizeRuntimeConfig(cfg RuntimeConfig) RuntimeConfig {
+	if cfg.Timeout <= 0 {
+		cfg.Timeout = 5 * time.Second
+	}
+	if cfg.Workers <= 0 {
+		cfg.Workers = 4
+	}
+	if cfg.MaxBodyBytes <= 0 {
+		cfg.MaxBodyBytes = defaultMaxBodyBytes
+	}
+	if cfg.MaxRedirects < 0 {
+		cfg.MaxRedirects = 0
+	}
+	return cfg
+}
+
+func executeCandidateCheck(parent context.Context, candidate CandidateCheck, cfg RuntimeConfig) ExecutionResult {
+	result := ExecutionResult{Candidate: candidate}
+	if candidate.Surface == nil {
+		result.Error = "candidate has no surface"
+		return result
+	}
+	if !scanner.IsHTTPService(candidate.Asset.Service, candidate.Asset.Port, candidate.Asset.TLS != nil) {
+		result.Error = "candidate service is not HTTP"
+		return result
+	}
+
+	reqURL, err := candidateURL(candidate)
+	if err != nil {
+		result.Error = err.Error()
+		return result
+	}
+
+	reqCtx, cancel := context.WithTimeout(parent, cfg.Timeout)
+	defer cancel()
+
+	method := candidateMethod(candidate)
+	req, err := http.NewRequestWithContext(reqCtx, method, reqURL, nil)
+	if err != nil {
+		result.Error = fmt.Sprintf("build request: %v", err)
+		return result
+	}
+	req.Header.Set("User-Agent", "flan-verify/1.0")
+	if candidate.Asset.Hostname != "" {
+		req.Host = candidate.Asset.Hostname
+	}
+
+	client := &http.Client{
+		Timeout:   cfg.Timeout,
+		Transport: runtimeHTTPTransport(candidate.Asset, cfg),
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			if cfg.MaxRedirects == 0 || len(via) >= cfg.MaxRedirects {
+				return http.ErrUseLastResponse
+			}
+			return nil
+		},
+	}
+
+	start := time.Now()
+	resp, err := client.Do(req)
+	result.DurationMS = time.Since(start).Milliseconds()
+	if err != nil {
+		result.Error = classifyExecutionError(err)
+		return result
+	}
+	defer resp.Body.Close()
+
+	body, truncated, readErr := readLimitedBody(resp.Body, cfg.MaxBodyBytes)
+	if readErr != nil {
+		result.Error = fmt.Sprintf("read response body: %v", readErr)
+		return result
+	}
+
+	result.Executed = true
+	result.Evidence = Evidence{
+		Detail: baselineDetail(resp.StatusCode, truncated),
+		Curl:   curlForRequest(req),
+		Request: &HTTPRequestEvidence{
+			Method:  req.Method,
+			URL:     req.URL.String(),
+			Headers: map[string]string{"User-Agent": "flan-verify/1.0"},
+			Body:    "",
+		},
+		Response: &HTTPResponseEvidence{
+			StatusCode: resp.StatusCode,
+			Headers:    cloneHeader(resp.Header),
+			Body:       body,
+		},
+	}
+	if req.Host != "" {
+		result.Evidence.Request.Headers["Host"] = req.Host
+	}
+	result.Evidence.Matches = evaluateExecution(candidate, result.Evidence)
+	if len(result.Evidence.Matches) > 0 {
+		result.Evidence.Matcher = result.Evidence.Matches[0].Name
+	}
+	return result
+}
+
+func candidateMethod(candidate CandidateCheck) string {
+	if candidate.Surface == nil || len(candidate.Surface.MethodHints) == 0 {
+		return http.MethodGet
+	}
+	method := strings.ToUpper(strings.TrimSpace(candidate.Surface.MethodHints[0]))
+	switch method {
+	case http.MethodGet, http.MethodHead, http.MethodOptions:
+		return method
+	default:
+		return http.MethodGet
+	}
+}
+
+func candidateURL(candidate CandidateCheck) (string, error) {
+	if candidate.Surface == nil {
+		return "", errors.New("candidate has no surface")
+	}
+	host := strings.TrimSpace(candidate.Asset.Host)
+	if host == "" {
+		return "", errors.New("candidate asset has no host")
+	}
+	urlHost := host
+	if strings.Contains(host, ":") && !strings.HasPrefix(host, "[") {
+		urlHost = "[" + host + "]"
+	}
+	scheme := scanner.HTTPScheme(candidate.Asset.TLS != nil || strings.Contains(strings.ToLower(candidate.Asset.Service), "https"))
+	return fmt.Sprintf("%s://%s:%d%s", scheme, urlHost, candidate.Asset.Port, normalizeSurfacePath(candidate.Surface.Path)), nil
+}
+
+func runtimeHTTPTransport(asset Asset, cfg RuntimeConfig) *http.Transport {
+	tlsCfg := &tls.Config{InsecureSkipVerify: !cfg.VerifyTLS}
+	if serverName := runtimeTLSServerName(asset.Host, asset.Hostname); serverName != "" {
+		tlsCfg.ServerName = serverName
+	}
+	return &http.Transport{
+		TLSClientConfig: tlsCfg,
+	}
+}
+
+func runtimeTLSServerName(host, hostname string) string {
+	if value := strings.TrimSpace(hostname); value != "" {
+		return strings.TrimSuffix(value, ".")
+	}
+	return strings.TrimSpace(host)
+}
+
+func readLimitedBody(body io.Reader, limit int64) (string, bool, error) {
+	reader := io.LimitReader(body, limit+1)
+	data, err := io.ReadAll(reader)
+	if err != nil {
+		return "", false, err
+	}
+	truncated := int64(len(data)) > limit
+	if truncated {
+		data = data[:limit]
+	}
+	return string(data), truncated, nil
+}
+
+func cloneHeader(header http.Header) map[string][]string {
+	if len(header) == 0 {
+		return nil
+	}
+	out := make(map[string][]string, len(header))
+	for key, values := range header {
+		out[key] = append([]string(nil), values...)
+	}
+	return out
+}
+
+func baselineDetail(statusCode int, truncated bool) string {
+	detail := "http response captured: status " + strconv.Itoa(statusCode)
+	if truncated {
+		return detail + " (body truncated)"
+	}
+	return detail
+}
+
+func classifyExecutionError(err error) string {
+	if err == nil {
+		return ""
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		return "request timed out"
+	}
+	return err.Error()
+}
+
+func curlForRequest(req *http.Request) string {
+	parts := []string{"curl", "-i", "-X", req.Method, strconv.Quote(req.URL.String())}
+	for key, value := range req.Header {
+		for _, headerValue := range value {
+			parts = append(parts, "-H", strconv.Quote(key+": "+headerValue))
+		}
+	}
+	if req.Host != "" {
+		parts = append(parts, "-H", strconv.Quote("Host: "+req.Host))
+	}
+	return strings.Join(parts, " ")
+}
+
+func evaluateExecution(candidate CandidateCheck, evidence Evidence) []MatchResult {
+	if evidence.Response == nil {
+		return nil
+	}
+	switch candidate.Family {
+	case "open-redirect":
+		return evaluateOpenRedirectMatch(evidence.Response)
+	case "unauth-api":
+		return evaluateUnauthAPIMatch(candidate, evidence.Response)
+	default:
+		return nil
+	}
+}
+
+func evaluateOpenRedirectMatch(response *HTTPResponseEvidence) []MatchResult {
+	location := firstHeaderValue(response.Headers, "Location")
+	if response.StatusCode >= 300 && response.StatusCode < 400 && location != "" {
+		return []MatchResult{{
+			Name:   "redirect-location",
+			Detail: "redirect status and Location header observed: " + location,
+		}}
+	}
+	return nil
+}
+
+func evaluateUnauthAPIMatch(candidate CandidateCheck, response *HTTPResponseEvidence) []MatchResult {
+	if response.StatusCode < 200 || response.StatusCode >= 300 {
+		return nil
+	}
+	detail := "reachable API response observed"
+	if candidate.Surface != nil && candidate.Surface.Path != "" {
+		detail = "reachable API response observed at " + normalizeSurfacePath(candidate.Surface.Path)
+	}
+	if contentType := firstHeaderValue(response.Headers, "Content-Type"); strings.Contains(strings.ToLower(contentType), "json") {
+		detail += " (json response)"
+	}
+	return []MatchResult{{
+		Name:   "reachable-api",
+		Detail: detail,
+	}}
+}
+
+func firstHeaderValue(headers map[string][]string, key string) string {
+	for header, values := range headers {
+		if !strings.EqualFold(header, key) || len(values) == 0 {
+			continue
+		}
+		return values[0]
+	}
+	return ""
+}

--- a/internal/verify/runtime_test.go
+++ b/internal/verify/runtime_test.go
@@ -1,0 +1,155 @@
+package verify
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+func TestExecuteCandidateChecksCapturesHTTPEvidence(t *testing.T) {
+	server := newIPv4Server(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got, want := r.Host, "app.example.test"; got != want {
+			t.Fatalf("request Host = %q, want %q", got, want)
+		}
+		w.Header().Set("Location", "https://example.com")
+		w.WriteHeader(http.StatusFound)
+		_, _ = w.Write([]byte("redirect body"))
+	}))
+	defer server.Close()
+
+	host, port := serverHostPort(t, server)
+	results := ExecuteCandidateChecks(context.Background(), []CandidateCheck{{
+		CheckID: "generic-web/open-redirect",
+		Family:  "open-redirect",
+		Adapter: "generic-web",
+		Asset: Asset{
+			Host:     host,
+			Hostname: "app.example.test",
+			Port:     port,
+			Service:  "http",
+		},
+		Surface: &Surface{Path: "/login?redirect=/", MethodHints: []string{"GET"}},
+	}}, RuntimeConfig{
+		Timeout:      2 * defaultRuntimeConfig().Timeout / 5,
+		Workers:      1,
+		MaxBodyBytes: 64,
+	})
+
+	if got, want := len(results), 1; got != want {
+		t.Fatalf("len(results) = %d, want %d", got, want)
+	}
+	result := results[0]
+	if !result.Executed {
+		t.Fatalf("result.Executed = false, error=%q", result.Error)
+	}
+	if result.Error != "" {
+		t.Fatalf("result.Error = %q, want empty", result.Error)
+	}
+	if got, want := result.Evidence.Response.StatusCode, http.StatusFound; got != want {
+		t.Fatalf("status = %d, want %d", got, want)
+	}
+	if got := result.Evidence.Response.Headers["Location"]; len(got) != 1 || got[0] != "https://example.com" {
+		t.Fatalf("location header = %v, want https://example.com", got)
+	}
+	if got, want := result.Evidence.Request.Headers["Host"], "app.example.test"; got != want {
+		t.Fatalf("request Host header = %q, want %q", got, want)
+	}
+	if got, want := len(result.Evidence.Matches), 1; got != want {
+		t.Fatalf("len(result.Evidence.Matches) = %d, want %d", got, want)
+	}
+	if got, want := result.Evidence.Matches[0].Name, "redirect-location"; got != want {
+		t.Fatalf("match name = %q, want %q", got, want)
+	}
+	if !strings.Contains(result.Evidence.Curl, "curl -i -X GET") {
+		t.Fatalf("curl repro = %q, want GET curl", result.Evidence.Curl)
+	}
+}
+
+func TestExecuteCandidateChecksUsesSafeMethodHints(t *testing.T) {
+	var gotMethod string
+	server := newIPv4Server(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	host, port := serverHostPort(t, server)
+	results := ExecuteCandidateChecks(context.Background(), []CandidateCheck{{
+		CheckID: "generic-web/head-probe",
+		Family:  "open-redirect",
+		Adapter: "generic-web",
+		Asset: Asset{
+			Host:    host,
+			Port:    port,
+			Service: "http",
+		},
+		Surface: &Surface{Path: "/", MethodHints: []string{"HEAD"}},
+	}}, DefaultRuntimeConfig())
+
+	if got, want := len(results), 1; got != want {
+		t.Fatalf("len(results) = %d, want %d", got, want)
+	}
+	if got, want := gotMethod, http.MethodHead; got != want {
+		t.Fatalf("request method = %q, want %q", got, want)
+	}
+	if got, want := results[0].Evidence.Request.Method, http.MethodHead; got != want {
+		t.Fatalf("evidence request method = %q, want %q", got, want)
+	}
+}
+
+func TestExecuteCandidateChecksRejectsNonHTTPService(t *testing.T) {
+	results := ExecuteCandidateChecks(context.Background(), []CandidateCheck{{
+		CheckID: "ldap/anonymous-bind",
+		Family:  "protocol-native",
+		Adapter: "ldap",
+		Asset: Asset{
+			Host:    "192.0.2.10",
+			Port:    636,
+			Service: "ldap",
+		},
+		Surface: &Surface{Path: "/"},
+	}}, DefaultRuntimeConfig())
+
+	if got, want := len(results), 1; got != want {
+		t.Fatalf("len(results) = %d, want %d", got, want)
+	}
+	if results[0].Executed {
+		t.Fatal("expected non-http candidate not to execute")
+	}
+	if got, want := results[0].Error, "candidate service is not HTTP"; got != want {
+		t.Fatalf("result.Error = %q, want %q", got, want)
+	}
+}
+
+func newIPv4Server(t *testing.T, handler http.Handler) *httptest.Server {
+	t.Helper()
+	server := httptest.NewUnstartedServer(handler)
+	listener, err := net.Listen("tcp4", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen tcp4: %v", err)
+	}
+	server.Listener = listener
+	server.Start()
+	return server
+}
+
+func serverHostPort(t *testing.T, server *httptest.Server) (string, int) {
+	t.Helper()
+	host, port, err := net.SplitHostPort(server.Listener.Addr().String())
+	if err != nil {
+		t.Fatalf("split host port: %v", err)
+	}
+	portNum, err := strconv.Atoi(port)
+	if err != nil {
+		t.Fatalf("parse port: %v", err)
+	}
+	return host, portNum
+}
+
+func defaultRuntimeConfig() RuntimeConfig {
+	return DefaultRuntimeConfig()
+}


### PR DESCRIPTION

- Added the first bounded verification runtime with worker-limited HTTP candidate execution, timeouts, redirect control, body caps, and TLS options
- Capture execution evidence including request details, response details, and curl repro output
- Added lightweight family-aware match plumbing for executed candidates without turning weak signals into final findings
- Extended flan verify --run to report execution results, failures, match summaries, and candidate reasoning