### PR TITLE
Add bounded family payload generation engine and tighten runtime

### DIFF
--- a/cmd/flan/verify.go
+++ b/cmd/flan/verify.go
@@ -24,6 +24,7 @@ type verifySummary struct {
 	Assets           int                      `json:"assets"`
 	Surfaces         int                      `json:"surfaces"`
 	Candidates       int                      `json:"candidates"`
+	Requests         int                      `json:"requests,omitempty"`
 	CandidateDetails []verifyCandidateSummary `json:"candidate_details,omitempty"`
 	Executed         int                      `json:"executed,omitempty"`
 	Failures         int                      `json:"failures,omitempty"`
@@ -48,6 +49,7 @@ type verifyExecutionSummary struct {
 	Host       string               `json:"host"`
 	Port       int                  `json:"port"`
 	Path       string               `json:"path,omitempty"`
+	Request    string               `json:"request,omitempty"`
 	Executed   bool                 `json:"executed"`
 	StatusCode int                  `json:"status_code,omitempty"`
 	DurationMS int64                `json:"duration_ms,omitempty"`
@@ -83,6 +85,7 @@ func runVerifyCommand(args []string, stdout, stderr io.Writer) error {
 	runFlag := fs.Bool("run", false, "")
 	timeoutFlag := fs.Duration("timeout", 5*time.Second, "")
 	workersFlag := fs.Int("workers", 4, "")
+	maxPayloadsFlag := fs.Int("max-payloads", 4, "")
 	maxBodyBytesFlag := fs.Int64("max-body-bytes", 8192, "")
 	maxRedirectsFlag := fs.Int("max-redirects", 0, "")
 	verifyTLSFlag := fs.Bool("tls-verify", false, "")
@@ -96,6 +99,7 @@ func runVerifyCommand(args []string, stdout, stderr io.Writer) error {
 		fmt.Fprintf(w, "  --run\texecute selected HTTP candidates and capture baseline evidence\n")
 		fmt.Fprintf(w, "  --timeout duration\trequest timeout for executed candidates\n")
 		fmt.Fprintf(w, "  --workers int\tmax concurrent candidate executions\n")
+		fmt.Fprintf(w, "  --max-payloads int\tmaximum generated requests per candidate\n")
 		fmt.Fprintf(w, "  --max-body-bytes int\tmaximum response body bytes to capture per execution\n")
 		fmt.Fprintf(w, "  --max-redirects int\tmaximum redirects to follow when executing candidates (0 = do not follow)\n")
 		fmt.Fprintf(w, "  --tls-verify\tverify TLS certificates when executing HTTPS candidates\n")
@@ -163,7 +167,11 @@ func runVerifyCommand(args []string, stdout, stderr io.Writer) error {
 				MaxBodyBytes: *maxBodyBytesFlag,
 				MaxRedirects: *maxRedirectsFlag,
 				VerifyTLS:    *verifyTLSFlag,
+				Payloads: verifymodel.PayloadConfig{
+					MaxPayloadsPerCandidate: *maxPayloadsFlag,
+				},
 			})
+			summary.Requests += len(executions)
 			for _, execution := range executions {
 				if execution.Executed {
 					summary.Executed++
@@ -178,6 +186,7 @@ func runVerifyCommand(args []string, stdout, stderr io.Writer) error {
 					Adapter:    execution.Candidate.Adapter,
 					Host:       execution.Candidate.Asset.Host,
 					Port:       execution.Candidate.Asset.Port,
+					Request:    execution.Request.Label,
 					Executed:   execution.Executed,
 					DurationMS: execution.DurationMS,
 					Error:      execution.Error,
@@ -222,6 +231,7 @@ func runVerifyCommand(args []string, stdout, stderr io.Writer) error {
 		}
 	}
 	if *runFlag {
+		fmt.Fprintf(stdout, "Requests: %d\n", summary.Requests)
 		fmt.Fprintf(stdout, "Executed: %d\n", summary.Executed)
 		fmt.Fprintf(stdout, "Failures: %d\n", summary.Failures)
 		fmt.Fprintf(stdout, "Matched: %d\n", summary.Matched)
@@ -239,6 +249,9 @@ func runVerifyCommand(args []string, stdout, stderr io.Writer) error {
 			fmt.Fprintln(stdout, line)
 			if execution.Detail != "" {
 				fmt.Fprintf(stdout, "  detail: %s\n", execution.Detail)
+			}
+			if execution.Request != "" {
+				fmt.Fprintf(stdout, "  request: %s\n", execution.Request)
 			}
 			for _, match := range execution.Matches {
 				fmt.Fprintf(stdout, "  match: %s", match.Name)

--- a/cmd/flan/verify_test.go
+++ b/cmd/flan/verify_test.go
@@ -87,7 +87,7 @@ func TestRunVerifyCommandPlainSummaryIncludesCandidateReasons(t *testing.T) {
 
 func TestRunVerifyCommandJSONRunIncludesExecutionDetails(t *testing.T) {
 	server := newIPv4VerifyServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Location", "https://example.com")
+		w.Header().Set("Location", r.URL.Query().Get("redirect"))
 		w.WriteHeader(http.StatusFound)
 	}))
 	defer server.Close()
@@ -97,7 +97,7 @@ func TestRunVerifyCommandJSONRunIncludesExecutionDetails(t *testing.T) {
 
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
-	if err := runVerifyCommand([]string{"--input", path, "--json", "--run", "--workers", "1"}, &stdout, &stderr); err != nil {
+	if err := runVerifyCommand([]string{"--input", path, "--json", "--run", "--workers", "1", "--max-payloads", "1"}, &stdout, &stderr); err != nil {
 		t.Fatalf("runVerifyCommand returned error: %v", err)
 	}
 	var summary verifySummary
@@ -106,6 +106,9 @@ func TestRunVerifyCommandJSONRunIncludesExecutionDetails(t *testing.T) {
 	}
 	if got, want := summary.Executed, 1; got != want {
 		t.Fatalf("summary.Executed = %d, want %d", got, want)
+	}
+	if got, want := summary.Requests, 1; got != want {
+		t.Fatalf("summary.Requests = %d, want %d", got, want)
 	}
 	if got, want := len(summary.ExecutionDetails), 1; got != want {
 		t.Fatalf("len(summary.ExecutionDetails) = %d, want %d", got, want)
@@ -124,6 +127,9 @@ func TestRunVerifyCommandJSONRunIncludesExecutionDetails(t *testing.T) {
 	}
 	if got, want := summary.ExecutionDetails[0].Matches[0].Name, "redirect-location"; got != want {
 		t.Fatalf("summary.ExecutionDetails[0].Matches[0].Name = %q, want %q", got, want)
+	}
+	if got, want := summary.ExecutionDetails[0].Request, "absolute-external:redirect"; got != want {
+		t.Fatalf("summary.ExecutionDetails[0].Request = %q, want %q", got, want)
 	}
 }
 

--- a/internal/verify/payloads.go
+++ b/internal/verify/payloads.go
@@ -1,0 +1,200 @@
+package verify
+
+import (
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+const defaultExternalRedirectTarget = "https://verify.invalid/flan"
+
+type PayloadConfig struct {
+	MaxPayloadsPerCandidate int
+	ExternalRedirectTarget  string
+}
+
+type GeneratedRequest struct {
+	Label   string            `json:"label"`
+	Method  string            `json:"method"`
+	Path    string            `json:"path"`
+	Headers map[string]string `json:"headers,omitempty"`
+	Body    string            `json:"body,omitempty"`
+}
+
+func DefaultPayloadConfig() PayloadConfig {
+	return PayloadConfig{
+		MaxPayloadsPerCandidate: 4,
+		ExternalRedirectTarget:  defaultExternalRedirectTarget,
+	}
+}
+
+func ExpandCandidateRequests(candidate CandidateCheck, cfg PayloadConfig) []GeneratedRequest {
+	cfg = normalizePayloadConfig(cfg)
+	switch candidate.Family {
+	case "open-redirect":
+		if requests := expandOpenRedirectRequests(candidate, cfg); len(requests) > 0 {
+			return requests
+		}
+	case "traversal-read":
+		if requests := expandTraversalRequests(candidate, cfg); len(requests) > 0 {
+			return requests
+		}
+	}
+	return []GeneratedRequest{baselineGeneratedRequest(candidate)}
+}
+
+func normalizePayloadConfig(cfg PayloadConfig) PayloadConfig {
+	if cfg.MaxPayloadsPerCandidate <= 0 {
+		cfg.MaxPayloadsPerCandidate = 4
+	}
+	if strings.TrimSpace(cfg.ExternalRedirectTarget) == "" {
+		cfg.ExternalRedirectTarget = defaultExternalRedirectTarget
+	}
+	return cfg
+}
+
+func baselineGeneratedRequest(candidate CandidateCheck) GeneratedRequest {
+	method := http.MethodGet
+	if candidate.Surface != nil && len(candidate.Surface.MethodHints) > 0 {
+		method = strings.ToUpper(strings.TrimSpace(candidate.Surface.MethodHints[0]))
+	}
+	switch method {
+	case http.MethodGet, http.MethodHead, http.MethodOptions:
+	default:
+		method = http.MethodGet
+	}
+	path := "/"
+	if candidate.Surface != nil {
+		path = normalizeSurfacePath(candidate.Surface.Path)
+	}
+	return GeneratedRequest{
+		Label:  "baseline",
+		Method: method,
+		Path:   path,
+	}
+}
+
+func expandOpenRedirectRequests(candidate CandidateCheck, cfg PayloadConfig) []GeneratedRequest {
+	if candidate.Surface == nil {
+		return nil
+	}
+	redirectParams := findParams(candidate.Surface.Params, redirectParams)
+	if len(redirectParams) == 0 {
+		return nil
+	}
+
+	payloads := []struct {
+		label      string
+		value      string
+		preEncoded bool
+	}{
+		{label: "absolute-external", value: cfg.ExternalRedirectTarget},
+		{label: "scheme-relative", value: "//verify.invalid/flan"},
+		{label: "encoded-external", value: "https:%2f%2fverify.invalid%2fflan", preEncoded: true},
+		{label: "path-confusion", value: "/\\verify.invalid/flan"},
+	}
+
+	requests := make([]GeneratedRequest, 0, cfg.MaxPayloadsPerCandidate)
+	for _, param := range redirectParams {
+		for _, payload := range payloads {
+			if len(requests) >= cfg.MaxPayloadsPerCandidate {
+				return requests
+			}
+			mutatedPath, ok := mutateQueryParam(candidate.Surface.Path, param, payload.value, payload.preEncoded)
+			if !ok {
+				continue
+			}
+			requests = append(requests, GeneratedRequest{
+				Label:  payload.label + ":" + param,
+				Method: baselineGeneratedRequest(candidate).Method,
+				Path:   mutatedPath,
+			})
+		}
+	}
+	return requests
+}
+
+func expandTraversalRequests(candidate CandidateCheck, cfg PayloadConfig) []GeneratedRequest {
+	if candidate.Surface == nil {
+		return nil
+	}
+	fileParams := findParams(candidate.Surface.Params, fileParams)
+	if len(fileParams) == 0 {
+		return nil
+	}
+
+	payloads := []struct {
+		label      string
+		value      string
+		preEncoded bool
+	}{
+		{label: "unix-passwd", value: "../../../../etc/passwd"},
+		{label: "encoded-unix-passwd", value: "..%2f..%2f..%2f..%2fetc/passwd", preEncoded: true},
+		{label: "windows-ini", value: `..\..\..\..\windows\win.ini`},
+	}
+
+	requests := make([]GeneratedRequest, 0, cfg.MaxPayloadsPerCandidate)
+	for _, param := range fileParams {
+		for _, payload := range payloads {
+			if len(requests) >= cfg.MaxPayloadsPerCandidate {
+				return requests
+			}
+			mutatedPath, ok := mutateQueryParam(candidate.Surface.Path, param, payload.value, payload.preEncoded)
+			if !ok {
+				continue
+			}
+			requests = append(requests, GeneratedRequest{
+				Label:  payload.label + ":" + param,
+				Method: baselineGeneratedRequest(candidate).Method,
+				Path:   mutatedPath,
+			})
+		}
+	}
+	return requests
+}
+
+func findParams(params []string, familyParams map[string]struct{}) []string {
+	out := make([]string, 0, len(params))
+	for _, param := range params {
+		if _, ok := familyParams[strings.ToLower(strings.TrimSpace(param))]; ok {
+			out = append(out, strings.ToLower(strings.TrimSpace(param)))
+		}
+	}
+	return dedupeStrings(out)
+}
+
+func mutateQueryParam(rawPath, param, value string, preEncoded bool) (string, bool) {
+	parsed, err := url.Parse(normalizeSurfacePath(rawPath))
+	if err != nil {
+		return "", false
+	}
+	if parsed.RawQuery == "" {
+		return "", false
+	}
+	parts := strings.Split(parsed.RawQuery, "&")
+	mutated := false
+	for i, part := range parts {
+		if part == "" {
+			continue
+		}
+		key, _, _ := strings.Cut(part, "=")
+		decodedKey, err := url.QueryUnescape(key)
+		if err != nil {
+			decodedKey = key
+		}
+		if !strings.EqualFold(decodedKey, param) {
+			continue
+		}
+		encodedValue := url.QueryEscape(value)
+		if preEncoded {
+			encodedValue = value
+		}
+		parts[i] = key + "=" + encodedValue
+		mutated = true
+	}
+	if !mutated {
+		return "", false
+	}
+	parsed.RawQuery = strings.Join(parts, "&")
+	return normalizeSurfacePath(parsed.Path + "?" + parsed.RawQuery), true
+}

--- a/internal/verify/payloads_test.go
+++ b/internal/verify/payloads_test.go
@@ -1,0 +1,87 @@
+package verify
+
+import "testing"
+
+func TestExpandCandidateRequestsOpenRedirect(t *testing.T) {
+	requests := ExpandCandidateRequests(CandidateCheck{
+		Family: "open-redirect",
+		Surface: &Surface{
+			Path:        "/login?redirect=/",
+			Params:      []string{"redirect"},
+			MethodHints: []string{"GET"},
+		},
+	}, PayloadConfig{
+		MaxPayloadsPerCandidate: 3,
+		ExternalRedirectTarget:  "https://verify.invalid/flan",
+	})
+
+	if got, want := len(requests), 3; got != want {
+		t.Fatalf("len(requests) = %d, want %d", got, want)
+	}
+	if got, want := requests[0].Label, "absolute-external:redirect"; got != want {
+		t.Fatalf("requests[0].Label = %q, want %q", got, want)
+	}
+	if got, want := requests[0].Path, "/login?redirect=https%3A%2F%2Fverify.invalid%2Fflan"; got != want {
+		t.Fatalf("requests[0].Path = %q, want %q", got, want)
+	}
+}
+
+func TestExpandCandidateRequestsPreservesPreEncodedPayloads(t *testing.T) {
+	requests := ExpandCandidateRequests(CandidateCheck{
+		Family: "open-redirect",
+		Surface: &Surface{
+			Path:        "/login?Redirect=/",
+			Params:      []string{"redirect"},
+			MethodHints: []string{"GET"},
+		},
+	}, PayloadConfig{
+		MaxPayloadsPerCandidate: 3,
+	})
+
+	if got, want := requests[2].Label, "encoded-external:redirect"; got != want {
+		t.Fatalf("requests[2].Label = %q, want %q", got, want)
+	}
+	if got, want := requests[2].Path, "/login?Redirect=https:%2f%2fverify.invalid%2fflan"; got != want {
+		t.Fatalf("requests[2].Path = %q, want %q", got, want)
+	}
+}
+
+func TestExpandCandidateRequestsTraversalRead(t *testing.T) {
+	requests := ExpandCandidateRequests(CandidateCheck{
+		Family: "traversal-read",
+		Surface: &Surface{
+			Path:        "/download?file=report.txt",
+			Params:      []string{"file"},
+			MethodHints: []string{"GET"},
+		},
+	}, PayloadConfig{
+		MaxPayloadsPerCandidate: 2,
+	})
+
+	if got, want := len(requests), 2; got != want {
+		t.Fatalf("len(requests) = %d, want %d", got, want)
+	}
+	if got, want := requests[0].Label, "unix-passwd:file"; got != want {
+		t.Fatalf("requests[0].Label = %q, want %q", got, want)
+	}
+	if got, want := requests[1].Path, "/download?file=..%2f..%2f..%2f..%2fetc/passwd"; got != want {
+		t.Fatalf("requests[1].Path = %q, want %q", got, want)
+	}
+}
+
+func TestExpandCandidateRequestsFallsBackToBaseline(t *testing.T) {
+	requests := ExpandCandidateRequests(CandidateCheck{
+		Family: "unauth-api",
+		Surface: &Surface{
+			Path:        "/v1/sys/health",
+			MethodHints: []string{"GET"},
+		},
+	}, DefaultPayloadConfig())
+
+	if got, want := len(requests), 1; got != want {
+		t.Fatalf("len(requests) = %d, want %d", got, want)
+	}
+	if got, want := requests[0].Label, "baseline"; got != want {
+		t.Fatalf("requests[0].Label = %q, want %q", got, want)
+	}
+}

--- a/internal/verify/runtime.go
+++ b/internal/verify/runtime.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"strconv"
 	"strings"
 	"sync"
@@ -23,14 +24,16 @@ type RuntimeConfig struct {
 	MaxBodyBytes int64
 	MaxRedirects int
 	VerifyTLS    bool
+	Payloads     PayloadConfig
 }
 
 type ExecutionResult struct {
-	Candidate  CandidateCheck `json:"candidate"`
-	Executed   bool           `json:"executed"`
-	DurationMS int64          `json:"duration_ms,omitempty"`
-	Error      string         `json:"error,omitempty"`
-	Evidence   Evidence       `json:"evidence,omitempty"`
+	Candidate  CandidateCheck   `json:"candidate"`
+	Request    GeneratedRequest `json:"request"`
+	Executed   bool             `json:"executed"`
+	DurationMS int64            `json:"duration_ms,omitempty"`
+	Error      string           `json:"error,omitempty"`
+	Evidence   Evidence         `json:"evidence,omitempty"`
 }
 
 func DefaultRuntimeConfig() RuntimeConfig {
@@ -39,6 +42,7 @@ func DefaultRuntimeConfig() RuntimeConfig {
 		Workers:      4,
 		MaxBodyBytes: defaultMaxBodyBytes,
 		MaxRedirects: 0,
+		Payloads:     DefaultPayloadConfig(),
 	}
 }
 
@@ -51,9 +55,11 @@ func ExecuteCandidateChecks(ctx context.Context, candidates []CandidateCheck, cf
 	type job struct {
 		index     int
 		candidate CandidateCheck
+		request   GeneratedRequest
 	}
 
-	results := make([]ExecutionResult, len(candidates))
+	jobsList := expandExecutionJobs(candidates, cfg.Payloads)
+	results := make([]ExecutionResult, len(jobsList))
 	jobs := make(chan job)
 	var wg sync.WaitGroup
 
@@ -62,24 +68,25 @@ func ExecuteCandidateChecks(ctx context.Context, candidates []CandidateCheck, cf
 		go func() {
 			defer wg.Done()
 			for job := range jobs {
-				results[job.index] = executeCandidateCheck(ctx, job.candidate, cfg)
+				results[job.index] = executeCandidateCheck(ctx, job.candidate, job.request, cfg)
 			}
 		}()
 	}
 
-	for i, candidate := range candidates {
+	for i, jobItem := range jobsList {
 		select {
 		case <-ctx.Done():
 			close(jobs)
 			wg.Wait()
-			for j := i; j < len(candidates); j++ {
+			for j := i; j < len(jobsList); j++ {
 				results[j] = ExecutionResult{
-					Candidate: candidates[j],
+					Candidate: jobsList[j].candidate,
+					Request:   jobsList[j].request,
 					Error:     ctx.Err().Error(),
 				}
 			}
 			return results
-		case jobs <- job{index: i, candidate: candidate}:
+		case jobs <- job{index: i, candidate: jobItem.candidate, request: jobItem.request}:
 		}
 	}
 	close(jobs)
@@ -100,11 +107,34 @@ func normalizeRuntimeConfig(cfg RuntimeConfig) RuntimeConfig {
 	if cfg.MaxRedirects < 0 {
 		cfg.MaxRedirects = 0
 	}
+	cfg.Payloads = normalizePayloadConfig(cfg.Payloads)
 	return cfg
 }
 
-func executeCandidateCheck(parent context.Context, candidate CandidateCheck, cfg RuntimeConfig) ExecutionResult {
-	result := ExecutionResult{Candidate: candidate}
+func expandExecutionJobs(candidates []CandidateCheck, cfg PayloadConfig) []struct {
+	candidate CandidateCheck
+	request   GeneratedRequest
+} {
+	jobs := make([]struct {
+		candidate CandidateCheck
+		request   GeneratedRequest
+	}, 0, len(candidates))
+	for _, candidate := range candidates {
+		for _, request := range ExpandCandidateRequests(candidate, cfg) {
+			jobs = append(jobs, struct {
+				candidate CandidateCheck
+				request   GeneratedRequest
+			}{
+				candidate: candidate,
+				request:   request,
+			})
+		}
+	}
+	return jobs
+}
+
+func executeCandidateCheck(parent context.Context, candidate CandidateCheck, request GeneratedRequest, cfg RuntimeConfig) ExecutionResult {
+	result := ExecutionResult{Candidate: candidate, Request: request}
 	if candidate.Surface == nil {
 		result.Error = "candidate has no surface"
 		return result
@@ -114,7 +144,7 @@ func executeCandidateCheck(parent context.Context, candidate CandidateCheck, cfg
 		return result
 	}
 
-	reqURL, err := candidateURL(candidate)
+	reqURL, err := candidateURL(candidate, request)
 	if err != nil {
 		result.Error = err.Error()
 		return result
@@ -123,13 +153,15 @@ func executeCandidateCheck(parent context.Context, candidate CandidateCheck, cfg
 	reqCtx, cancel := context.WithTimeout(parent, cfg.Timeout)
 	defer cancel()
 
-	method := candidateMethod(candidate)
-	req, err := http.NewRequestWithContext(reqCtx, method, reqURL, nil)
+	req, err := http.NewRequestWithContext(reqCtx, request.Method, reqURL, strings.NewReader(request.Body))
 	if err != nil {
 		result.Error = fmt.Sprintf("build request: %v", err)
 		return result
 	}
 	req.Header.Set("User-Agent", "flan-verify/1.0")
+	for key, value := range request.Headers {
+		req.Header.Set(key, value)
+	}
 	if candidate.Asset.Hostname != "" {
 		req.Host = candidate.Asset.Hostname
 	}
@@ -167,8 +199,8 @@ func executeCandidateCheck(parent context.Context, candidate CandidateCheck, cfg
 		Request: &HTTPRequestEvidence{
 			Method:  req.Method,
 			URL:     req.URL.String(),
-			Headers: map[string]string{"User-Agent": "flan-verify/1.0"},
-			Body:    "",
+			Headers: requestHeaders(req.Header),
+			Body:    request.Body,
 		},
 		Response: &HTTPResponseEvidence{
 			StatusCode: resp.StatusCode,
@@ -179,27 +211,14 @@ func executeCandidateCheck(parent context.Context, candidate CandidateCheck, cfg
 	if req.Host != "" {
 		result.Evidence.Request.Headers["Host"] = req.Host
 	}
-	result.Evidence.Matches = evaluateExecution(candidate, result.Evidence)
+	result.Evidence.Matches = evaluateExecution(candidate, request, result.Evidence)
 	if len(result.Evidence.Matches) > 0 {
 		result.Evidence.Matcher = result.Evidence.Matches[0].Name
 	}
 	return result
 }
 
-func candidateMethod(candidate CandidateCheck) string {
-	if candidate.Surface == nil || len(candidate.Surface.MethodHints) == 0 {
-		return http.MethodGet
-	}
-	method := strings.ToUpper(strings.TrimSpace(candidate.Surface.MethodHints[0]))
-	switch method {
-	case http.MethodGet, http.MethodHead, http.MethodOptions:
-		return method
-	default:
-		return http.MethodGet
-	}
-}
-
-func candidateURL(candidate CandidateCheck) (string, error) {
+func candidateURL(candidate CandidateCheck, request GeneratedRequest) (string, error) {
 	if candidate.Surface == nil {
 		return "", errors.New("candidate has no surface")
 	}
@@ -212,7 +231,7 @@ func candidateURL(candidate CandidateCheck) (string, error) {
 		urlHost = "[" + host + "]"
 	}
 	scheme := scanner.HTTPScheme(candidate.Asset.TLS != nil || strings.Contains(strings.ToLower(candidate.Asset.Service), "https"))
-	return fmt.Sprintf("%s://%s:%d%s", scheme, urlHost, candidate.Asset.Port, normalizeSurfacePath(candidate.Surface.Path)), nil
+	return fmt.Sprintf("%s://%s:%d%s", scheme, urlHost, candidate.Asset.Port, normalizeSurfacePath(request.Path)), nil
 }
 
 func runtimeHTTPTransport(asset Asset, cfg RuntimeConfig) *http.Transport {
@@ -256,6 +275,20 @@ func cloneHeader(header http.Header) map[string][]string {
 	return out
 }
 
+func requestHeaders(header http.Header) map[string]string {
+	if len(header) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(header))
+	for key, values := range header {
+		if len(values) == 0 {
+			continue
+		}
+		out[key] = values[0]
+	}
+	return out
+}
+
 func baselineDetail(statusCode int, truncated bool) string {
 	detail := "http response captured: status " + strconv.Itoa(statusCode)
 	if truncated {
@@ -287,13 +320,13 @@ func curlForRequest(req *http.Request) string {
 	return strings.Join(parts, " ")
 }
 
-func evaluateExecution(candidate CandidateCheck, evidence Evidence) []MatchResult {
+func evaluateExecution(candidate CandidateCheck, request GeneratedRequest, evidence Evidence) []MatchResult {
 	if evidence.Response == nil {
 		return nil
 	}
 	switch candidate.Family {
 	case "open-redirect":
-		return evaluateOpenRedirectMatch(evidence.Response)
+		return evaluateOpenRedirectMatch(request, evidence.Response)
 	case "unauth-api":
 		return evaluateUnauthAPIMatch(candidate, evidence.Response)
 	default:
@@ -301,9 +334,9 @@ func evaluateExecution(candidate CandidateCheck, evidence Evidence) []MatchResul
 	}
 }
 
-func evaluateOpenRedirectMatch(response *HTTPResponseEvidence) []MatchResult {
+func evaluateOpenRedirectMatch(request GeneratedRequest, response *HTTPResponseEvidence) []MatchResult {
 	location := firstHeaderValue(response.Headers, "Location")
-	if response.StatusCode >= 300 && response.StatusCode < 400 && location != "" {
+	if response.StatusCode >= 300 && response.StatusCode < 400 && isExternalRedirectMatch(location, request.Path) {
 		return []MatchResult{{
 			Name:   "redirect-location",
 			Detail: "redirect status and Location header observed: " + location,
@@ -314,6 +347,9 @@ func evaluateOpenRedirectMatch(response *HTTPResponseEvidence) []MatchResult {
 
 func evaluateUnauthAPIMatch(candidate CandidateCheck, response *HTTPResponseEvidence) []MatchResult {
 	if response.StatusCode < 200 || response.StatusCode >= 300 {
+		return nil
+	}
+	if !isVerifiedUnauthAPIResponse(candidate, response) {
 		return nil
 	}
 	detail := "reachable API response observed"
@@ -327,6 +363,60 @@ func evaluateUnauthAPIMatch(candidate CandidateCheck, response *HTTPResponseEvid
 		Name:   "reachable-api",
 		Detail: detail,
 	}}
+}
+
+func isExternalRedirectMatch(location, requestPath string) bool {
+	location = strings.TrimSpace(location)
+	if location == "" {
+		return false
+	}
+	if value, ok := queryParamValue(requestPath, redirectParams); ok && strings.EqualFold(strings.TrimSpace(value), location) {
+		return true
+	}
+	locationLower := strings.ToLower(location)
+	return strings.Contains(locationLower, "verify.invalid")
+}
+
+func isVerifiedUnauthAPIResponse(candidate CandidateCheck, response *HTTPResponseEvidence) bool {
+	body := strings.ToLower(strings.TrimSpace(response.Body))
+	contentType := strings.ToLower(firstHeaderValue(response.Headers, "Content-Type"))
+	switch candidate.Adapter {
+	case "kubernetes":
+		if candidate.Surface == nil {
+			return false
+		}
+		path := normalizeSurfacePath(candidate.Surface.Path)
+		switch path {
+		case "/version":
+			return strings.Contains(contentType, "json") && strings.Contains(body, "gitversion")
+		case "/api", "/apis":
+			return strings.Contains(contentType, "json") && strings.Contains(body, "versions")
+		}
+	case "vault":
+		return strings.Contains(contentType, "json") &&
+			strings.Contains(body, "\"sealed\"") &&
+			strings.Contains(body, "\"initialized\"")
+	case "consul":
+		return strings.Contains(contentType, "json") &&
+			strings.Contains(body, "\"config\"") &&
+			strings.Contains(body, "\"member\"")
+	}
+	return false
+}
+
+func queryParamValue(rawPath string, params map[string]struct{}) (string, bool) {
+	parsed, err := url.Parse(normalizeSurfacePath(rawPath))
+	if err != nil {
+		return "", false
+	}
+	query := parsed.Query()
+	for key, values := range query {
+		if _, ok := params[strings.ToLower(strings.TrimSpace(key))]; !ok || len(values) == 0 {
+			continue
+		}
+		return values[0], true
+	}
+	return "", false
 }
 
 func firstHeaderValue(headers map[string][]string, key string) string {

--- a/internal/verify/runtime_test.go
+++ b/internal/verify/runtime_test.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestExecuteCandidateChecksCapturesHTTPEvidence(t *testing.T) {
@@ -15,7 +16,7 @@ func TestExecuteCandidateChecksCapturesHTTPEvidence(t *testing.T) {
 		if got, want := r.Host, "app.example.test"; got != want {
 			t.Fatalf("request Host = %q, want %q", got, want)
 		}
-		w.Header().Set("Location", "https://example.com")
+		w.Header().Set("Location", r.URL.Query().Get("redirect"))
 		w.WriteHeader(http.StatusFound)
 		_, _ = w.Write([]byte("redirect body"))
 	}))
@@ -32,11 +33,15 @@ func TestExecuteCandidateChecksCapturesHTTPEvidence(t *testing.T) {
 			Port:     port,
 			Service:  "http",
 		},
-		Surface: &Surface{Path: "/login?redirect=/", MethodHints: []string{"GET"}},
+		Surface: &Surface{Path: "/login?redirect=/", Params: []string{"redirect"}, MethodHints: []string{"GET"}},
 	}}, RuntimeConfig{
 		Timeout:      2 * defaultRuntimeConfig().Timeout / 5,
 		Workers:      1,
 		MaxBodyBytes: 64,
+		Payloads: PayloadConfig{
+			MaxPayloadsPerCandidate: 1,
+			ExternalRedirectTarget:  "https://verify.invalid/flan",
+		},
 	})
 
 	if got, want := len(results), 1; got != want {
@@ -52,8 +57,8 @@ func TestExecuteCandidateChecksCapturesHTTPEvidence(t *testing.T) {
 	if got, want := result.Evidence.Response.StatusCode, http.StatusFound; got != want {
 		t.Fatalf("status = %d, want %d", got, want)
 	}
-	if got := result.Evidence.Response.Headers["Location"]; len(got) != 1 || got[0] != "https://example.com" {
-		t.Fatalf("location header = %v, want https://example.com", got)
+	if got := result.Evidence.Response.Headers["Location"]; len(got) != 1 || got[0] != "https://verify.invalid/flan" {
+		t.Fatalf("location header = %v, want https://verify.invalid/flan", got)
 	}
 	if got, want := result.Evidence.Request.Headers["Host"], "app.example.test"; got != want {
 		t.Fatalf("request Host header = %q, want %q", got, want)
@@ -66,6 +71,41 @@ func TestExecuteCandidateChecksCapturesHTTPEvidence(t *testing.T) {
 	}
 	if !strings.Contains(result.Evidence.Curl, "curl -i -X GET") {
 		t.Fatalf("curl repro = %q, want GET curl", result.Evidence.Curl)
+	}
+	if got, want := result.Request.Label, "absolute-external:redirect"; got != want {
+		t.Fatalf("request label = %q, want %q", got, want)
+	}
+}
+
+func TestExecuteCandidateChecksDoesNotMatchInternalRedirect(t *testing.T) {
+	server := newIPv4Server(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Location", "/dashboard")
+		w.WriteHeader(http.StatusFound)
+	}))
+	defer server.Close()
+
+	host, port := serverHostPort(t, server)
+	results := ExecuteCandidateChecks(context.Background(), []CandidateCheck{{
+		CheckID: "generic-web/open-redirect",
+		Family:  "open-redirect",
+		Adapter: "generic-web",
+		Asset: Asset{
+			Host:    host,
+			Port:    port,
+			Service: "http",
+		},
+		Surface: &Surface{Path: "/login?redirect=/", Params: []string{"redirect"}, MethodHints: []string{"GET"}},
+	}}, RuntimeConfig{
+		Timeout:  5 * time.Second,
+		Workers:  1,
+		Payloads: PayloadConfig{MaxPayloadsPerCandidate: 1},
+	})
+
+	if got, want := len(results), 1; got != want {
+		t.Fatalf("len(results) = %d, want %d", got, want)
+	}
+	if got := len(results[0].Evidence.Matches); got != 0 {
+		t.Fatalf("len(results[0].Evidence.Matches) = %d, want 0", got)
 	}
 }
 
@@ -88,7 +128,11 @@ func TestExecuteCandidateChecksUsesSafeMethodHints(t *testing.T) {
 			Service: "http",
 		},
 		Surface: &Surface{Path: "/", MethodHints: []string{"HEAD"}},
-	}}, DefaultRuntimeConfig())
+	}}, RuntimeConfig{
+		Timeout:  5 * time.Second,
+		Workers:  1,
+		Payloads: PayloadConfig{MaxPayloadsPerCandidate: 1},
+	})
 
 	if got, want := len(results), 1; got != want {
 		t.Fatalf("len(results) = %d, want %d", got, want)
@@ -122,6 +166,75 @@ func TestExecuteCandidateChecksRejectsNonHTTPService(t *testing.T) {
 	}
 	if got, want := results[0].Error, "candidate service is not HTTP"; got != want {
 		t.Fatalf("result.Error = %q, want %q", got, want)
+	}
+}
+
+func TestExecuteCandidateChecksMatchesVaultUnauthAPIWithExpectedShape(t *testing.T) {
+	server := newIPv4Server(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"initialized":true,"sealed":false,"standby":false}`))
+	}))
+	defer server.Close()
+
+	host, port := serverHostPort(t, server)
+	results := ExecuteCandidateChecks(context.Background(), []CandidateCheck{{
+		CheckID: "vault/unauth-api",
+		Family:  "unauth-api",
+		Adapter: "vault",
+		Asset: Asset{
+			Host:    host,
+			Port:    port,
+			Service: "http",
+		},
+		Surface: &Surface{Path: "/v1/sys/health", MethodHints: []string{"GET"}},
+	}}, RuntimeConfig{
+		Timeout:  5 * time.Second,
+		Workers:  1,
+		Payloads: PayloadConfig{MaxPayloadsPerCandidate: 1},
+	})
+
+	if got, want := len(results), 1; got != want {
+		t.Fatalf("len(results) = %d, want %d", got, want)
+	}
+	if got, want := len(results[0].Evidence.Matches), 1; got != want {
+		t.Fatalf("len(results[0].Evidence.Matches) = %d, want %d", got, want)
+	}
+	if got, want := results[0].Evidence.Matches[0].Name, "reachable-api"; got != want {
+		t.Fatalf("match name = %q, want %q", got, want)
+	}
+}
+
+func TestExecuteCandidateChecksDoesNotMatchGeneric200AsUnauthAPI(t *testing.T) {
+	server := newIPv4Server(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("<html>ok</html>"))
+	}))
+	defer server.Close()
+
+	host, port := serverHostPort(t, server)
+	results := ExecuteCandidateChecks(context.Background(), []CandidateCheck{{
+		CheckID: "vault/unauth-api",
+		Family:  "unauth-api",
+		Adapter: "vault",
+		Asset: Asset{
+			Host:    host,
+			Port:    port,
+			Service: "http",
+		},
+		Surface: &Surface{Path: "/v1/sys/health", MethodHints: []string{"GET"}},
+	}}, RuntimeConfig{
+		Timeout:  5 * time.Second,
+		Workers:  1,
+		Payloads: PayloadConfig{MaxPayloadsPerCandidate: 1},
+	})
+
+	if got, want := len(results), 1; got != want {
+		t.Fatalf("len(results) = %d, want %d", got, want)
+	}
+	if got := len(results[0].Evidence.Matches); got != 0 {
+		t.Fatalf("len(results[0].Evidence.Matches) = %d, want 0", got)
 	}
 }
 


### PR DESCRIPTION

- Added family-owned payload corpora and bounded request generation for open-redirect and traversal-read (Just for initial testing, this will significantly increase)
- Integrated generated requests into the verification runtime and surface request labels in `flan verify --run`
- Preserved intended pre-encoded payload variants instead of double-encoding them during query mutation
- Tightened runtime match logic 