### PR TITLE
Add thin nuclei runner to flan verify

### DIFF
--- a/cmd/flan/verify.go
+++ b/cmd/flan/verify.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"flag"
@@ -49,6 +50,7 @@ func runVerifyCommand(args []string, stdout, stderr io.Writer) error {
 	inputPath := fs.String("input", "", "")
 	inputShort := fs.String("i", "", "")
 	jsonFlag := fs.Bool("json", false, "")
+	runFlag := fs.Bool("run", false, "")
 	fs.Usage = func() {
 		fmt.Fprintln(stderr, "Usage:")
 		fmt.Fprintln(stderr, "  flan verify [flags]")
@@ -56,10 +58,12 @@ func runVerifyCommand(args []string, stdout, stderr io.Writer) error {
 		w := tabwriter.NewWriter(stderr, 0, 0, 2, ' ', 0)
 		fmt.Fprintf(w, "  --input, -i string\tpath to scan results in JSON or JSONL format; use - for stdin\n")
 		fmt.Fprintf(w, "  --json\toutput surface summary as JSON\n")
+		fmt.Fprintf(w, "  --run\trun nuclei against derived HTTP targets (requires nuclei on PATH)\n")
 		_ = w.Flush()
 		fmt.Fprintln(stderr)
 		fmt.Fprintln(stderr, "Examples:")
 		fmt.Fprintln(stderr, "  flan verify --input reports/scan-20260406-120000.json")
+		fmt.Fprintln(stderr, "  flan verify --input reports/scan-20260406-120000.json --run")
 		fmt.Fprintln(stderr, "  flan --jsonl -t scanme.nmap.org | flan verify --input -")
 	}
 	if err := fs.Parse(args); err != nil {
@@ -88,10 +92,17 @@ func runVerifyCommand(args []string, stdout, stderr io.Writer) error {
 	if err != nil {
 		return err
 	}
+	if *jsonFlag && *runFlag {
+		return errors.New("--json cannot be combined with --run")
+	}
 
 	summary := verifySummary{
 		InputPath: path,
 		Results:   len(results),
+	}
+	if *runFlag {
+		targets := verifymodel.NucleiTargetsFromScanResults(results)
+		return verifymodel.RunNuclei(context.Background(), stdout, stderr, targets)
 	}
 	if *jsonFlag {
 		for _, result := range results {

--- a/internal/verify/nuclei.go
+++ b/internal/verify/nuclei.go
@@ -1,0 +1,87 @@
+package verify
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"slices"
+	"strings"
+
+	"github.com/therandomsecurityguy/flan-go-scan/internal/scanner"
+)
+
+func NucleiTargetsFromScanResults(results []scanner.ScanResult) []string {
+	if len(results) == 0 {
+		return nil
+	}
+
+	seen := make(map[string]struct{}, len(results)*2)
+	targets := make([]string, 0, len(results)*2)
+	for _, result := range results {
+		if !scanner.IsHTTPService(result.Service, result.Port, result.TLS != nil) {
+			continue
+		}
+		scheme := scanner.HTTPScheme(result.TLS != nil || strings.Contains(strings.ToLower(result.Service), "https"))
+		host := nucleiURLHost(result.Host)
+		if host == "" {
+			continue
+		}
+		for _, surface := range SurfacesFromScanResult(result) {
+			target := fmt.Sprintf("%s://%s:%d%s", scheme, host, result.Port, normalizeSurfacePath(surface.Path))
+			if _, ok := seen[target]; ok {
+				continue
+			}
+			seen[target] = struct{}{}
+			targets = append(targets, target)
+		}
+	}
+	slices.Sort(targets)
+	return targets
+}
+
+func RunNuclei(ctx context.Context, stdout, stderr io.Writer, targets []string) error {
+	if len(targets) == 0 {
+		return errors.New("no HTTP targets available for nuclei")
+	}
+	nucleiPath, err := exec.LookPath("nuclei")
+	if err != nil {
+		return errors.New("nuclei not found on PATH")
+	}
+
+	targetFile, err := os.CreateTemp("", "flan-nuclei-targets-*.txt")
+	if err != nil {
+		return fmt.Errorf("create nuclei targets file: %w", err)
+	}
+	targetFilePath := targetFile.Name()
+	defer os.Remove(targetFilePath)
+	defer targetFile.Close()
+
+	if _, err := targetFile.WriteString(strings.Join(targets, "\n") + "\n"); err != nil {
+		return fmt.Errorf("write nuclei targets file: %w", err)
+	}
+	if err := targetFile.Close(); err != nil {
+		return fmt.Errorf("close nuclei targets file: %w", err)
+	}
+
+	cmd := exec.CommandContext(ctx, nucleiPath, "-l", targetFilePath, "-duc")
+	cmd.Stdout = stdout
+	cmd.Stderr = stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("run nuclei: %w", err)
+	}
+	return nil
+}
+
+func nucleiURLHost(host string) string {
+	host = strings.TrimSpace(host)
+	if host == "" {
+		return ""
+	}
+	if strings.Contains(host, ":") && !strings.HasPrefix(host, "[") {
+		return "[" + host + "]"
+	}
+	return host
+}


### PR DESCRIPTION

- Derive HTTP targets from existing scan artifacts and invoke nuclei from PATH using `--verify`
- Kept flan verify summary mode intact and reject --json --run
