### PR TITLE
Add nuclei run bundles and template passthrough

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 reports/
+artifacts/
 .DS_Store
 scan-state.json
 /flan-go-scan

--- a/cmd/flan/verify.go
+++ b/cmd/flan/verify.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"text/tabwriter"
 
 	"github.com/therandomsecurityguy/flan-go-scan/internal/output"
@@ -51,6 +52,10 @@ func runVerifyCommand(args []string, stdout, stderr io.Writer) error {
 	inputShort := fs.String("i", "", "")
 	jsonFlag := fs.Bool("json", false, "")
 	runFlag := fs.Bool("run", false, "")
+	templatesFlag := fs.String("templates", "", "")
+	templateURLFlag := fs.String("template-url", "", "")
+	workflowsFlag := fs.String("workflows", "", "")
+	workflowURLFlag := fs.String("workflow-url", "", "")
 	fs.Usage = func() {
 		fmt.Fprintln(stderr, "Usage:")
 		fmt.Fprintln(stderr, "  flan verify [flags]")
@@ -59,6 +64,10 @@ func runVerifyCommand(args []string, stdout, stderr io.Writer) error {
 		fmt.Fprintf(w, "  --input, -i string\tpath to scan results in JSON or JSONL format; use - for stdin\n")
 		fmt.Fprintf(w, "  --json\toutput surface summary as JSON\n")
 		fmt.Fprintf(w, "  --run\trun nuclei against derived HTTP targets (requires nuclei on PATH)\n")
+		fmt.Fprintf(w, "  --templates string\tcomma-separated nuclei template files or directories\n")
+		fmt.Fprintf(w, "  --template-url string\tcomma-separated remote nuclei template URLs\n")
+		fmt.Fprintf(w, "  --workflows string\tcomma-separated nuclei workflow files or directories\n")
+		fmt.Fprintf(w, "  --workflow-url string\tcomma-separated remote nuclei workflow URLs\n")
 		_ = w.Flush()
 		fmt.Fprintln(stderr)
 		fmt.Fprintln(stderr, "Examples:")
@@ -102,7 +111,17 @@ func runVerifyCommand(args []string, stdout, stderr io.Writer) error {
 	}
 	if *runFlag {
 		targets := verifymodel.NucleiTargetsFromScanResults(results)
-		return verifymodel.RunNuclei(context.Background(), stdout, stderr, targets)
+		bundle, err := verifymodel.RunNuclei(context.Background(), stdout, stderr, verifymodel.NucleiRunOptions{
+			ArtifactRoot: filepath.Join("artifacts", "verify"),
+			Templates:    splitCSV(*templatesFlag),
+			TemplateURLs: splitCSV(*templateURLFlag),
+			Workflows:    splitCSV(*workflowsFlag),
+			WorkflowURLs: splitCSV(*workflowURLFlag),
+		}, targets)
+		if bundle != nil {
+			fmt.Fprintf(stderr, "nuclei run bundle: %s\n", bundle.Directory)
+		}
+		return err
 	}
 	if *jsonFlag {
 		for _, result := range results {

--- a/cmd/flan/verify_test.go
+++ b/cmd/flan/verify_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -91,6 +92,89 @@ func TestRunVerifyCommandPlainSummaryIncludesSurfaceDetails(t *testing.T) {
 	}
 	if !strings.Contains(got, "1.1.1.1:80/ source=service service=http") {
 		t.Fatalf("expected inferred service surface in output, got %q", got)
+	}
+}
+
+func TestRunVerifyCommandRunPassesTemplateSourcesToNuclei(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell-based fake nuclei binary requires unix-like shell")
+	}
+
+	path := writeVerifyInput(t, `[{"host":"1.1.1.1","port":80,"protocol":"tcp","service":"http","endpoints":[{"path":"/login","status_code":200}]}]`)
+	binDir := t.TempDir()
+	argsPath := filepath.Join(binDir, "args.txt")
+	nucleiPath := filepath.Join(binDir, "nuclei")
+	script := `#!/bin/sh
+set -eu
+printf '%s
+' "$@" > "$NUCLEI_ARGS_PATH"
+jsonl=""
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -jle)
+      jsonl="$2"
+      shift 2
+      ;;
+    *)
+      shift
+      ;;
+  esac
+done
+: > "$jsonl"
+`
+	if err := os.WriteFile(nucleiPath, []byte(script), 0700); err != nil {
+		t.Fatalf("write fake nuclei: %v", err)
+	}
+
+	oldPath := os.Getenv("PATH")
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+oldPath)
+	t.Setenv("NUCLEI_ARGS_PATH", argsPath)
+
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	tempWorkDir := t.TempDir()
+	if err := os.Chdir(tempWorkDir); err != nil {
+		t.Fatalf("chdir temp work dir: %v", err)
+	}
+	defer os.Chdir(wd)
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	err = runVerifyCommand([]string{
+		"--input", path,
+		"--run",
+		"--templates", "http/exposures,custom/login.yaml",
+		"--template-url", "https://templates.example.com/exposure.yaml",
+		"--workflows", "workflows/external",
+		"--workflow-url", "https://templates.example.com/workflow.yaml",
+	}, &stdout, &stderr)
+	if err != nil {
+		t.Fatalf("runVerifyCommand returned error: %v", err)
+	}
+
+	argsBytes, err := os.ReadFile(argsPath)
+	if err != nil {
+		t.Fatalf("read captured args: %v", err)
+	}
+	gotArgs := string(argsBytes)
+	for _, expected := range []string{
+		"-t",
+		"http/exposures,custom/login.yaml",
+		"-turl",
+		"https://templates.example.com/exposure.yaml",
+		"-w",
+		"workflows/external",
+		"-wurl",
+		"https://templates.example.com/workflow.yaml",
+	} {
+		if !strings.Contains(gotArgs, expected) {
+			t.Fatalf("expected %q in nuclei args, got %q", expected, gotArgs)
+		}
+	}
+	if !strings.Contains(stderr.String(), "nuclei run bundle:") {
+		t.Fatalf("expected run bundle path in stderr, got %q", stderr.String())
 	}
 }
 

--- a/internal/verify/nuclei.go
+++ b/internal/verify/nuclei.go
@@ -2,24 +2,76 @@ package verify
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"slices"
 	"strings"
+	"time"
 
 	"github.com/therandomsecurityguy/flan-go-scan/internal/scanner"
 )
 
-func NucleiTargetsFromScanResults(results []scanner.ScanResult) []string {
+type NucleiTarget struct {
+	URL       string   `json:"url"`
+	Host      string   `json:"host"`
+	Port      int      `json:"port"`
+	Service   string   `json:"service,omitempty"`
+	Source    string   `json:"source,omitempty"`
+	Path      string   `json:"path"`
+	AuthHints []string `json:"auth_hints,omitempty"`
+}
+
+type NucleiRunBundle struct {
+	RunID           string
+	Directory       string
+	ManifestPath    string
+	TargetsPath     string
+	TargetMapPath   string
+	NucleiJSONLPath string
+	StdoutLogPath   string
+	StderrLogPath   string
+}
+
+type NucleiRunOptions struct {
+	ArtifactRoot string
+	Templates    []string
+	TemplateURLs []string
+	Workflows    []string
+	WorkflowURLs []string
+}
+
+type NucleiRunManifest struct {
+	RunID           string   `json:"run_id"`
+	Status          string   `json:"status"`
+	CreatedAt       string   `json:"created_at"`
+	CompletedAt     string   `json:"completed_at,omitempty"`
+	TargetCount     int      `json:"target_count"`
+	NucleiBinary    string   `json:"nuclei_binary"`
+	Command         []string `json:"command"`
+	TargetsFile     string   `json:"targets_file"`
+	TargetMapFile   string   `json:"target_map_file"`
+	NucleiJSONLFile string   `json:"nuclei_jsonl_file"`
+	StdoutLogFile   string   `json:"stdout_log_file"`
+	StderrLogFile   string   `json:"stderr_log_file"`
+	Templates       []string `json:"templates,omitempty"`
+	TemplateURLs    []string `json:"template_urls,omitempty"`
+	Workflows       []string `json:"workflows,omitempty"`
+	WorkflowURLs    []string `json:"workflow_urls,omitempty"`
+	ExitCode        int      `json:"exit_code,omitempty"`
+	Error           string   `json:"error,omitempty"`
+}
+
+func NucleiTargetsFromScanResults(results []scanner.ScanResult) []NucleiTarget {
 	if len(results) == 0 {
 		return nil
 	}
 
-	seen := make(map[string]struct{}, len(results)*2)
-	targets := make([]string, 0, len(results)*2)
+	seen := make(map[string]NucleiTarget, len(results)*2)
 	for _, result := range results {
 		if !scanner.IsHTTPService(result.Service, result.Port, result.TLS != nil) {
 			continue
@@ -30,49 +82,113 @@ func NucleiTargetsFromScanResults(results []scanner.ScanResult) []string {
 			continue
 		}
 		for _, surface := range SurfacesFromScanResult(result) {
-			target := fmt.Sprintf("%s://%s:%d%s", scheme, host, result.Port, normalizeSurfacePath(surface.Path))
-			if _, ok := seen[target]; ok {
+			targetURL := fmt.Sprintf("%s://%s:%d%s", scheme, host, result.Port, normalizeSurfacePath(surface.Path))
+			if _, ok := seen[targetURL]; ok {
 				continue
 			}
-			seen[target] = struct{}{}
-			targets = append(targets, target)
+			seen[targetURL] = NucleiTarget{
+				URL:       targetURL,
+				Host:      result.Host,
+				Port:      result.Port,
+				Service:   result.Service,
+				Source:    surface.Source,
+				Path:      normalizeSurfacePath(surface.Path),
+				AuthHints: slices.Clone(surface.AuthHints),
+			}
 		}
 	}
-	slices.Sort(targets)
+
+	urls := make([]string, 0, len(seen))
+	for url := range seen {
+		urls = append(urls, url)
+	}
+	slices.Sort(urls)
+
+	targets := make([]NucleiTarget, 0, len(urls))
+	for _, url := range urls {
+		targets = append(targets, seen[url])
+	}
 	return targets
 }
 
-func RunNuclei(ctx context.Context, stdout, stderr io.Writer, targets []string) error {
+func RunNuclei(ctx context.Context, stdout, stderr io.Writer, options NucleiRunOptions, targets []NucleiTarget) (*NucleiRunBundle, error) {
 	if len(targets) == 0 {
-		return errors.New("no HTTP targets available for nuclei")
+		return nil, errors.New("no HTTP targets available for nuclei")
+	}
+	if strings.TrimSpace(options.ArtifactRoot) == "" {
+		return nil, errors.New("artifact root is required")
 	}
 	nucleiPath, err := exec.LookPath("nuclei")
 	if err != nil {
-		return errors.New("nuclei not found on PATH")
+		return nil, errors.New("nuclei not found on PATH")
 	}
 
-	targetFile, err := os.CreateTemp("", "flan-nuclei-targets-*.txt")
+	bundle, err := createNucleiRunBundle(options.ArtifactRoot, targets)
 	if err != nil {
-		return fmt.Errorf("create nuclei targets file: %w", err)
-	}
-	targetFilePath := targetFile.Name()
-	defer os.Remove(targetFilePath)
-	defer targetFile.Close()
-
-	if _, err := targetFile.WriteString(strings.Join(targets, "\n") + "\n"); err != nil {
-		return fmt.Errorf("write nuclei targets file: %w", err)
-	}
-	if err := targetFile.Close(); err != nil {
-		return fmt.Errorf("close nuclei targets file: %w", err)
+		return nil, err
 	}
 
-	cmd := exec.CommandContext(ctx, nucleiPath, "-l", targetFilePath, "-duc")
-	cmd.Stdout = stdout
-	cmd.Stderr = stderr
+	stdoutLog, err := os.Create(bundle.StdoutLogPath)
+	if err != nil {
+		return bundle, fmt.Errorf("create stdout log: %w", err)
+	}
+	defer stdoutLog.Close()
+
+	stderrLog, err := os.Create(bundle.StderrLogPath)
+	if err != nil {
+		return bundle, fmt.Errorf("create stderr log: %w", err)
+	}
+	defer stderrLog.Close()
+
+	cmdArgs := []string{"-l", bundle.TargetsPath, "-duc", "-jle", bundle.NucleiJSONLPath}
+	cmdArgs = appendNucleiTemplateSourceArgs(cmdArgs, options)
+	manifest := NucleiRunManifest{
+		RunID:           bundle.RunID,
+		Status:          "running",
+		CreatedAt:       time.Now().UTC().Format(time.RFC3339Nano),
+		TargetCount:     len(targets),
+		NucleiBinary:    nucleiPath,
+		Command:         append([]string{nucleiPath}, cmdArgs...),
+		TargetsFile:     filepath.Base(bundle.TargetsPath),
+		TargetMapFile:   filepath.Base(bundle.TargetMapPath),
+		NucleiJSONLFile: filepath.Base(bundle.NucleiJSONLPath),
+		StdoutLogFile:   filepath.Base(bundle.StdoutLogPath),
+		StderrLogFile:   filepath.Base(bundle.StderrLogPath),
+		Templates:       slices.Clone(options.Templates),
+		TemplateURLs:    slices.Clone(options.TemplateURLs),
+		Workflows:       slices.Clone(options.Workflows),
+		WorkflowURLs:    slices.Clone(options.WorkflowURLs),
+	}
+	if err := writeNucleiRunManifest(bundle.ManifestPath, manifest); err != nil {
+		return bundle, err
+	}
+
+	cmd := exec.CommandContext(ctx, nucleiPath, cmdArgs...)
+	cmd.Stdout = io.MultiWriter(writerOrDiscard(stdout), stdoutLog)
+	cmd.Stderr = io.MultiWriter(writerOrDiscard(stderr), stderrLog)
 	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("run nuclei: %w", err)
+		manifest.Status = "failed"
+		manifest.CompletedAt = time.Now().UTC().Format(time.RFC3339Nano)
+		manifest.Error = err.Error()
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			manifest.ExitCode = exitErr.ExitCode()
+		} else {
+			manifest.ExitCode = -1
+		}
+		if writeErr := writeNucleiRunManifest(bundle.ManifestPath, manifest); writeErr != nil {
+			return bundle, fmt.Errorf("write nuclei manifest: %w", writeErr)
+		}
+		return bundle, fmt.Errorf("run nuclei: %w", err)
 	}
-	return nil
+
+	manifest.Status = "completed"
+	manifest.CompletedAt = time.Now().UTC().Format(time.RFC3339Nano)
+	manifest.ExitCode = 0
+	if err := writeNucleiRunManifest(bundle.ManifestPath, manifest); err != nil {
+		return bundle, err
+	}
+	return bundle, nil
 }
 
 func nucleiURLHost(host string) string {
@@ -84,4 +200,88 @@ func nucleiURLHost(host string) string {
 		return "[" + host + "]"
 	}
 	return host
+}
+
+func createNucleiRunBundle(artifactRoot string, targets []NucleiTarget) (*NucleiRunBundle, error) {
+	if err := os.MkdirAll(artifactRoot, 0755); err != nil {
+		return nil, fmt.Errorf("create artifact root: %w", err)
+	}
+
+	directory, err := os.MkdirTemp(artifactRoot, "run-")
+	if err != nil {
+		return nil, fmt.Errorf("create run bundle directory: %w", err)
+	}
+
+	bundle := &NucleiRunBundle{
+		RunID:           filepath.Base(directory),
+		Directory:       directory,
+		ManifestPath:    filepath.Join(directory, "manifest.json"),
+		TargetsPath:     filepath.Join(directory, "targets.txt"),
+		TargetMapPath:   filepath.Join(directory, "target-map.json"),
+		NucleiJSONLPath: filepath.Join(directory, "nuclei.jsonl"),
+		StdoutLogPath:   filepath.Join(directory, "stdout.log"),
+		StderrLogPath:   filepath.Join(directory, "stderr.log"),
+	}
+
+	urls := make([]string, 0, len(targets))
+	for _, target := range targets {
+		urls = append(urls, target.URL)
+	}
+	if err := os.WriteFile(bundle.TargetsPath, []byte(strings.Join(urls, "\n")+"\n"), 0600); err != nil {
+		return nil, fmt.Errorf("write nuclei targets file: %w", err)
+	}
+	if err := writeNucleiTargetMap(bundle.TargetMapPath, targets); err != nil {
+		return nil, err
+	}
+	if err := os.WriteFile(bundle.NucleiJSONLPath, nil, 0600); err != nil {
+		return nil, fmt.Errorf("initialize nuclei jsonl file: %w", err)
+	}
+	return bundle, nil
+}
+
+func writeNucleiTargetMap(path string, targets []NucleiTarget) error {
+	body, err := json.MarshalIndent(targets, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal target map: %w", err)
+	}
+	body = append(body, '\n')
+	if err := os.WriteFile(path, body, 0600); err != nil {
+		return fmt.Errorf("write target map: %w", err)
+	}
+	return nil
+}
+
+func writeNucleiRunManifest(path string, manifest NucleiRunManifest) error {
+	body, err := json.MarshalIndent(manifest, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal nuclei manifest: %w", err)
+	}
+	body = append(body, '\n')
+	if err := os.WriteFile(path, body, 0600); err != nil {
+		return fmt.Errorf("write nuclei manifest: %w", err)
+	}
+	return nil
+}
+
+func writerOrDiscard(w io.Writer) io.Writer {
+	if w == nil {
+		return io.Discard
+	}
+	return w
+}
+
+func appendNucleiTemplateSourceArgs(args []string, options NucleiRunOptions) []string {
+	if len(options.Templates) > 0 {
+		args = append(args, "-t", strings.Join(options.Templates, ","))
+	}
+	if len(options.TemplateURLs) > 0 {
+		args = append(args, "-turl", strings.Join(options.TemplateURLs, ","))
+	}
+	if len(options.Workflows) > 0 {
+		args = append(args, "-w", strings.Join(options.Workflows, ","))
+	}
+	if len(options.WorkflowURLs) > 0 {
+		args = append(args, "-wurl", strings.Join(options.WorkflowURLs, ","))
+	}
+	return args
 }


### PR DESCRIPTION
- Added local `artifacts/verify/<run-id>/` run bundles with manifest, targets, target map, raw nuclei.jsonl, and stdout/stderr logs
- Passed template paths, template URLs, workflows, and workflow URLs through flan `verify --run` and record them for reproducible runs