### PR TITLE
Add profile-driven nuclei execution planning

### DIFF
--- a/cmd/flan/verify.go
+++ b/cmd/flan/verify.go
@@ -56,6 +56,10 @@ func runVerifyCommand(args []string, stdout, stderr io.Writer) error {
 	templateURLFlag := fs.String("template-url", "", "")
 	workflowsFlag := fs.String("workflows", "", "")
 	workflowURLFlag := fs.String("workflow-url", "", "")
+	tagsFlag := fs.String("tags", "", "")
+	severityFlag := fs.String("severity", "", "")
+	rateLimitFlag := fs.Int("rate-limit", 0, "")
+	timeoutFlag := fs.Int("timeout", 0, "")
 	fs.Usage = func() {
 		fmt.Fprintln(stderr, "Usage:")
 		fmt.Fprintln(stderr, "  flan verify [flags]")
@@ -68,6 +72,10 @@ func runVerifyCommand(args []string, stdout, stderr io.Writer) error {
 		fmt.Fprintf(w, "  --template-url string\tcomma-separated remote nuclei template URLs\n")
 		fmt.Fprintf(w, "  --workflows string\tcomma-separated nuclei workflow files or directories\n")
 		fmt.Fprintf(w, "  --workflow-url string\tcomma-separated remote nuclei workflow URLs\n")
+		fmt.Fprintf(w, "  --tags string\tcomma-separated nuclei tags\n")
+		fmt.Fprintf(w, "  --severity string\tcomma-separated nuclei severities\n")
+		fmt.Fprintf(w, "  --rate-limit int\tnuclei requests per second\n")
+		fmt.Fprintf(w, "  --timeout int\tnuclei per-request timeout in seconds\n")
 		_ = w.Flush()
 		fmt.Fprintln(stderr)
 		fmt.Fprintln(stderr, "Examples:")
@@ -111,14 +119,21 @@ func runVerifyCommand(args []string, stdout, stderr io.Writer) error {
 	}
 	if *runFlag {
 		targets := verifymodel.NucleiTargetsFromScanResults(results)
-		bundle, err := verifymodel.RunNuclei(context.Background(), stdout, stderr, verifymodel.NucleiRunOptions{
+		bundles, err := verifymodel.RunNuclei(context.Background(), stdout, stderr, verifymodel.NucleiRunOptions{
 			ArtifactRoot: filepath.Join("artifacts", "verify"),
 			Templates:    splitCSV(*templatesFlag),
 			TemplateURLs: splitCSV(*templateURLFlag),
 			Workflows:    splitCSV(*workflowsFlag),
 			WorkflowURLs: splitCSV(*workflowURLFlag),
+			Tags:         splitCSV(*tagsFlag),
+			Severity:     splitCSV(*severityFlag),
+			RateLimit:    *rateLimitFlag,
+			Timeout:      *timeoutFlag,
 		}, targets)
-		if bundle != nil {
+		for _, bundle := range bundles {
+			if bundle == nil {
+				continue
+			}
 			fmt.Fprintf(stderr, "nuclei run bundle: %s\n", bundle.Directory)
 		}
 		return err

--- a/cmd/flan/verify_test.go
+++ b/cmd/flan/verify_test.go
@@ -95,6 +95,141 @@ func TestRunVerifyCommandPlainSummaryIncludesSurfaceDetails(t *testing.T) {
 	}
 }
 
+func TestRunVerifyCommandRunAutoSelectsBoundedProfilesAndControls(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell-based fake nuclei binary requires unix-like shell")
+	}
+
+	path := writeVerifyInput(t, `[{"host":"1.1.1.1","port":443,"protocol":"tcp","service":"https","endpoints":[{"path":"/login","status_code":200},{"path":"/graphql","status_code":200},{"path":"/openapi.json","status_code":200}],"products":[{"name":"Grafana","confidence":"high"}]},{"host":"2.2.2.2","port":80,"protocol":"tcp","service":"http","endpoints":[{"path":"/login","status_code":200}]}]`)
+	binDir := t.TempDir()
+	argsPath := filepath.Join(binDir, "args.txt")
+	targetCopiesDir := filepath.Join(binDir, "targets")
+	nucleiPath := filepath.Join(binDir, "nuclei")
+	script := `#!/bin/sh
+set -eu
+count_file="${NUCLEI_CALL_COUNT_PATH}"
+count=0
+if [ -f "$count_file" ]; then
+  count="$(cat "$count_file")"
+fi
+count=$((count + 1))
+printf '%s' "$count" > "$count_file"
+printf -- '--- call %s ---\n' "$count" >> "$NUCLEI_ARGS_PATH"
+printf '%s\n' "$@" >> "$NUCLEI_ARGS_PATH"
+targets_file=""
+jsonl=""
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -l)
+      targets_file="$2"
+      shift 2
+      ;;
+    -jle)
+      jsonl="$2"
+      shift 2
+      ;;
+    *)
+      shift
+      ;;
+  esac
+done
+cp "$targets_file" "$NUCLEI_TARGETS_DIR/call-$count.txt"
+: > "$jsonl"
+`
+	if err := os.WriteFile(nucleiPath, []byte(script), 0700); err != nil {
+		t.Fatalf("write fake nuclei: %v", err)
+	}
+	if err := os.MkdirAll(targetCopiesDir, 0700); err != nil {
+		t.Fatalf("mkdir target copies dir: %v", err)
+	}
+
+	oldPath := os.Getenv("PATH")
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+oldPath)
+	t.Setenv("NUCLEI_ARGS_PATH", argsPath)
+	t.Setenv("NUCLEI_TARGETS_DIR", targetCopiesDir)
+	t.Setenv("NUCLEI_CALL_COUNT_PATH", filepath.Join(binDir, "call-count.txt"))
+
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	tempWorkDir := t.TempDir()
+	if err := os.Chdir(tempWorkDir); err != nil {
+		t.Fatalf("chdir temp work dir: %v", err)
+	}
+	defer os.Chdir(wd)
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	err = runVerifyCommand([]string{
+		"--input", path,
+		"--run",
+		"--severity", "high,critical",
+		"--rate-limit", "25",
+		"--timeout", "5",
+	}, &stdout, &stderr)
+	if err != nil {
+		t.Fatalf("runVerifyCommand returned error: %v", err)
+	}
+
+	argsBytes, err := os.ReadFile(argsPath)
+	if err != nil {
+		t.Fatalf("read captured args: %v", err)
+	}
+	gotArgs := string(argsBytes)
+	for _, expected := range []string{
+		"-s",
+		"critical,high",
+		"-rl",
+		"25",
+		"-timeout",
+		"5",
+	} {
+		if !strings.Contains(gotArgs, expected) {
+			t.Fatalf("expected %q in nuclei args, got %q", expected, gotArgs)
+		}
+	}
+	if got := strings.Count(gotArgs, "--- call "); got < 2 {
+		t.Fatalf("expected multiple grouped nuclei calls, got %d; args=%q", got, gotArgs)
+	}
+	if !strings.Contains(gotArgs, "http/misconfiguration/graphql") || !strings.Contains(gotArgs, "workflows/grafana-workflow.yaml") || !strings.Contains(gotArgs, "ssl/tls-version.yaml") {
+		t.Fatalf("expected API/observability/TLS selectors in grouped args, got %q", gotArgs)
+	}
+
+	targetEntries, err := os.ReadDir(targetCopiesDir)
+	if err != nil {
+		t.Fatalf("read target copies dir: %v", err)
+	}
+	if len(targetEntries) < 2 {
+		t.Fatalf("expected multiple grouped target files, got %d", len(targetEntries))
+	}
+
+	seenContents := make(map[string]struct{}, len(targetEntries))
+	combinedTargets := strings.Builder{}
+	for _, entry := range targetEntries {
+		contentBytes, err := os.ReadFile(filepath.Join(targetCopiesDir, entry.Name()))
+		if err != nil {
+			t.Fatalf("read grouped target file %s: %v", entry.Name(), err)
+		}
+		content := string(contentBytes)
+		seenContents[content] = struct{}{}
+		combinedTargets.WriteString(content)
+		if strings.Contains(content, "https://1.1.1.1:443/openapi.json") && strings.Contains(content, "http://2.2.2.2:80/login") {
+			t.Fatalf("expected grouped target files to avoid mixed selector unions, got %q", content)
+		}
+	}
+	if len(seenContents) < 2 {
+		t.Fatalf("expected grouped target files to differ, got %d unique files", len(seenContents))
+	}
+	allTargets := combinedTargets.String()
+	if !strings.Contains(allTargets, "https://1.1.1.1:443/openapi.json") {
+		t.Fatalf("expected API target in grouped target files, got %q", allTargets)
+	}
+	if !strings.Contains(allTargets, "http://2.2.2.2:80/login") {
+		t.Fatalf("expected plain login target in grouped target files, got %q", allTargets)
+	}
+}
+
 func TestRunVerifyCommandRunPassesTemplateSourcesToNuclei(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("shell-based fake nuclei binary requires unix-like shell")
@@ -161,7 +296,7 @@ done
 	gotArgs := string(argsBytes)
 	for _, expected := range []string{
 		"-t",
-		"http/exposures,custom/login.yaml",
+		"custom/login.yaml,http/exposures",
 		"-turl",
 		"https://templates.example.com/exposure.yaml",
 		"-w",
@@ -171,6 +306,14 @@ done
 	} {
 		if !strings.Contains(gotArgs, expected) {
 			t.Fatalf("expected %q in nuclei args, got %q", expected, gotArgs)
+		}
+	}
+	for _, unexpected := range []string{
+		"http/technologies/tech-detect.yaml",
+		"workflows/grafana-workflow.yaml",
+	} {
+		if strings.Contains(gotArgs, unexpected) {
+			t.Fatalf("did not expect auto-selected %q in nuclei args, got %q", unexpected, gotArgs)
 		}
 	}
 	if !strings.Contains(stderr.String(), "nuclei run bundle:") {

--- a/internal/verify/nuclei.go
+++ b/internal/verify/nuclei.go
@@ -10,6 +10,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"slices"
+	"strconv"
 	"strings"
 	"time"
 
@@ -17,13 +18,21 @@ import (
 )
 
 type NucleiTarget struct {
-	URL       string   `json:"url"`
-	Host      string   `json:"host"`
-	Port      int      `json:"port"`
-	Service   string   `json:"service,omitempty"`
-	Source    string   `json:"source,omitempty"`
-	Path      string   `json:"path"`
-	AuthHints []string `json:"auth_hints,omitempty"`
+	AssetID         string   `json:"asset_id,omitempty"`
+	URL             string   `json:"url"`
+	Host            string   `json:"host"`
+	Port            int      `json:"port"`
+	Scheme          string   `json:"scheme,omitempty"`
+	Service         string   `json:"service,omitempty"`
+	Source          string   `json:"source,omitempty"`
+	Path            string   `json:"path"`
+	AuthHints       []string `json:"auth_hints,omitempty"`
+	Products        []string `json:"products,omitempty"`
+	Profiles        []string `json:"profiles,omitempty"`
+	ProviderContext []string `json:"provider_context,omitempty"`
+	SafetyLevel     string   `json:"safety_level,omitempty"`
+	TLS             bool     `json:"tls,omitempty"`
+	Kubernetes      bool     `json:"kubernetes,omitempty"`
 }
 
 type NucleiRunBundle struct {
@@ -43,6 +52,16 @@ type NucleiRunOptions struct {
 	TemplateURLs []string
 	Workflows    []string
 	WorkflowURLs []string
+	Tags         []string
+	Severity     []string
+	Profiles     []string
+	RateLimit    int
+	Timeout      int
+}
+
+type NucleiExecutionPlan struct {
+	Options NucleiRunOptions
+	Targets []NucleiTarget
 }
 
 type NucleiRunManifest struct {
@@ -62,6 +81,11 @@ type NucleiRunManifest struct {
 	TemplateURLs    []string `json:"template_urls,omitempty"`
 	Workflows       []string `json:"workflows,omitempty"`
 	WorkflowURLs    []string `json:"workflow_urls,omitempty"`
+	Tags            []string `json:"tags,omitempty"`
+	Severity        []string `json:"severity,omitempty"`
+	Profiles        []string `json:"profiles,omitempty"`
+	RateLimit       int      `json:"rate_limit,omitempty"`
+	Timeout         int      `json:"timeout,omitempty"`
 	ExitCode        int      `json:"exit_code,omitempty"`
 	Error           string   `json:"error,omitempty"`
 }
@@ -81,19 +105,32 @@ func NucleiTargetsFromScanResults(results []scanner.ScanResult) []NucleiTarget {
 		if host == "" {
 			continue
 		}
+		products := scanResultProducts(result)
+		hasKubernetes := len(result.Kubernetes) > 0
+		providerContext := scanResultProviderContext(result)
+		assetID := fmt.Sprintf("%s:%d", result.Host, result.Port)
 		for _, surface := range SurfacesFromScanResult(result) {
 			targetURL := fmt.Sprintf("%s://%s:%d%s", scheme, host, result.Port, normalizeSurfacePath(surface.Path))
 			if _, ok := seen[targetURL]; ok {
 				continue
 			}
+			profiles := selectNucleiProfiles(result, surface, scheme)
 			seen[targetURL] = NucleiTarget{
-				URL:       targetURL,
-				Host:      result.Host,
-				Port:      result.Port,
-				Service:   result.Service,
-				Source:    surface.Source,
-				Path:      normalizeSurfacePath(surface.Path),
-				AuthHints: slices.Clone(surface.AuthHints),
+				AssetID:         assetID,
+				URL:             targetURL,
+				Host:            result.Host,
+				Port:            result.Port,
+				Scheme:          scheme,
+				Service:         result.Service,
+				Source:          surface.Source,
+				Path:            normalizeSurfacePath(surface.Path),
+				AuthHints:       slices.Clone(surface.AuthHints),
+				Products:        products,
+				Profiles:        profiles,
+				ProviderContext: providerContext,
+				SafetyLevel:     nucleiSafetyLevelSafe,
+				TLS:             result.TLS != nil || scheme == "https",
+				Kubernetes:      hasKubernetes,
 			}
 		}
 	}
@@ -111,7 +148,7 @@ func NucleiTargetsFromScanResults(results []scanner.ScanResult) []NucleiTarget {
 	return targets
 }
 
-func RunNuclei(ctx context.Context, stdout, stderr io.Writer, options NucleiRunOptions, targets []NucleiTarget) (*NucleiRunBundle, error) {
+func RunNuclei(ctx context.Context, stdout, stderr io.Writer, options NucleiRunOptions, targets []NucleiTarget) ([]*NucleiRunBundle, error) {
 	if len(targets) == 0 {
 		return nil, errors.New("no HTTP targets available for nuclei")
 	}
@@ -123,6 +160,25 @@ func RunNuclei(ctx context.Context, stdout, stderr io.Writer, options NucleiRunO
 		return nil, errors.New("nuclei not found on PATH")
 	}
 
+	plans := planNucleiExecutions(options, targets)
+	if len(plans) == 0 {
+		return nil, errors.New("no nuclei execution plans derived from targets")
+	}
+
+	bundles := make([]*NucleiRunBundle, 0, len(plans))
+	for _, plan := range plans {
+		bundle, err := runNucleiPlan(ctx, stdout, stderr, nucleiPath, plan.Options, plan.Targets)
+		if bundle != nil {
+			bundles = append(bundles, bundle)
+		}
+		if err != nil {
+			return bundles, err
+		}
+	}
+	return bundles, nil
+}
+
+func runNucleiPlan(ctx context.Context, stdout, stderr io.Writer, nucleiPath string, options NucleiRunOptions, targets []NucleiTarget) (*NucleiRunBundle, error) {
 	bundle, err := createNucleiRunBundle(options.ArtifactRoot, targets)
 	if err != nil {
 		return nil, err
@@ -141,7 +197,7 @@ func RunNuclei(ctx context.Context, stdout, stderr io.Writer, options NucleiRunO
 	defer stderrLog.Close()
 
 	cmdArgs := []string{"-l", bundle.TargetsPath, "-duc", "-jle", bundle.NucleiJSONLPath}
-	cmdArgs = appendNucleiTemplateSourceArgs(cmdArgs, options)
+	cmdArgs = appendNucleiSelectorArgs(cmdArgs, options)
 	manifest := NucleiRunManifest{
 		RunID:           bundle.RunID,
 		Status:          "running",
@@ -158,6 +214,11 @@ func RunNuclei(ctx context.Context, stdout, stderr io.Writer, options NucleiRunO
 		TemplateURLs:    slices.Clone(options.TemplateURLs),
 		Workflows:       slices.Clone(options.Workflows),
 		WorkflowURLs:    slices.Clone(options.WorkflowURLs),
+		Tags:            slices.Clone(options.Tags),
+		Severity:        slices.Clone(options.Severity),
+		Profiles:        slices.Clone(options.Profiles),
+		RateLimit:       options.RateLimit,
+		Timeout:         options.Timeout,
 	}
 	if err := writeNucleiRunManifest(bundle.ManifestPath, manifest); err != nil {
 		return bundle, err
@@ -284,4 +345,257 @@ func appendNucleiTemplateSourceArgs(args []string, options NucleiRunOptions) []s
 		args = append(args, "-wurl", strings.Join(options.WorkflowURLs, ","))
 	}
 	return args
+}
+
+func appendNucleiSelectorArgs(args []string, options NucleiRunOptions) []string {
+	args = appendNucleiTemplateSourceArgs(args, options)
+	if len(options.Tags) > 0 {
+		args = append(args, "-tags", strings.Join(options.Tags, ","))
+	}
+	if len(options.Severity) > 0 {
+		args = append(args, "-s", strings.Join(options.Severity, ","))
+	}
+	if options.RateLimit > 0 {
+		args = append(args, "-rl", strconv.Itoa(options.RateLimit))
+	}
+	if options.Timeout > 0 {
+		args = append(args, "-timeout", strconv.Itoa(options.Timeout))
+	}
+	return args
+}
+
+func planNucleiExecutions(options NucleiRunOptions, targets []NucleiTarget) []NucleiExecutionPlan {
+	if len(targets) == 0 {
+		return nil
+	}
+
+	sortedTargets := slices.Clone(targets)
+	slices.SortFunc(sortedTargets, func(a, b NucleiTarget) int {
+		return strings.Compare(a.URL, b.URL)
+	})
+
+	if hasExplicitNucleiSelectors(options) {
+		return []NucleiExecutionPlan{{
+			Options: normalizeNucleiRunOptions(options),
+			Targets: sortedTargets,
+		}}
+	}
+
+	grouped := make(map[string]*NucleiExecutionPlan)
+	for _, target := range sortedTargets {
+		plannedOptions := applyAutoNucleiSelectors(options, []NucleiTarget{target})
+		key := nucleiExecutionPlanKey(plannedOptions)
+		plan, ok := grouped[key]
+		if !ok {
+			grouped[key] = &NucleiExecutionPlan{
+				Options: plannedOptions,
+				Targets: []NucleiTarget{target},
+			}
+			continue
+		}
+		plan.Targets = append(plan.Targets, target)
+	}
+
+	keys := make([]string, 0, len(grouped))
+	for key := range grouped {
+		keys = append(keys, key)
+	}
+	slices.Sort(keys)
+
+	plans := make([]NucleiExecutionPlan, 0, len(keys))
+	for _, key := range keys {
+		plans = append(plans, *grouped[key])
+	}
+	return plans
+}
+
+func applyAutoNucleiSelectors(options NucleiRunOptions, targets []NucleiTarget) NucleiRunOptions {
+	if hasExplicitNucleiSelectors(options) {
+		return normalizeNucleiRunOptions(options)
+	}
+
+	profilesSeen := make(map[string]struct{})
+	for _, target := range targets {
+		for _, profile := range target.Profiles {
+			profilesSeen[profile] = struct{}{}
+		}
+	}
+	if len(profilesSeen) == 0 {
+		profilesSeen[nucleiProfileBaselineWeb] = struct{}{}
+	}
+
+	profiles := make([]string, 0, len(profilesSeen))
+	for profile := range profilesSeen {
+		profiles = append(profiles, profile)
+	}
+	slices.Sort(profiles)
+
+	options.Profiles = profiles
+	options.Templates = dedupeStrings(append(options.Templates, compileNucleiProfileTemplates(profiles)...))
+	options.Workflows = dedupeStrings(append(options.Workflows, compileNucleiProfileWorkflows(profiles)...))
+	return normalizeNucleiRunOptions(options)
+}
+
+func nucleiExecutionPlanKey(options NucleiRunOptions) string {
+	normalized := normalizeNucleiRunOptions(options)
+	return strings.Join([]string{
+		strings.Join(normalized.Profiles, ","),
+		strings.Join(normalized.Templates, ","),
+		strings.Join(normalized.TemplateURLs, ","),
+		strings.Join(normalized.Workflows, ","),
+		strings.Join(normalized.WorkflowURLs, ","),
+		strings.Join(normalized.Tags, ","),
+		strings.Join(normalized.Severity, ","),
+		strconv.Itoa(normalized.RateLimit),
+		strconv.Itoa(normalized.Timeout),
+	}, "|")
+}
+
+func normalizeNucleiRunOptions(options NucleiRunOptions) NucleiRunOptions {
+	options.Templates = dedupeStrings(options.Templates)
+	options.TemplateURLs = dedupeStrings(options.TemplateURLs)
+	options.Workflows = dedupeStrings(options.Workflows)
+	options.WorkflowURLs = dedupeStrings(options.WorkflowURLs)
+	options.Tags = dedupeStrings(options.Tags)
+	options.Severity = dedupeStrings(options.Severity)
+	options.Profiles = dedupeStrings(options.Profiles)
+	return options
+}
+
+func hasExplicitNucleiSelectors(options NucleiRunOptions) bool {
+	return len(options.Templates) > 0 ||
+		len(options.TemplateURLs) > 0 ||
+		len(options.Workflows) > 0 ||
+		len(options.WorkflowURLs) > 0 ||
+		len(options.Tags) > 0
+}
+
+const (
+	nucleiProfileBaselineWeb    = "baseline-web"
+	nucleiProfileAPIExposure    = "api-exposure"
+	nucleiProfileSwaggerOpenAPI = "swagger-openapi"
+	nucleiProfileGraphQL        = "graphql"
+	nucleiProfileAuthSurface    = "auth-surface"
+	nucleiProfileObservability  = "observability"
+	nucleiProfileSSLTLS         = "ssl-tls"
+	nucleiProfileK8sExposure    = "k8s-exposure"
+
+	nucleiSafetyLevelSafe = "safe"
+)
+
+var nucleiProfileTemplates = map[string][]string{
+	nucleiProfileBaselineWeb: {
+		"http/technologies/tech-detect.yaml",
+		"http/technologies/favicon-detect.yaml",
+	},
+	nucleiProfileAPIExposure: {
+		"http/exposures/apis",
+	},
+	nucleiProfileSwaggerOpenAPI: {
+		"http/exposures/apis",
+	},
+	nucleiProfileGraphQL: {
+		"http/technologies/graphql-detect.yaml",
+		"http/technologies/graphiql-detect.yaml",
+		"http/misconfiguration/graphql",
+	},
+	nucleiProfileAuthSurface: {
+		"http/exposed-panels",
+	},
+	nucleiProfileSSLTLS: {
+		"ssl/tls-version.yaml",
+		"ssl/deprecated-tls.yaml",
+		"ssl/expired-ssl.yaml",
+		"ssl/self-signed-ssl.yaml",
+		"ssl/untrusted-root-certificate.yaml",
+		"ssl/mismatched-ssl-certificate.yaml",
+		"ssl/wildcard-tls.yaml",
+		"ssl/insecure-cipher-suite-detect.yaml",
+	},
+	nucleiProfileK8sExposure: {
+		"http/technologies/kubernetes",
+		"http/misconfiguration/kubernetes",
+		"http/exposed-panels/kubernetes-dashboard.yaml",
+	},
+}
+
+var nucleiProfileWorkflows = map[string][]string{
+	nucleiProfileObservability: {
+		"workflows/prometheus-workflow.yaml",
+		"workflows/grafana-workflow.yaml",
+	},
+}
+
+func compileNucleiProfileTemplates(profiles []string) []string {
+	var templates []string
+	for _, profile := range profiles {
+		templates = append(templates, nucleiProfileTemplates[profile]...)
+	}
+	return dedupeStrings(templates)
+}
+
+func compileNucleiProfileWorkflows(profiles []string) []string {
+	var workflows []string
+	for _, profile := range profiles {
+		workflows = append(workflows, nucleiProfileWorkflows[profile]...)
+	}
+	return dedupeStrings(workflows)
+}
+
+func selectNucleiProfiles(result scanner.ScanResult, surface Surface, scheme string) []string {
+	profiles := []string{nucleiProfileBaselineWeb}
+	path := strings.ToLower(normalizeSurfacePath(surface.Path))
+	service := strings.ToLower(strings.TrimSpace(result.Service))
+	productText := strings.Join(scanResultProducts(result), " ")
+
+	if strings.Contains(path, "/graphql") || strings.Contains(productText, "graphql") {
+		profiles = append(profiles, nucleiProfileGraphQL)
+	}
+	if strings.Contains(path, "/api") {
+		profiles = append(profiles, nucleiProfileAPIExposure)
+	}
+	if strings.Contains(path, "/openapi") || strings.Contains(path, "/swagger") {
+		profiles = append(profiles, nucleiProfileAPIExposure, nucleiProfileSwaggerOpenAPI)
+	}
+	if len(surface.AuthHints) > 0 {
+		profiles = append(profiles, nucleiProfileAuthSurface)
+	}
+	if strings.Contains(productText, "grafana") || strings.Contains(productText, "prometheus") || strings.Contains(path, "/metrics") {
+		profiles = append(profiles, nucleiProfileObservability)
+	}
+	if result.TLS != nil || scheme == "https" || strings.Contains(service, "ssl") || strings.Contains(service, "https") {
+		profiles = append(profiles, nucleiProfileSSLTLS)
+	}
+	if len(result.Kubernetes) > 0 || strings.Contains(productText, "kubernetes") {
+		profiles = append(profiles, nucleiProfileK8sExposure)
+	}
+	return dedupeStrings(profiles)
+}
+
+func scanResultProducts(result scanner.ScanResult) []string {
+	names := make([]string, 0, len(result.Products)+1)
+	for _, product := range result.Products {
+		if strings.TrimSpace(product.Name) != "" {
+			names = append(names, strings.ToLower(strings.TrimSpace(product.Name)))
+		}
+	}
+	if result.App != nil {
+		for _, product := range result.App.Products {
+			if strings.TrimSpace(product.Name) != "" {
+				names = append(names, strings.ToLower(strings.TrimSpace(product.Name)))
+			}
+		}
+	}
+	if len(result.Kubernetes) > 0 {
+		names = append(names, "kubernetes")
+	}
+	return dedupeStrings(names)
+}
+
+func scanResultProviderContext(result scanner.ScanResult) []string {
+	var context []string
+	if len(result.Kubernetes) > 0 {
+		context = append(context, "kubernetes")
+	}
+	return dedupeStrings(context)
 }


### PR DESCRIPTION

- Derived richer Nuclei target descriptors from Flan discovery output
- Mapped discovery signals to bounded verification profiles and compile them to Nuclei selectors
- Grouped Nuclei runs by selector set instead of unioning every target into one broad scan
- Added verify controls for tags, severity, rate limits, and timeouts while preserving explicit selector passthrough