### PR TITLE
Unify verify findings across native signals and nuclei

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,9 @@ Flan is a Swiss army knife network scanner in Go. Successor to [Flan Scan](https
 - Pretty streaming CLI output with TTY detection (JSONL when piping)
 - Per-run scan metadata report (`scan-metadata-*.json`) for auditability
 - JSON, JSONL (streaming), CSV, and text output
+- `flan verify` turns saved scan JSON/JSONL into operator-facing findings
+- Optional Nuclei-backed verification via `flan verify --run` with local run bundles under `artifacts/verify/`
+- Unified findings promote native signals such as `/metrics`, `/debug/pprof`, TLS trust issues, and linked sourcemap references into the same output stream as Nuclei matches
 - Domain-mode output keeps subdomain and IP context (`hostname (ip):port`)
 - Security header checks are evaluated on `2xx/3xx` HTTP responses; `4xx/5xx` responses are reported as skipped
 - Configurable via YAML
@@ -275,6 +278,30 @@ Use a custom asset context file for policy-aware AI analysis:
 flan -t api.example.com --context /path/to/context.yaml
 ```
 
+Turn saved scan output into operator-facing findings:
+
+```bash
+flan verify --input reports/scan-20260406-120000.json
+```
+
+Run Nuclei against derived HTTP surfaces and merge the results:
+
+```bash
+flan verify --input reports/scan-20260406-120000.json --run
+```
+
+Emit unified verify findings as JSON:
+
+```bash
+flan verify --input reports/scan-20260406-120000.json --run --json
+```
+
+Pipe a scan directly into `verify`:
+
+```bash
+flan -t api.example.com --crawl --jsonl | flan verify --input - --run
+```
+
 ## Runtime Behavior
 
 > [!NOTE]
@@ -297,6 +324,8 @@ dns:
 ```
 
 Use `--workers`, `--rate-limit`, and `--max-host-conns` to tune scan concurrency and make large inventory-backed runs gentler on shared targets and load-balanced services.
+
+When you run `flan verify --run`, Flan derives bounded HTTP targets from scan results, invokes the `nuclei` binary found on `PATH`, and stores per-run artifacts under `artifacts/verify/`. Each run bundle includes the target list, target map, Nuclei JSONL output, logs, and a manifest so operators can inspect or replay the verification step without vendoring templates into this repository.
 
 > [!TIP]
 Security-header findings are generated only for HTTP `2xx/3xx` responses. On `4xx/5xx` responses, which are common on load balancer and CDN default pages, Flan reports header checks as skipped instead of treating them as header failures.
@@ -434,6 +463,22 @@ If --kube-diff-against is omitted but --kube-inventory-out is set, Flan reuses t
 | `--json` | JSON output |
 | `--jsonl` | JSONL streaming output |
 | `--csv` | CSV output |
+
+### `flan verify` Flags
+
+| Flag | Description |
+|------|-------------|
+| `--input`, `-i` | Path to scan results in JSON or JSONL format; use `-` for stdin |
+| `--json` | Emit the unified verify summary and findings as JSON |
+| `--run` | Run Nuclei against derived HTTP targets and merge results into findings |
+| `--templates` | Comma-separated Nuclei template files or directories |
+| `--template-url` | Comma-separated remote Nuclei template URLs |
+| `--workflows` | Comma-separated Nuclei workflow files or directories |
+| `--workflow-url` | Comma-separated remote Nuclei workflow URLs |
+| `--tags` | Comma-separated Nuclei tags |
+| `--severity` | Comma-separated Nuclei severities |
+| `--rate-limit` | Nuclei requests per second |
+| `--timeout` | Nuclei per-request timeout in seconds |
 
 ## Tests
 

--- a/cmd/flan/verify.go
+++ b/cmd/flan/verify.go
@@ -9,8 +9,11 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"slices"
+	"strings"
 	"text/tabwriter"
 
+	"github.com/therandomsecurityguy/flan-go-scan/internal/findings"
 	"github.com/therandomsecurityguy/flan-go-scan/internal/output"
 	verifymodel "github.com/therandomsecurityguy/flan-go-scan/internal/verify"
 )
@@ -21,6 +24,8 @@ type verifySummary struct {
 	InputPath      string                 `json:"input_path"`
 	Results        int                    `json:"results"`
 	Surfaces       int                    `json:"surfaces"`
+	FindingCount   int                    `json:"finding_count,omitempty"`
+	Findings       []findings.Finding     `json:"findings,omitempty"`
 	SurfaceDetails []verifySurfaceSummary `json:"surface_details,omitempty"`
 }
 
@@ -109,17 +114,30 @@ func runVerifyCommand(args []string, stdout, stderr io.Writer) error {
 	if err != nil {
 		return err
 	}
-	if *jsonFlag && *runFlag {
-		return errors.New("--json cannot be combined with --run")
-	}
 
 	summary := verifySummary{
 		InputPath: path,
 		Results:   len(results),
 	}
+	for _, result := range results {
+		surfaces := verifymodel.SurfacesFromScanResult(result)
+		summary.Surfaces += len(surfaces)
+		for _, surface := range surfaces {
+			summary.SurfaceDetails = append(summary.SurfaceDetails, verifySurfaceSummary{
+				Host:      result.Host,
+				Port:      result.Port,
+				Service:   result.Service,
+				Source:    surface.Source,
+				Path:      surface.Path,
+				AuthHints: surface.AuthHints,
+			})
+		}
+	}
+
+	allFindings := findings.FromScanResults(results)
 	if *runFlag {
 		targets := verifymodel.NucleiTargetsFromScanResults(results)
-		bundles, err := verifymodel.RunNuclei(context.Background(), stdout, stderr, verifymodel.NucleiRunOptions{
+		bundles, err := verifymodel.RunNuclei(context.Background(), nil, stderr, verifymodel.NucleiRunOptions{
 			ArtifactRoot: filepath.Join("artifacts", "verify"),
 			Templates:    splitCSV(*templatesFlag),
 			TemplateURLs: splitCSV(*templateURLFlag),
@@ -136,33 +154,42 @@ func runVerifyCommand(args []string, stdout, stderr io.Writer) error {
 			}
 			fmt.Fprintf(stderr, "nuclei run bundle: %s\n", bundle.Directory)
 		}
-		return err
-	}
-	if *jsonFlag {
-		for _, result := range results {
-			surfaces := verifymodel.SurfacesFromScanResult(result)
-			summary.Surfaces += len(surfaces)
-			for _, surface := range surfaces {
-				summary.SurfaceDetails = append(summary.SurfaceDetails, verifySurfaceSummary{
-					Host:      result.Host,
-					Port:      result.Port,
-					Service:   result.Service,
-					Source:    surface.Source,
-					Path:      surface.Path,
-					AuthHints: surface.AuthHints,
-				})
-			}
+		if err != nil {
+			return err
 		}
+		nucleiFindings, err := findings.FromNucleiBundles(bundles)
+		if err != nil {
+			return err
+		}
+		allFindings = append(allFindings, nucleiFindings...)
+	}
+	sortFindings(allFindings)
+	summary.Findings = allFindings
+	summary.FindingCount = len(allFindings)
+
+	if *jsonFlag {
 		enc := json.NewEncoder(stdout)
 		enc.SetIndent("", "  ")
 		return enc.Encode(summary)
 	}
 
-	for _, result := range results {
-		summary.Surfaces += len(verifymodel.SurfacesFromScanResult(result))
-	}
 	fmt.Fprintf(stdout, "Loaded %d scan results\n", summary.Results)
 	fmt.Fprintf(stdout, "Surfaces: %d\n", summary.Surfaces)
+	fmt.Fprintf(stdout, "Findings: %d\n", summary.FindingCount)
+	for _, finding := range summary.Findings {
+		line := fmt.Sprintf("- [%s] %s", strings.ToUpper(finding.Severity), finding.Title)
+		location := finding.URL
+		if location == "" && finding.Path != "" {
+			location = fmt.Sprintf("%s:%d%s", finding.Host, finding.Port, finding.Path)
+		}
+		if location != "" {
+			line += "  " + location
+		}
+		if finding.Source != "" {
+			line += "  source=" + finding.Source
+		}
+		fmt.Fprintln(stdout, line)
+	}
 	for _, result := range results {
 		for _, surface := range verifymodel.SurfacesFromScanResult(result) {
 			line := fmt.Sprintf("- %s:%d%s", result.Host, result.Port, surface.Path)
@@ -176,6 +203,47 @@ func runVerifyCommand(args []string, stdout, stderr io.Writer) error {
 		}
 	}
 	return nil
+}
+
+func sortFindings(values []findings.Finding) {
+	slices.SortFunc(values, func(a, b findings.Finding) int {
+		if rank := compareSeverity(a.Severity, b.Severity); rank != 0 {
+			return rank
+		}
+		if rank := strings.Compare(a.Host, b.Host); rank != 0 {
+			return rank
+		}
+		if rank := strings.Compare(a.Path, b.Path); rank != 0 {
+			return rank
+		}
+		return strings.Compare(a.Title, b.Title)
+	})
+}
+
+func compareSeverity(a, b string) int {
+	order := map[string]int{
+		"critical": 0,
+		"high":     1,
+		"medium":   2,
+		"low":      3,
+		"info":     4,
+	}
+	left, ok := order[strings.ToLower(strings.TrimSpace(a))]
+	if !ok {
+		left = len(order)
+	}
+	right, ok := order[strings.ToLower(strings.TrimSpace(b))]
+	if !ok {
+		right = len(order)
+	}
+	switch {
+	case left < right:
+		return -1
+	case left > right:
+		return 1
+	default:
+		return 0
+	}
 }
 
 func stdinHasData() bool {

--- a/internal/findings/findings.go
+++ b/internal/findings/findings.go
@@ -1,0 +1,350 @@
+package findings
+
+import (
+	"bufio"
+	"crypto/sha1"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"os"
+	"path"
+	"strings"
+
+	"github.com/therandomsecurityguy/flan-go-scan/internal/scanner"
+	verifymodel "github.com/therandomsecurityguy/flan-go-scan/internal/verify"
+)
+
+type Finding struct {
+	ID          string   `json:"id"`
+	Source      string   `json:"source"`
+	Severity    string   `json:"severity"`
+	Title       string   `json:"title"`
+	Description string   `json:"description,omitempty"`
+	Remediation string   `json:"remediation,omitempty"`
+	Confidence  string   `json:"confidence,omitempty"`
+	Host        string   `json:"host"`
+	Hostname    string   `json:"hostname,omitempty"`
+	Port        int      `json:"port"`
+	Service     string   `json:"service,omitempty"`
+	AssetID     string   `json:"asset_id,omitempty"`
+	URL         string   `json:"url,omitempty"`
+	Path        string   `json:"path,omitempty"`
+	TemplateID  string   `json:"template_id,omitempty"`
+	MatcherName string   `json:"matcher_name,omitempty"`
+	Tags        []string `json:"tags,omitempty"`
+	Evidence    []string `json:"evidence,omitempty"`
+}
+
+func FromScanResults(results []scanner.ScanResult) []Finding {
+	findings := make([]Finding, 0, len(results)*2)
+	for _, result := range results {
+		findings = append(findings, nativeFindingsFromScanResult(result)...)
+	}
+	return findings
+}
+
+func FromNucleiBundles(bundles []*verifymodel.NucleiRunBundle) ([]Finding, error) {
+	findings := make([]Finding, 0, len(bundles))
+	for _, bundle := range bundles {
+		if bundle == nil {
+			continue
+		}
+		targetIndex, err := loadNucleiTargetIndex(bundle.TargetMapPath)
+		if err != nil {
+			return nil, err
+		}
+		bundleFindings, err := loadNucleiBundleFindings(bundle, targetIndex)
+		if err != nil {
+			return nil, err
+		}
+		findings = append(findings, bundleFindings...)
+	}
+	return dedupeFindings(findings), nil
+}
+
+func nativeFindingsFromScanResult(result scanner.ScanResult) []Finding {
+	findings := make([]Finding, 0, 4)
+
+	if result.TLS != nil && strings.TrimSpace(result.TLS.VerificationError) != "" {
+		findings = append(findings, newFinding(result, "high", "TLS Verification Failed", "", []string{
+			result.TLS.VerificationError,
+		}))
+	}
+	if result.TLSEnum != nil && len(result.TLSEnum.WeakVersions) > 0 {
+		findings = append(findings, newFinding(result, "medium", "Weak TLS Versions Enabled", "", []string{
+			"Supported deprecated versions: " + strings.Join(result.TLSEnum.WeakVersions, ", "),
+		}))
+	}
+
+	for _, endpoint := range result.Endpoints {
+		path := strings.TrimSpace(endpoint.Path)
+		switch {
+		case endpoint.StatusCode >= 200 && endpoint.StatusCode < 400 && path == "/metrics":
+			findings = append(findings, newFinding(result, "medium", "Metrics Endpoint Exposed", path, []string{
+				fmt.Sprintf("HTTP %d", endpoint.StatusCode),
+				strings.TrimSpace(endpoint.ContentType),
+			}))
+		case endpoint.StatusCode >= 200 && endpoint.StatusCode < 400 && strings.HasPrefix(path, "/debug/pprof"):
+			findings = append(findings, newFinding(result, "high", "Pprof Debug Endpoint Exposed", path, []string{
+				fmt.Sprintf("HTTP %d", endpoint.StatusCode),
+			}))
+		}
+		for _, asset := range endpoint.ExternalAssets {
+			if strings.TrimSpace(asset.Kind) != "sourcemap" || strings.TrimSpace(asset.URL) == "" {
+				continue
+			}
+			findings = append(findings, Finding{
+				ID:          fmt.Sprintf("%x", sha1.Sum([]byte(strings.Join([]string{"external-sourcemap", result.Host, asset.URL}, "|")))),
+				Source:      "native",
+				Severity:    "medium",
+				Title:       "External Sourcemap Reference Exposed",
+				Confidence:  "medium",
+				Host:        result.Host,
+				Hostname:    result.Hostname,
+				Port:        result.Port,
+				Service:     result.Service,
+				URL:         asset.URL,
+				Path:        asset.SourcePath,
+				Description: "A linked asset exposed a sourcemap reference outside the scanned origin.",
+				Evidence:    compactEvidence([]string{asset.SourceURL, asset.URL}),
+			})
+		}
+	}
+
+	return dedupeFindings(findings)
+}
+
+func newFinding(result scanner.ScanResult, severity, title, path string, evidence []string) Finding {
+	url := ""
+	if path != "" && scanner.IsHTTPService(result.Service, result.Port, result.TLS != nil) {
+		url = fmt.Sprintf("%s://%s:%d%s", scanner.HTTPScheme(result.TLS != nil), result.Host, result.Port, path)
+	}
+	base := strings.Join([]string{
+		title,
+		result.Host,
+		fmt.Sprintf("%d", result.Port),
+		path,
+	}, "|")
+	return Finding{
+		ID:         fmt.Sprintf("%x", sha1.Sum([]byte(base))),
+		Source:     "native",
+		Severity:   severity,
+		Title:      title,
+		Confidence: "high",
+		Host:       result.Host,
+		Hostname:   result.Hostname,
+		Port:       result.Port,
+		Service:    result.Service,
+		URL:        url,
+		Path:       path,
+		Evidence:   compactEvidence(evidence),
+	}
+}
+
+type nucleiJSONLInfo struct {
+	Name     string   `json:"name"`
+	Severity string   `json:"severity"`
+	Tags     []string `json:"tags"`
+}
+
+type nucleiJSONLRecord struct {
+	TemplateID  string          `json:"template-id"`
+	MatcherName string          `json:"matcher-name"`
+	MatchedAt   string          `json:"matched-at"`
+	Host        string          `json:"host"`
+	Type        string          `json:"type"`
+	Info        nucleiJSONLInfo `json:"info"`
+}
+
+func loadNucleiBundleFindings(bundle *verifymodel.NucleiRunBundle, targetIndex map[string]verifymodel.NucleiTarget) ([]Finding, error) {
+	file, err := os.Open(bundle.NucleiJSONLPath)
+	if err != nil {
+		return nil, fmt.Errorf("open nuclei jsonl: %w", err)
+	}
+	defer file.Close()
+
+	findings := make([]Finding, 0, 8)
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+		var record nucleiJSONLRecord
+		if err := json.Unmarshal([]byte(line), &record); err != nil {
+			return nil, fmt.Errorf("parse nuclei jsonl: %w", err)
+		}
+		findings = append(findings, findingFromNucleiRecord(record, targetIndex))
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("scan nuclei jsonl: %w", err)
+	}
+	return findings, nil
+}
+
+func findingFromNucleiRecord(record nucleiJSONLRecord, targetIndex map[string]verifymodel.NucleiTarget) Finding {
+	matchedURL := firstNonEmpty(record.MatchedAt, record.Host)
+	normalizedURL := normalizeFindingURL(matchedURL)
+	target := lookupNucleiTarget(targetIndex, normalizedURL)
+	title := strings.TrimSpace(record.Info.Name)
+	if title == "" {
+		title = strings.TrimSpace(record.TemplateID)
+	}
+	base := strings.Join([]string{
+		"nuclei",
+		record.TemplateID,
+		record.MatcherName,
+		normalizedURL,
+	}, "|")
+	return Finding{
+		ID:          fmt.Sprintf("%x", sha1.Sum([]byte(base))),
+		Source:      "nuclei",
+		Severity:    strings.ToLower(strings.TrimSpace(record.Info.Severity)),
+		Title:       title,
+		Confidence:  "high",
+		Host:        firstNonEmpty(target.Host, extractHostFromURL(normalizedURL)),
+		Port:        target.Port,
+		Service:     target.Service,
+		AssetID:     target.AssetID,
+		URL:         normalizedURL,
+		Path:        firstNonEmpty(target.Path, extractPathFromURL(normalizedURL)),
+		TemplateID:  strings.TrimSpace(record.TemplateID),
+		MatcherName: strings.TrimSpace(record.MatcherName),
+		Tags:        compactEvidence(record.Info.Tags),
+		Evidence:    compactEvidence([]string{normalizedURL}),
+	}
+}
+
+func loadNucleiTargetIndex(path string) (map[string]verifymodel.NucleiTarget, error) {
+	body, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read nuclei target map: %w", err)
+	}
+	var targets []verifymodel.NucleiTarget
+	if err := json.Unmarshal(body, &targets); err != nil {
+		return nil, fmt.Errorf("parse nuclei target map: %w", err)
+	}
+	index := make(map[string]verifymodel.NucleiTarget, len(targets))
+	for _, target := range targets {
+		for _, key := range nucleiTargetLookupKeys(target.URL) {
+			index[key] = target
+		}
+	}
+	return index, nil
+}
+
+func normalizeFindingURL(raw string) string {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return ""
+	}
+	parsed, err := url.Parse(trimmed)
+	if err != nil {
+		return trimmed
+	}
+	if parsed.Path == "" {
+		parsed.Path = "/"
+	}
+	parsed.Path = path.Clean(parsed.Path)
+	if !strings.HasPrefix(parsed.Path, "/") {
+		parsed.Path = "/" + parsed.Path
+	}
+	return parsed.String()
+}
+
+func lookupNucleiTarget(index map[string]verifymodel.NucleiTarget, rawURL string) verifymodel.NucleiTarget {
+	for _, key := range nucleiTargetLookupKeys(rawURL) {
+		if target, ok := index[key]; ok {
+			return target
+		}
+	}
+	return verifymodel.NucleiTarget{}
+}
+
+func nucleiTargetLookupKeys(rawURL string) []string {
+	normalized := normalizeFindingURL(rawURL)
+	if normalized == "" {
+		return nil
+	}
+	keys := []string{normalized}
+	trimmedDefaultPort := trimDefaultPort(normalized)
+	if trimmedDefaultPort != normalized {
+		keys = append(keys, trimmedDefaultPort)
+	}
+	return keys
+}
+
+func trimDefaultPort(rawURL string) string {
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		return rawURL
+	}
+	switch {
+	case parsed.Scheme == "https" && parsed.Port() == "443":
+		parsed.Host = parsed.Hostname()
+	case parsed.Scheme == "http" && parsed.Port() == "80":
+		parsed.Host = parsed.Hostname()
+	default:
+		return rawURL
+	}
+	return parsed.String()
+}
+
+func extractHostFromURL(raw string) string {
+	parsed, err := url.Parse(raw)
+	if err != nil {
+		return ""
+	}
+	return parsed.Hostname()
+}
+
+func extractPathFromURL(raw string) string {
+	parsed, err := url.Parse(raw)
+	if err != nil {
+		return ""
+	}
+	if parsed.Path == "" {
+		return "/"
+	}
+	return parsed.Path
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+func compactEvidence(values []string) []string {
+	out := make([]string, 0, len(values))
+	seen := make(map[string]struct{}, len(values))
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			continue
+		}
+		if _, ok := seen[value]; ok {
+			continue
+		}
+		seen[value] = struct{}{}
+		out = append(out, value)
+	}
+	return out
+}
+
+func dedupeFindings(findings []Finding) []Finding {
+	out := make([]Finding, 0, len(findings))
+	seen := make(map[string]struct{}, len(findings))
+	for _, finding := range findings {
+		if _, ok := seen[finding.ID]; ok {
+			continue
+		}
+		seen[finding.ID] = struct{}{}
+		out = append(out, finding)
+	}
+	return out
+}

--- a/internal/scanner/crawl.go
+++ b/internal/scanner/crawl.go
@@ -9,6 +9,7 @@ import (
 	"log/slog"
 	"net/http"
 	"net/url"
+	"regexp"
 	"strings"
 	"time"
 
@@ -16,11 +17,12 @@ import (
 )
 
 type CrawlResult struct {
-	Path        string `json:"path"`
-	StatusCode  int    `json:"status_code"`
-	ContentType string `json:"content_type,omitempty"`
-	Title       string `json:"title,omitempty"`
-	RedirectTo  string `json:"redirect_to,omitempty"`
+	Path           string          `json:"path"`
+	StatusCode     int             `json:"status_code"`
+	ContentType    string          `json:"content_type,omitempty"`
+	Title          string          `json:"title,omitempty"`
+	RedirectTo     string          `json:"redirect_to,omitempty"`
+	ExternalAssets []ExternalAsset `json:"external_assets,omitempty"`
 }
 
 type AppFingerprint struct {
@@ -229,6 +231,8 @@ var productProbePaths = []string{
 	"/app/rest/server",
 	"/ui/",
 }
+
+var sourceMapPattern = regexp.MustCompile(`(?m)sourceMappingURL=([^\s*]+)`)
 
 func Crawl(ctx context.Context, scheme, ip, hostname string, port int, maxDepth int, timeout time.Duration, reqDelay time.Duration, verifyTLS bool) ([]CrawlResult, *AppFingerprint) {
 	return crawlHTTP(ctx, scheme, ip, hostname, port, maxDepth, timeout, reqDelay, verifyTLS, true)
@@ -468,11 +472,13 @@ func fetchPath(ctx context.Context, client *http.Client, base, hostname, path st
 		return cr, ""
 	}
 	body := string(b)
+	requestURL := base + path
 
 	if strings.Contains(cr.ContentType, "text/html") {
 		cr.Title = extractTitle(body)
 	}
 	detectDeeperProduct(path, cr, resp.Header, body, fp, productsFound)
+	cr.ExternalAssets = dedupeExternalAssets(append(cr.ExternalAssets, inspectExternalAssets(ctx, client, requestURL, path, cr.ContentType, body)...))
 
 	return cr, body
 }
@@ -639,6 +645,184 @@ func extractLinks(body, base string) []string {
 	}
 
 	return links
+}
+
+func extractAssetURLs(body, base string) []string {
+	baseURL, err := url.Parse(base)
+	if err != nil {
+		return nil
+	}
+
+	seen := make(map[string]struct{})
+	var assets []string
+
+	z := html.NewTokenizer(strings.NewReader(body))
+	for {
+		tt := z.Next()
+		if tt == html.ErrorToken {
+			break
+		}
+		if tt != html.StartTagToken && tt != html.SelfClosingTagToken {
+			continue
+		}
+
+		tok := z.Token()
+		var attrName string
+		switch tok.Data {
+		case "script", "img":
+			attrName = "src"
+		case "link":
+			attrName = "href"
+		default:
+			continue
+		}
+
+		for _, attr := range tok.Attr {
+			if attr.Key != attrName {
+				continue
+			}
+			raw := strings.TrimSpace(attr.Val)
+			if raw == "" || strings.HasPrefix(raw, "javascript:") || strings.HasPrefix(raw, "data:") || strings.HasPrefix(raw, "#") {
+				continue
+			}
+			u, err := url.Parse(raw)
+			if err != nil {
+				continue
+			}
+			resolved := baseURL.ResolveReference(u).String()
+			if _, ok := seen[resolved]; ok {
+				continue
+			}
+			seen[resolved] = struct{}{}
+			assets = append(assets, resolved)
+		}
+	}
+
+	return assets
+}
+
+func extractSourceMapURLs(body, assetURL string) []string {
+	matches := sourceMapPattern.FindAllStringSubmatch(body, -1)
+	if len(matches) == 0 {
+		return nil
+	}
+	baseURL, err := url.Parse(assetURL)
+	if err != nil {
+		return nil
+	}
+	seen := make(map[string]struct{}, len(matches))
+	var urls []string
+	for _, match := range matches {
+		if len(match) < 2 {
+			continue
+		}
+		raw := strings.Trim(match[1], `"' `)
+		raw = strings.TrimSuffix(raw, "*/")
+		raw = strings.TrimSpace(raw)
+		if raw == "" {
+			continue
+		}
+		u, err := url.Parse(raw)
+		if err != nil {
+			continue
+		}
+		resolved := baseURL.ResolveReference(u).String()
+		if _, ok := seen[resolved]; ok {
+			continue
+		}
+		seen[resolved] = struct{}{}
+		urls = append(urls, resolved)
+	}
+	return urls
+}
+
+func inspectExternalAssets(ctx context.Context, client *http.Client, requestURL, sourcePath, contentType, body string) []ExternalAsset {
+	var assets []ExternalAsset
+
+	for _, sourcemapURL := range extractSourceMapURLs(body, requestURL) {
+		assets = append(assets, ExternalAsset{
+			URL:        sourcemapURL,
+			Kind:       "sourcemap",
+			SourceURL:  requestURL,
+			SourcePath: sourcePath,
+		})
+	}
+
+	if !strings.Contains(strings.ToLower(contentType), "text/html") {
+		return assets
+	}
+
+	const maxLinkedAssets = 4
+	linkedAssets := extractAssetURLs(body, requestURL)
+	fetchedAssets := 0
+	for _, assetURL := range linkedAssets {
+		if !looksLikeScriptOrStyleAsset(assetURL) {
+			continue
+		}
+		if fetchedAssets >= maxLinkedAssets {
+			break
+		}
+		assetBody, err := fetchExternalAssetBody(ctx, client, assetURL)
+		if err != nil || assetBody == "" {
+			continue
+		}
+		fetchedAssets++
+		for _, sourcemapURL := range extractSourceMapURLs(assetBody, assetURL) {
+			assets = append(assets, ExternalAsset{
+				URL:        sourcemapURL,
+				Kind:       "sourcemap",
+				SourceURL:  assetURL,
+				SourcePath: sourcePath,
+			})
+		}
+	}
+
+	return assets
+}
+
+func fetchExternalAssetBody(ctx context.Context, client *http.Client, assetURL string) (string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, assetURL, nil)
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("User-Agent", "flan-scanner/1.0")
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 400 || !shouldReadHTTPBody(resp.Header.Get("Content-Type")) {
+		io.Copy(io.Discard, resp.Body) //nolint:errcheck
+		return "", nil
+	}
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 64*1024))
+	if err != nil {
+		return "", err
+	}
+	io.Copy(io.Discard, resp.Body) //nolint:errcheck
+	return string(body), nil
+}
+
+func looksLikeScriptOrStyleAsset(assetURL string) bool {
+	lower := strings.ToLower(strings.TrimSpace(assetURL))
+	return strings.Contains(lower, ".js") || strings.Contains(lower, ".css")
+}
+
+func dedupeExternalAssets(values []ExternalAsset) []ExternalAsset {
+	if len(values) == 0 {
+		return nil
+	}
+	seen := make(map[string]struct{}, len(values))
+	out := make([]ExternalAsset, 0, len(values))
+	for _, value := range values {
+		key := strings.Join([]string{value.Kind, value.URL, value.SourceURL, value.SourcePath}, "|")
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		out = append(out, value)
+	}
+	return out
 }
 
 func sameHost(a, b *url.URL) bool {

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -7,6 +7,13 @@ type ProductFingerprint struct {
 	Confidence string `json:"confidence"`
 }
 
+type ExternalAsset struct {
+	URL        string `json:"url"`
+	Kind       string `json:"kind,omitempty"`
+	SourceURL  string `json:"source_url,omitempty"`
+	SourcePath string `json:"source_path,omitempty"`
+}
+
 type KubernetesOrigin struct {
 	Cluster   string `json:"cluster,omitempty"`
 	Context   string `json:"context,omitempty"`


### PR DESCRIPTION

- Added a shared findings layer that turns saved scan results and Nuclei JSONL into one operator-facing finding stream with asset correlation
- Turned high-signal native issues into findings, including /metrics, /debug/pprof (were part of my testing), TLS trust/deprecated-version problems, and bounded external sourcemap references
- Updated flan verify and the README so verification can render merged findings, support --run/--json, and document the local Nuclei bundle workflow under artifacts/verify
